### PR TITLE
Migrate peer cache to blockchain data store - Closes #135

### DIFF
--- a/services/core/jobs/peers.js
+++ b/services/core/jobs/peers.js
@@ -16,7 +16,6 @@
 const logger = require('lisk-service-framework').Logger();
 
 const peerCache = require('../shared/core/peerCache');
-const core = require('../shared/core');
 
 module.exports = [
 	{
@@ -25,11 +24,11 @@ module.exports = [
 		interval: 45, // seconds
 		init: () => {
 			logger.debug('Initializing peer list...');
-			peerCache.reload(core);
+			peerCache.reload();
 		},
 		controller: () => {
 			logger.debug('Scheduling peer list reload...');
-			peerCache.reload(core);
+			peerCache.reload();
 		},
 	},
 ];

--- a/services/core/methods/controllers/peers.js
+++ b/services/core/methods/controllers/peers.js
@@ -42,14 +42,12 @@ const getDisconnectedPeers = async params => {
 	};
 };
 
-const getPeersStatistics = () => {
-	const response = coreService.getPeersStatistics();
-
-	const meta = {};
+const getPeersStatistics = async () => {
+	const response = await coreService.getPeersStatistics();
 
 	return {
-		data: response,
-		meta,
+		data: response.data,
+		meta: response.meta,
 	};
 };
 

--- a/services/core/methods/controllers/peers.js
+++ b/services/core/methods/controllers/peers.js
@@ -34,7 +34,7 @@ const getConnectedPeers = async params => {
 };
 
 const getDisconnectedPeers = async params => {
-	const response = await coreService.getPeers(params);
+	const response = await coreService.getDisconnectedPeers(params);
 
 	return {
 		data: response.data,

--- a/services/core/methods/controllers/peers.js
+++ b/services/core/methods/controllers/peers.js
@@ -13,84 +13,19 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const GeoService = require('../../shared/geolocation.js');
-const peerCache = require('../../shared/core/peerCache.js');
+const coreService = require('../../shared/core');
 
-const addLocation = async (ipaddress) => {
-	try {
-		const result = await GeoService.requestData(ipaddress);
-		return result;
-	} catch (e) {
-		return {};
-	}
-};
-
-const getPeers = async (params) => {
-	let peers = {};
-
-	const state = params.state ? params.state.toString().toLowerCase() : undefined;
-
-	if (state === '2' || state === 'connected') peers = await peerCache.get('connected');
-	else if (state === '1' || state === 'disconnected') peers = await peerCache.get('disconnected');
-	else if (state === '0' || state === 'unknown') peers = []; // not supported anymore
-	else peers = await peerCache.get();
-
-	const intersect = (a, b) => {
-		const setB = new Set(b);
-		return [...new Set(a)].filter(x => setB.has(x));
-	};
-
-	const filterParams = ['ip', 'httpPort', 'wsPort', 'os', 'version', 'height', 'broadhash'];
-	const activeParams = Object.keys(params).filter(item => params[item]);
-	const activeFilters = intersect(filterParams, activeParams);
-
-	const filteredPeers = peers.filter(peer => {
-		let result = true;
-
-		activeFilters.forEach(property => {
-			if (params[property] !== peer[property]) result = false;
-		});
-
-		return result;
-	});
-
-	const sortBy = (array, p) => {
-		const [property, direction] = p.split(':');
-		if (property === 'version') array.sort((a, b) => a[property] > b[property]);
-		if (property === 'height') array.sort((a, b) => Number(a[property]) < Number(b[property]));
-		if (direction === 'asc') array.reverse();
-		return array;
-	};
-
-	if (params.sort && /^.+:(asc|desc)$/.test(params.sort)) sortBy(filteredPeers, params.sort);
-
-	let sortedPeers = filteredPeers;
-
-	if (params.offset || params.limit) {
-		if (!params.offset) params.offset = 0;
-		sortedPeers = filteredPeers.slice(params.offset,
-			(params.limit || filteredPeers.length) + params.offset);
-	}
-
-	const dataWithLocation = await Promise.all(sortedPeers.map(async (elem) => {
-		elem.location = await addLocation(elem.ip);
-		return elem;
-	}));
-
-	const meta = {
-		count: dataWithLocation.length,
-		offset: params.offset || 0,
-		total: peers.length,
-	};
+const getPeers = async params => {
+	const response = await coreService.getPeers(params);
 
 	return {
-		data: dataWithLocation,
-		meta,
+		data: response.data,
+		meta: response.meta,
 	};
 };
 
 const getConnectedPeers = async params => {
-	const response = await getPeers(Object.assign(params, { state: 'connected' }));
+	const response = await coreService.getConnectedPeers(params);
 
 	return {
 		data: response.data,
@@ -99,7 +34,7 @@ const getConnectedPeers = async params => {
 };
 
 const getDisconnectedPeers = async params => {
-	const response = await getPeers(Object.assign(params, { state: 'disconnected' }));
+	const response = await coreService.getPeers(params);
 
 	return {
 		data: response.data,
@@ -107,10 +42,16 @@ const getDisconnectedPeers = async params => {
 	};
 };
 
-const getPeersStatistics = () => ({
-	data: peerCache.getStatistics(),
-	meta: {},
-});
+const getPeersStatistics = () => {
+	const response = coreService.getPeersStatistics();
+
+	const meta = {};
+
+	return {
+		data: response,
+		meta,
+	};
+};
 
 module.exports = {
 	getPeers,

--- a/services/core/shared/core/compat/common/constants.js
+++ b/services/core/shared/core/compat/common/constants.js
@@ -19,7 +19,7 @@ const http = require('./httpRequest');
 const ObjectUtilService = Utils.Data;
 const { isProperObject } = ObjectUtilService;
 
-let coreVersion;
+let coreVersion = '1.0.0-alpha.0';
 let readyStatus;
 
 const getNetworkConstants = async () => {

--- a/services/core/shared/core/compat/sdk_v2/coreV1Mappings.js
+++ b/services/core/shared/core/compat/sdk_v2/coreV1Mappings.js
@@ -15,6 +15,13 @@
  */
 const { getDelegateRankByUsername } = require('./delegateCache');
 
+const reverseMap = (originalMap) => {
+	const result = {};
+	Object.entries(originalMap).forEach(([k, v]) => result[v] = String(k).toLowerCase());
+
+	return result;
+};
+
 const peerStates = {
 	'1.0.0-alpha.0': {
 		UNKNOWN: 0,
@@ -39,6 +46,11 @@ const mapState = state => {
 		disconnected: peerStates['1.0.0-alpha.0'].DISCONNECTED,
 	};
 	return stateMapping[state] !== undefined ? stateMapping[state] : state;
+};
+
+const mapStateName = state => {
+	const peerStateNames = reverseMap(peerStates['1.0.0-alpha.0']);
+	return peerStateNames[state] !== undefined ? peerStateNames[state] : state;
 };
 
 const transactionTypeParamMap = {
@@ -85,7 +97,11 @@ const mapDelegate = ({ voteWeight, ...delegate }) => ({
 
 const responseMappers = {
 	'/peers': response => {
-		response.data = response.data.map(peer => ({ ...peer, state: mapState(peer.state) }));
+		response.data = response.data.map(peer => ({
+			...peer,
+			stateName: mapStateName(peer.state),
+			state: mapState(peer.state),
+		}));
 		return response;
 	},
 	'/transactions': response => {

--- a/services/core/shared/core/compat/sdk_v2/coreV3Mappings.js
+++ b/services/core/shared/core/compat/sdk_v2/coreV3Mappings.js
@@ -15,6 +15,13 @@
  */
 const { getDelegateRankByUsername } = require('./delegateCache');
 
+const reverseMap = (originalMap) => {
+	const result = {};
+	Object.entries(originalMap).forEach(([k, v]) => result[v] = String(k).toLowerCase());
+
+	return result;
+};
+
 const peerStates = {
 	'3.0.0-alpha.0': {
 		DISCONNECTED: 'disconnected',
@@ -43,6 +50,11 @@ const mapState = state => {
 		[peerStates['3.0.0-alpha.0'].DISCONNECTED]: 1,
 	};
 	return stateMapping[state] !== undefined ? stateMapping[state] : state;
+};
+
+const mapStateName = state => {
+	const peerStateNames = reverseMap(peerStates['3.0.0-alpha.0']);
+	return peerStateNames[state] !== undefined ? peerStateNames[state] : state;
 };
 
 const transactionTypeParamMap = {
@@ -89,7 +101,11 @@ const mapDelegate = ({ voteWeight, ...delegate }) => ({
 
 const responseMappers = {
 	'/peers': response => {
-		response.data = response.data.map(peer => ({ ...peer, state: mapState(peer.state) }));
+		response.data = response.data.map(peer => ({
+			...peer,
+			stateName: mapStateName(peer.state),
+			state: mapState(peer.state),
+		}));
 		return response;
 	},
 	'/transactions': response => {

--- a/services/core/shared/core/compat/sdk_v2/coreVersionCompatibility.js
+++ b/services/core/shared/core/compat/sdk_v2/coreVersionCompatibility.js
@@ -30,7 +30,8 @@ const mapResponse = (response, url) => {
 	const mapper = responseMappers[referenceKey]
 		&& responseMappers[referenceKey][url];
 	if (mapper) {
-		response = mapper(response);
+		// TODO: remove the nested if condition and responseMapper entry when sdk_v3 is implemented
+		if (referenceKey !== '1.0.0-alpha.0' || url === '/peers') response = mapper(response);
 	}
 	return response;
 };

--- a/services/core/shared/core/compat/sdk_v2/coreVersionCompatibility.js
+++ b/services/core/shared/core/compat/sdk_v2/coreVersionCompatibility.js
@@ -22,6 +22,7 @@ let coreVersion = '1.0.0-alpha.0';
 let referenceKey = coreVersion;
 
 const responseMappers = {
+	'1.0.0-alpha.0': coreV1Mappings.responseMappers,
 	'3.0.0-alpha.0': coreV3Mappings.responseMappers,
 };
 

--- a/services/core/shared/core/compat/sdk_v2/mappings.js
+++ b/services/core/shared/core/compat/sdk_v2/mappings.js
@@ -15,6 +15,13 @@
  */
 const { getDelegateRankByUsername } = require('./delegateCache');
 
+const reverseMap = (originalMap) => {
+    const result = {};
+    Object.entries(originalMap).forEach(([k, v]) => result[v] = String(k).toLowerCase());
+
+    return result;
+};
+
 const peerStates = {
     UNKNOWN: 0,
     DISCONNECTED: 1,
@@ -35,6 +42,11 @@ const mapState = state => {
         disconnected: peerStates.DISCONNECTED,
     };
     return stateMapping[state] !== undefined ? stateMapping[state] : state;
+};
+
+const mapStateName = state => {
+    const peerStateNames = reverseMap(peerStates);
+    return peerStateNames[state] !== undefined ? peerStateNames[state] : state;
 };
 
 const mapTransaction = transaction => {
@@ -72,7 +84,11 @@ const mapDelegate = ({ voteWeight, ...delegate }) => ({
 
 const responseMappers = {
     '/peers': response => {
-        response.data = response.data.map(peer => ({ ...peer, state: mapState(peer.state) }));
+        response.data = response.data.map(peer => ({
+            ...peer,
+            stateName: mapStateName(peer.state),
+            state: mapState(peer.state),
+        }));
         return response;
     },
     '/transactions': response => {

--- a/services/core/shared/core/compat/sdk_v3/mappings.js
+++ b/services/core/shared/core/compat/sdk_v3/mappings.js
@@ -15,6 +15,13 @@
 //  */
 // const { getDelegateRankByUsername } = require('./delegateCache');
 
+// const reverseMap = (originalMap) => {
+//     const result = {};
+//     Object.entries(originalMap).forEach(([k, v]) => result[v] = String(k).toLowerCase());
+
+//     return result;
+// };
+
 // const peerStates = {
 
 //     DISCONNECTED: 'disconnected',
@@ -40,6 +47,11 @@
 //         [peerStates.DISCONNECTED]: 1,
 //     };
 //     return stateMapping[state] !== undefined ? stateMapping[state] : state;
+// };
+
+// const mapStateName = state => {
+//     const peerStateNames = reverseMap(peerStateParamMap);
+//     return peerStateNames[state] !== undefined ? peerStateNames[state] : state;
 // };
 
 // const transactionTypeParamMap = {
@@ -86,7 +98,11 @@
 
 // const responseMappers = {
 //     '/peers': response => {
-//         response.data = response.data.map(peer => ({ ...peer, state: mapState(peer.state) }));
+//         response.data = response.data.map(peer => ({
+//             ...peer,
+//             stateName: mapStateName(peer.state),
+//             state: mapState(peer.state),
+//         }));
 //         return response;
 //     },
 //     '/transactions': response => {

--- a/services/core/shared/core/index.js
+++ b/services/core/shared/core/index.js
@@ -16,6 +16,12 @@
 const { getBlocks } = require('./blocks');
 const { getTransactions } = require('./transactions');
 const { getAccounts } = require('./accounts');
+const {
+	getPeers,
+	getConnectedPeers,
+	getDisconnectedPeers,
+	getPeersStatistics,
+} = require('./peers');
 
 const {
 	EMAcalc,
@@ -57,7 +63,6 @@ const {
 	getNextForgers,
 	getNetworkStatus,
 	getNetworkConstants,
-	getPeers,
 	numOfActiveDelegates,
 	peerStates,
 	setReadyStatus,
@@ -103,6 +108,9 @@ module.exports = {
 	getNetworkStatus,
 	getNetworkConstants,
 	getPeers,
+	getConnectedPeers,
+	getDisconnectedPeers,
+	getPeersStatistics,
 	numOfActiveDelegates,
 	peerStates,
 	setReadyStatus,

--- a/services/core/shared/core/peerCache.js
+++ b/services/core/shared/core/peerCache.js
@@ -14,8 +14,11 @@
  *
  */
 const { Logger } = require('lisk-service-framework');
-const { peerStates } = require('./compat');
+
+const core = require('./compat');
 const requestAll = require('../requestAll');
+
+const { peerStates } = require('./compat');
 
 const logger = Logger();
 
@@ -75,7 +78,7 @@ const refreshStatistics = async () => {
 
 const getStatistics = () => peerStore.statistics;
 
-const reload = async (core) => {
+const reload = async () => {
 	logger.debug('Refreshing peer cache...');
 	peerStore.peers = await requestAll(core.getPeers, {});
 	peerStore.connected = peerStore.peers.filter(o => o.state === peerStates.CONNECTED);

--- a/services/core/shared/core/peers.js
+++ b/services/core/shared/core/peers.js
@@ -1,0 +1,112 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const peerCache = require('./peerCache');
+const GeoService = require('../geolocation');
+
+const addLocation = async (ipaddress) => {
+    try {
+        const result = await GeoService.requestData(ipaddress);
+        return result;
+    } catch (e) {
+        return {};
+    }
+};
+
+const getPeers = async params => {
+    let peers;
+
+    const state = params.state ? params.state.toString().toLowerCase() : undefined;
+
+    if (state === '2' || state === 'connected') peers = await peerCache.get('connected');
+    else if (state === '1' || state === 'disconnected') peers = await peerCache.get('disconnected');
+    else if (state === '0' || state === 'unknown') peers = []; // not supported anymore
+    else peers = await peerCache.get();
+
+    const intersect = (a, b) => {
+        const setB = new Set(b);
+        return [...new Set(a)].filter(x => setB.has(x));
+    };
+
+    const filterParams = ['ip', 'httpPort', 'wsPort', 'os', 'version', 'height', 'broadhash'];
+    const activeParams = Object.keys(params).filter(item => params[item]);
+    const activeFilters = intersect(filterParams, activeParams);
+
+    const filteredPeers = peers.filter(peer => {
+        let result = true;
+
+        activeFilters.forEach(property => {
+            if (params[property] !== peer[property]) result = false;
+        });
+
+        return result;
+    });
+
+    const sortBy = (array, p) => {
+        const [property, direction] = p.split(':');
+        if (property === 'version') array.sort((a, b) => a[property] > b[property]);
+        if (property === 'height') array.sort((a, b) => Number(a[property]) < Number(b[property]));
+        if (direction === 'asc') array.reverse();
+        return array;
+    };
+
+    if (params.sort && /^.+:(asc|desc)$/.test(params.sort)) sortBy(filteredPeers, params.sort);
+
+    let sortedPeers = filteredPeers;
+
+    if (params.offset || params.limit) {
+        if (!params.offset) params.offset = 0;
+        sortedPeers = filteredPeers.slice(params.offset,
+            (params.limit || filteredPeers.length) + params.offset);
+    }
+
+    const dataWithLocation = await Promise.all(sortedPeers.map(async (elem) => {
+        elem.location = await addLocation(elem.ip);
+        return elem;
+    }));
+
+    const meta = {
+        count: dataWithLocation.length,
+        offset: params.offset || 0,
+        total: peers.length,
+    };
+
+    return {
+        data: dataWithLocation,
+        meta,
+    };
+};
+
+const getConnectedPeers = async params => {
+    const response = await getPeers(Object.assign(params, { state: 'connected' }));
+    return response;
+};
+
+const getDisconnectedPeers = async params => {
+    const response = await getPeers(Object.assign(params, { state: 'disconnected' }));
+    return response;
+};
+
+const getPeersStatistics = () => ({
+    data: peerCache.getStatistics(),
+    meta: {},
+});
+
+module.exports = {
+    getPeers,
+    getConnectedPeers,
+    getDisconnectedPeers,
+    getPeersStatistics,
+};

--- a/services/core/shared/core/peers.js
+++ b/services/core/shared/core/peers.js
@@ -105,7 +105,7 @@ const getPeersStatistics = async () => {
     return {
         data: response,
         meta: {},
-    }
+    };
 };
 
 module.exports = {

--- a/services/core/shared/core/peers.js
+++ b/services/core/shared/core/peers.js
@@ -99,10 +99,14 @@ const getDisconnectedPeers = async params => {
     return response;
 };
 
-const getPeersStatistics = () => ({
-    data: peerCache.getStatistics(),
-    meta: {},
-});
+const getPeersStatistics = async () => {
+    const response = await peerCache.getStatistics();
+
+    return {
+        data: response,
+        meta: {},
+    }
+};
 
 module.exports = {
     getPeers,

--- a/services/gateway/sources/mappings/peer.js
+++ b/services/gateway/sources/mappings/peer.js
@@ -20,6 +20,7 @@ module.exports = {
 	os: '=,string',
 	version: '=,string',
 	state: '=,number',
+	stateName: '=,string',
 	height: '=,number',
 	broadhash: '=,string',
 	nonce: '=,string',

--- a/tests/integration_testnet/api/http/peers.test.js
+++ b/tests/integration_testnet/api/http/peers.test.js
@@ -24,6 +24,7 @@ const networkEndpoint = `${baseUrlV1}/network`;
 const peerSchema = {
 	ip: 'string',
 	state: 'number',
+	stateName: 'string',
 	version: 'string',
 };
 
@@ -36,6 +37,7 @@ const peerStatistics = {
 
 const peerOptionalSchema = {
 	state: 'number',
+	stateName: 'string',
 	version: 'string',
 	broadhash: 'string',
 	height: 'number',

--- a/tests/integration_testnet/schemas/peer.schema.js
+++ b/tests/integration_testnet/schemas/peer.schema.js
@@ -20,6 +20,7 @@ const peerSchema = Joi.object({
 	httpPort: Joi.number().port().optional(),
 	wsPort: Joi.number().port().optional(),
 	state: Joi.number().required(),
+	stateName: Joi.string().required(),
 	version: Joi.string().required(),
 	broadhash: Joi.string().optional(),
 	height: Joi.number().optional(),


### PR DESCRIPTION
### What was the problem?
This PR resolves #135 

### How was it solved?
- [x] Peer data is available through the same logic it is done before
- [x] The search logic is moved from the controller to the blockchain datastore
- [x] state and stateName are implemented internally
- [x] Data need not be migrated to PouchDB for persistence

### How was it tested?
Local + Jenkins
