### PR TITLE
Implement blockchain data storage data retention - Closes #138

### DIFF
--- a/services/core/config.js
+++ b/services/core/config.js
@@ -76,6 +76,8 @@ config.db = {
 				['generatorAddress', 'unixTimestamp'],
 				['generatorUsername', 'unixTimestamp'],
 			],
+			// Only retain the latest n blocks (Default: Approx. 1 year)
+			purge_limit: process.env.SERVICE_DB_PURGE_LIMIT_BLOCKS || 3162240,
 		},
 		delegates: {
 			name: 'delegates',
@@ -103,6 +105,8 @@ config.db = {
 				['senderId', 'timestamp'],
 				['recipientId', 'timestamp'],
 			],
+			// Only retain transactions contained in the latest n blocks
+			purge_limit: process.env.SERVICE_DB_PURGE_LIMIT_TRANSACTIONS || 3162240,
 		},
 		transaction_statistics: {
 			name: 'transaction_statistics',

--- a/services/core/jobs/dbCleanup.js
+++ b/services/core/jobs/dbCleanup.js
@@ -1,0 +1,50 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const logger = require('lisk-service-framework').Logger();
+
+const config = require('../config');
+const purger = require('../shared/core/purge');
+
+module.exports = [
+	{
+		name: 'purge.blocks',
+		description: 'Remove old blocks',
+		schedule: '0 0 * * *', // Every day at mid-night
+		updateOnInit: true,
+		init: () => {
+			logger.debug('Scheduling delegate list init...');
+			purger.purgeBlocks(config.db.collections.blocks.purge_limit);
+		},
+		controller: async () => {
+			logger.debug('Scheduling delegate list reload...');
+			purger.purgeBlocks(config.db.collections.blocks.purge_limit);
+		},
+	},
+	{
+		name: 'purge.transactions',
+		description: 'Remove old transactions',
+		schedule: '0 0 * * *', // Every day at mid-night
+		updateOnInit: true,
+		init: () => {
+			logger.debug('Scheduling delegate list init...');
+			purger.purgeTransactions(config.db.collections.transactions.purge_limit);
+		},
+		controller: async () => {
+			logger.debug('Scheduling delegate list reload...');
+			purger.purgeTransactions(config.db.collections.transactions.purge_limit);
+		},
+	},
+];

--- a/services/core/jobs/transactionStatistics.js
+++ b/services/core/jobs/transactionStatistics.js
@@ -21,7 +21,7 @@ const transactionStatistics = require('../shared/core/transactionStatistics');
 
 module.exports = [
 	{
-		name: 'refresh.delegates',
+		name: 'refresh.transactionstats',
 		description: 'Keep the transaction statistics up-to-date',
 		schedule: '*/30 * * * *', // Every 30 min
 		updateOnInit: true,

--- a/services/core/shared/core/purge.js
+++ b/services/core/shared/core/purge.js
@@ -21,6 +21,8 @@ const { getBlocks } = require('./blocks');
 
 const logger = Logger();
 
+const minBlockHeight = 1;
+
 const getSelector = params => {
 	const result = {};
 	const selector = {};
@@ -44,8 +46,9 @@ const purgeBlocks = async purgeLimit => {
 	const purgeResult = await db.deleteBatch(purgableBlocks);
 	const purgeCount = purgeResult ? purgeResult.length : 0;
 
+	const purgeHeight = (latestBlockHeight - purgeLimit > 0) ? latestBlockHeight - purgeLimit : minBlockHeight;
 	logger.info('Purged '.concat(purgeCount)
-		.concat(' blocks from db at height lower than ').concat(latestBlockHeight - purgeLimit));
+		.concat(' blocks from db at height lower than ').concat(purgeHeight));
 
 	return purgeCount;
 };
@@ -62,8 +65,9 @@ const purgeTransactions = async purgeLimit => {
 	const purgeResult = await db.deleteBatch(purgableTransactions);
 	const purgeCount = purgeResult ? purgeResult.length : 0;
 
+	const purgeHeight = (latestBlockHeight - purgeLimit > 0) ? latestBlockHeight - purgeLimit : minBlockHeight;
 	logger.info('Purged '.concat(purgeCount)
-		.concat(' transactions from db contained within blocks at height lower than ').concat(latestBlockHeight - purgeLimit));
+		.concat(' transactions from db contained within blocks at height lower than ').concat(purgeHeight));
 
 	return purgeCount;
 };

--- a/services/core/shared/core/purge.js
+++ b/services/core/shared/core/purge.js
@@ -25,45 +25,45 @@ const getSelector = params => {
 	const result = {};
 	const selector = {};
 
-	if (params.purge_limit_height) selector.height = {};
-	if (params.purge_limit_height) Object.assign(selector.height, { $lte: params.purge_limit_height });
+	if (params.purge_height) selector.height = {};
+	if (params.purge_height) Object.assign(selector.height, { $lte: params.purge_height });
 
 	result.selector = selector;
 	return result;
-}
+};
 
-const purgeBlocks = async purge_limit => {
+const purgeBlocks = async purgeLimit => {
 	const db = await pouchdb(config.db.collections.blocks.name);
 
 	const latestBlock = (await getBlocks({ limit: 1 })).data[0];
 	const latestBlockHeight = latestBlock.height;
 
-	const dbFilterParams = getSelector({ purge_limit_height: latestBlockHeight - purge_limit });
+	const dbFilterParams = getSelector({ purge_height: latestBlockHeight - purgeLimit });
 	const purgableBlocks = await db.find(dbFilterParams);
 
 	const purgeResult = await db.deleteBatch(purgableBlocks);
 	const purgeCount = purgeResult ? purgeResult.length : 0;
 
 	logger.info('Purged '.concat(purgeCount)
-		.concat(' blocks from db at height lower than ').concat(latestBlockHeight - purge_limit));
+		.concat(' blocks from db at height lower than ').concat(latestBlockHeight - purgeLimit));
 
 	return purgeCount;
 };
 
-const purgeTransactions = async purge_limit => {
+const purgeTransactions = async purgeLimit => {
 	const db = await pouchdb(config.db.collections.transactions.name);
 
 	const latestBlock = (await getBlocks({ limit: 1 })).data[0];
 	const latestBlockHeight = latestBlock.height;
 
-	const dbFilterParams = getSelector({ purge_limit_height: latestBlockHeight - purge_limit });
+	const dbFilterParams = getSelector({ purge_height: latestBlockHeight - purgeLimit });
 	const purgableTransactions = await db.find(dbFilterParams);
 
 	const purgeResult = await db.deleteBatch(purgableTransactions);
 	const purgeCount = purgeResult ? purgeResult.length : 0;
 
 	logger.info('Purged '.concat(purgeCount)
-		.concat(' transactions from db contained within blocks at height lower than ').concat(latestBlockHeight - purge_limit));
+		.concat(' transactions from db contained within blocks at height lower than ').concat(latestBlockHeight - purgeLimit));
 
 	return purgeCount;
 };

--- a/services/core/shared/core/purge.js
+++ b/services/core/shared/core/purge.js
@@ -46,7 +46,8 @@ const purgeBlocks = async purgeLimit => {
 	const purgeResult = await db.deleteBatch(purgableBlocks);
 	const purgeCount = purgeResult ? purgeResult.length : 0;
 
-	const purgeHeight = (latestBlockHeight - purgeLimit > 0) ? latestBlockHeight - purgeLimit : minBlockHeight;
+	const purgeHeight = (latestBlockHeight - purgeLimit) > 0
+		? latestBlockHeight - purgeLimit : minBlockHeight;
 	logger.info('Purged '.concat(purgeCount)
 		.concat(' blocks from db at height lower than ').concat(purgeHeight));
 
@@ -65,7 +66,8 @@ const purgeTransactions = async purgeLimit => {
 	const purgeResult = await db.deleteBatch(purgableTransactions);
 	const purgeCount = purgeResult ? purgeResult.length : 0;
 
-	const purgeHeight = (latestBlockHeight - purgeLimit > 0) ? latestBlockHeight - purgeLimit : minBlockHeight;
+	const purgeHeight = (latestBlockHeight - purgeLimit) > 0
+		? latestBlockHeight - purgeLimit : minBlockHeight;
 	logger.info('Purged '.concat(purgeCount)
 		.concat(' transactions from db contained within blocks at height lower than ').concat(purgeHeight));
 

--- a/services/core/shared/core/purge.js
+++ b/services/core/shared/core/purge.js
@@ -1,0 +1,74 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const { Logger } = require('lisk-service-framework');
+
+const config = require('../../config');
+const pouchdb = require('../pouchdb');
+const { getBlocks } = require('./blocks');
+
+const logger = Logger();
+
+const getSelector = params => {
+	const result = {};
+	const selector = {};
+
+	if (params.purge_limit_height) selector.height = {};
+	if (params.purge_limit_height) Object.assign(selector.height, { $lte: params.purge_limit_height });
+
+	result.selector = selector;
+	return result;
+}
+
+const purgeBlocks = async purge_limit => {
+	const db = await pouchdb(config.db.collections.blocks.name);
+
+	const latestBlock = (await getBlocks({ limit: 1 })).data[0];
+	const latestBlockHeight = latestBlock.height;
+
+	const dbFilterParams = getSelector({ purge_limit_height: latestBlockHeight - purge_limit });
+	const purgableBlocks = await db.find(dbFilterParams);
+
+	const purgeResult = await db.deleteBatch(purgableBlocks);
+	const purgeCount = purgeResult ? purgeResult.length : 0;
+
+	logger.info('Purged '.concat(purgeCount)
+		.concat(' blocks from db at height lower than ').concat(latestBlockHeight - purge_limit));
+
+	return purgeCount;
+};
+
+const purgeTransactions = async purge_limit => {
+	const db = await pouchdb(config.db.collections.transactions.name);
+
+	const latestBlock = (await getBlocks({ limit: 1 })).data[0];
+	const latestBlockHeight = latestBlock.height;
+
+	const dbFilterParams = getSelector({ purge_limit_height: latestBlockHeight - purge_limit });
+	const purgableTransactions = await db.find(dbFilterParams);
+
+	const purgeResult = await db.deleteBatch(purgableTransactions);
+	const purgeCount = purgeResult ? purgeResult.length : 0;
+
+	logger.info('Purged '.concat(purgeCount)
+		.concat(' transactions from db contained within blocks at height lower than ').concat(latestBlockHeight - purge_limit));
+
+	return purgeCount;
+};
+
+module.exports = {
+	purgeBlocks,
+	purgeTransactions,
+};

--- a/services/core/shared/pouchdb.js
+++ b/services/core/shared/pouchdb.js
@@ -143,7 +143,7 @@ const getDbInstance = async (collectionName, idxList = []) => {
 	const deleteById = async (id) => db.remove(await findById(id));
 
 	const deleteBatch = async (docs) => {
-		if (docs instanceof Array && docs.length === 0) return;
+		if (docs instanceof Array && docs.length === 0) return null;
 		docs.map((doc) => {
 			if (!doc._id) doc._id = doc.id;
 			doc._deleted = true;

--- a/services/core/shared/pouchdb.js
+++ b/services/core/shared/pouchdb.js
@@ -149,7 +149,7 @@ const getDbInstance = async (collectionName, idxList = []) => {
 			doc._deleted = true;
 			return doc;
 		});
-		db.bulkDocs(docs);
+		return db.bulkDocs(docs);
 	};
 
 	const deleteByProperty = async (property, value) => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #138 

### How was it solved?
Add jobs to clean up DB to reclaim space by removing old:
- [x] Blocks
- [x] Transactions
- [x] Transaction statistics (Already taken care of when calculating the latest statistics)

**NOTE:** Space reclamation is automatic as the `auto_compaction` is enabled on all the DBs. Refer to the PouchDB [documentation regarding auto-compaction](https://pouchdb.com/guides/compact-and-destroy.html#auto-compaction) for more information.

### How was it tested?
Local