### PR TITLE
Enable particular APIs dynamically through environment variable - Closes #129

### DIFF
--- a/services/gateway/config.js
+++ b/services/gateway/config.js
@@ -14,6 +14,7 @@
  *
  */
 const config = {
+	api: {},
 	log: {},
 };
 
@@ -50,5 +51,11 @@ config.log.gelf = process.env.SERVICE_LOG_GELF || 'false';
 config.log.file = process.env.SERVICE_LOG_FILE || 'false';
 config.log.docker_host = process.env.DOCKER_HOST || 'local';
 config.debug = process.env.SERVICE_LOG_LEVEL === 'debug';
+
+/**
+ * API enablement
+ */
+config.api.http = process.env.ENABLE_HTTP_API || 'http-version1,http-version1-compat,http-status';
+config.api.ws = process.env.ENABLE_WS_API || 'rpc,rpc-v1,blockchain';
 
 module.exports = config;

--- a/services/gateway/namespaces.js
+++ b/services/gateway/namespaces.js
@@ -13,6 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+const config = require('./config');
 const registerApi = require('./shared/registerRpcApi');
 
 const defaultConfig = {
@@ -20,8 +21,29 @@ const defaultConfig = {
 	aliases: {},
 };
 
-module.exports = {
-	'/rpc': registerApi('http-version1', { ...defaultConfig }),
-	'/rpc-v1': registerApi('http-version1', { ...defaultConfig }),
-	'/rpc-test': registerApi('http-test', { ...defaultConfig }),
-};
+const enableApiWS = config.api.ws.split(',');
+const exportedApi = {};
+
+enableApiWS.forEach(apiName => {
+	if ('rpc' === apiName) {
+		exportedApi['/rpc'] = registerApi('http-version1', { ...defaultConfig });
+	}
+	if ('rpc-v1' === apiName) {
+		exportedApi['/rpc-v1'] = registerApi('http-version1', { ...defaultConfig });
+	}
+	if ('rpc-test' === apiName) {
+		exportedApi['/rpc-test'] = registerApi('http-version1', { ...defaultConfig });
+	}
+	if ('blockchain' === apiName) {
+		exportedApi['/blockchain'] = {
+			events: {
+				call: {
+					mappingPolicy: 'restrict',
+					aliases: {},
+				},
+			},
+		};
+	}
+});
+
+module.exports = exportedApi;

--- a/services/gateway/routes.js
+++ b/services/gateway/routes.js
@@ -13,6 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+const config = require('./config');
 const registerApi = require('./shared/registerHttpApi');
 
 const defaultConfig = {
@@ -40,9 +41,21 @@ const defaultConfig = {
 	},
 };
 
-module.exports = [
-	registerApi('http-version1', { ...defaultConfig, path: '/v1' }),
-	registerApi('http-version1-compat', { ...defaultConfig, path: '/v1' }),
-	registerApi('http-test', { ...defaultConfig, path: '/test' }),
-	registerApi('http-status', { ...defaultConfig, path: '/' }),
-];
+const enableApiHTTP = config.api.http.split(',');
+
+const exportedApi = enableApiHTTP.map(apiName => {
+	if ('http-version1' === apiName) {
+		return registerApi('http-version1', { ...defaultConfig, path: '/v1' });
+	}
+	if ('http-version1-compat' === apiName) {
+		return registerApi('http-version1-compat', { ...defaultConfig, path: '/v1' });
+	}
+	if ('http-test' === apiName) {
+		return registerApi('http-test', { ...defaultConfig, path: '/test' });
+	}
+	if ('http-status' === apiName) {
+		return registerApi('http-status', { ...defaultConfig, path: '/' });
+	}
+});
+
+module.exports = exportedApi;


### PR DESCRIPTION
### What was the problem?
This PR resolves #129 

### How was it solved?
- [x] Add configuration entries in `lisk-service/service/gateway/config.js`
- [x] `ENABLE_HTTP_API` and `ENABLE_WS_API` environment are made available
- [x] `config.js` has a default set of the APIs used on production enabled, the rest is skipped
- [ ] Testnet config for Docker enables all APIs that production uses
- [ ] Development configuration has got all APIs enabled
- [ ] Jenkins env config has got APIs needed by tests

### How was it tested?
Local + Jenkins
