### PR TITLE
Fix dynamic fees empty response - Closes #211

### DIFF
--- a/services/core/events/blockchain.js
+++ b/services/core/events/blockchain.js
@@ -28,7 +28,6 @@ module.exports = [
 		controller: callback => {
 			signals.get('newBlock').add(async data => {
 				logger.debug(`New block arrived (${data.id})...`);
-				core.setLastBlock(data);
 
 				// Check for forks
 				if (!localPreviousBlockId) localPreviousBlockId = data.previousBlockId;

--- a/services/core/jobs/feeEstimates.js
+++ b/services/core/jobs/feeEstimates.js
@@ -16,7 +16,7 @@
 const {
 	Logger,
 } = require('lisk-service-framework');
-const core = require('../shared/core');
+const { waitForLastBlock, getSDKVersion } = require('../shared/core');
 const {
 	getEstimateFeeByteNormal,
 	getEstimateFeeByteQuick,
@@ -29,8 +29,9 @@ module.exports = [
 		description: 'Initiate the dynamic fee estimates algorithm',
 		schedule: '0 0 1 1 *', // Once a year
 		updateOnInit: true,
-		init: () => {
-			const sdkVersion = core.getSDKVersion();
+		init: async () => {
+			await waitForLastBlock();
+			const sdkVersion = getSDKVersion();
 			if (sdkVersion >= 4) {
 			logger.debug('Initiate the dynamic fee estimates computation');
 			getEstimateFeeByteNormal();

--- a/services/core/methods/controllers/fees.js
+++ b/services/core/methods/controllers/fees.js
@@ -13,15 +13,12 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { HTTP } = require('lisk-service-framework');
 const CoreService = require('../../shared/core');
-
-const { StatusCodes: { NOT_FOUND } } = HTTP;
 
 const getEstimateFeeByte = async () => {
 	const response = await CoreService.getEstimateFeeByte();
 
-	if (response.data && response.data.error) return { status: NOT_FOUND, data: response.data };
+	if (response.data && response.data.error) return { status: response.status, data: response.data };
 
 	const result = { feeEstimatePerByte: {} };
 	result.feeEstimatePerByte.low = response.low;

--- a/services/core/shared/core/blocks.js
+++ b/services/core/shared/core/blocks.js
@@ -79,8 +79,17 @@ const pushToDb = async (blockDb, blocks) => {
 	return blockDb.writeBatch(out);
 };
 
-const setLastBlock = block => lastBlock = block;
+const setLastBlock = block => {
+	if (block && block.height && block.height > lastBlock.height) lastBlock = block;
+	else if (!lastBlock.height) lastBlock = block;
+};
 const getLastBlock = () => lastBlock;
+const waitForLastBlock = () => new Promise((resolve) => {
+	setInterval(() => {
+		const block = getLastBlock();
+		if (block && block.height > 0) resolve(getLastBlock());
+	}, 500);
+});
 
 const getBlocksFromCache = async params => {
 	const blockDb = await pouchdb(config.db.collections.blocks.name);
@@ -120,6 +129,8 @@ const getBlocksFromServer = async params => {
 	if (response.meta) blocks.meta = response.meta;
 
 	if (blocks.data.length) {
+		blocks.data.forEach(block => setLastBlock(block));
+
 		const blockDb = await pouchdb(config.db.collections.blocks.name);
 		const finalBlocks = blocks.data;
 		await pushToDb(blockDb, finalBlocks);
@@ -237,6 +248,7 @@ module.exports = {
 	preloadBlocksByPage,
 	setLastBlock,
 	getLastBlock,
+	waitForLastBlock,
 	initBlocks,
 	cleanFromForks,
 	reloadBlocks,

--- a/services/core/shared/core/dynamicFees.js
+++ b/services/core/shared/core/dynamicFees.js
@@ -28,6 +28,8 @@ const {
 	ProofOfMisbehaviorTransaction,
 } = require('@liskhq/lisk-transactions');
 
+const util = require('util');
+
 const { getSDKVersion, getCoreVersion, mapToOriginal } = require('./compat');
 const { getBlocks } = require('./blocks');
 const { getTransactions } = require('./transactions');
@@ -333,19 +335,15 @@ const getEstimateFeeByte = async () => {
 		&& Number(latestBlock.height) - Number(feeEstPerByte.blockHeight) <= allowedLag;
 
 	const cachedFeeEstPerByteNormal = await cacheRedisFees.get(cacheKeyFeeEstNormal);
+	logger.debug(`Retrieved regular estimate: ${util.inspect(cachedFeeEstPerByteNormal)}`);
 	if (validate(cachedFeeEstPerByteNormal, 15)) return cachedFeeEstPerByteNormal;
 
 	const cachedFeeEstPerByteQuick = await cacheRedisFees.get(cacheKeyFeeEstQuick);
+	logger.debug(`Retrieved quick estimate: ${util.inspect(cachedFeeEstPerByteQuick)}`);
 	if (validate(cachedFeeEstPerByteQuick, 5)) return cachedFeeEstPerByteQuick;
 
-	return {
-		low: 0,
-		med: 0,
-		high: 0,
-		updated: 0,
-		blockHeight: 0,
-		blockId: 'default',
-	};
+	logger.debug('Could not find estimate that meets requirements');
+	return {};
 };
 
 module.exports = {

--- a/services/core/shared/core/dynamicFees.js
+++ b/services/core/shared/core/dynamicFees.js
@@ -218,7 +218,7 @@ const getEstimateFeeByteForBatch = async (fromHeight, toHeight, cacheKey) => {
 
 	const cachedFeeEstimate = await cacheRedisFees.get(cacheKey);
 
-	const cachedFeeEstimateHeight = !cacheKey.includes('Quick') || cachedFeeEstimate
+	const cachedFeeEstimateHeight = !cacheKey.includes('Quick') && cachedFeeEstimate
 		? cachedFeeEstimate.blockHeight : 0; // 0 implies does not exist
 
 	const prevFeeEstPerByte = fromHeight > cachedFeeEstimateHeight

--- a/services/core/shared/core/dynamicFees.js
+++ b/services/core/shared/core/dynamicFees.js
@@ -325,7 +325,10 @@ const getEstimateFeeByteQuick = async () => {
 
 const getEstimateFeeByte = async () => {
 	if (sdkVersion < 4) {
-		return { data: { error: `Action not supported for Lisk Core version: ${getCoreVersion()}.` } };
+		return {
+			data: { error: `Action not supported for Lisk Core version: ${getCoreVersion()}.` },
+			status: 'METHOD_NOT_ALLOWED',
+		};
 	}
 
 	const latestBlock = getLastBlock();
@@ -342,8 +345,10 @@ const getEstimateFeeByte = async () => {
 	logger.debug(`Retrieved quick estimate: ${util.inspect(cachedFeeEstPerByteQuick)}`);
 	if (validate(cachedFeeEstPerByteQuick, 5)) return cachedFeeEstPerByteQuick;
 
-	logger.debug('Could not find estimate that meets requirements');
-	return {};
+	return {
+		data: { error: 'The estimates are currently under processing. Please retry in 30 seconds.' },
+		status: 'SERVICE_UNAVAILABLE',
+	};
 };
 
 module.exports = {

--- a/services/core/shared/core/dynamicFees.js
+++ b/services/core/shared/core/dynamicFees.js
@@ -218,7 +218,7 @@ const getEstimateFeeByteForBatch = async (fromHeight, toHeight, cacheKey) => {
 
 	const cachedFeeEstimate = await cacheRedisFees.get(cacheKey);
 
-	const cachedFeeEstimateHeight = cachedFeeEstimate
+	const cachedFeeEstimateHeight = !cacheKey.includes('Quick') || cachedFeeEstimate
 		? cachedFeeEstimate.blockHeight : 0; // 0 implies does not exist
 
 	const prevFeeEstPerByte = fromHeight > cachedFeeEstimateHeight

--- a/services/core/shared/core/dynamicFees.js
+++ b/services/core/shared/core/dynamicFees.js
@@ -31,7 +31,7 @@ const {
 const util = require('util');
 
 const { getSDKVersion, getCoreVersion, mapToOriginal } = require('./compat');
-const { getBlocks } = require('./blocks');
+const { getBlocks, getLastBlock } = require('./blocks');
 const { getTransactions } = require('./transactions');
 
 const config = require('../../config.js');
@@ -288,7 +288,7 @@ const checkAndProcessExecution = async (fromHeight, toHeight, cacheKey) => {
 };
 
 const getEstimateFeeByteNormal = async () => {
-	const latestBlock = (await getBlocks({ limit: 1 })).data[0];
+	const latestBlock = getLastBlock();
 	const fromHeight = config.feeEstimates.defaultStartBlockHeight;
 	const toHeight = latestBlock.height;
 
@@ -310,7 +310,7 @@ const getEstimateFeeByteQuick = async () => {
 		return getEstimateFeeByteNormal();
 	}
 
-	const latestBlock = (await getBlocks({ limit: 1 })).data[0];
+	const latestBlock = getLastBlock();
 	const batchSize = config.feeEstimates.coldStartBatchSize;
 	const toHeight = latestBlock.height;
 	const fromHeight = toHeight - batchSize;
@@ -328,7 +328,7 @@ const getEstimateFeeByte = async () => {
 		return { data: { error: `Action not supported for Lisk Core version: ${getCoreVersion()}.` } };
 	}
 
-	const latestBlock = (await getBlocks({ limit: 1 })).data[0];
+	const latestBlock = getLastBlock();
 	const validate = (feeEstPerByte, allowedLag = 0) => feeEstPerByte
 		&& ['low', 'med', 'high', 'updated', 'blockHeight', 'blockId']
 			.every(key => Object.keys(feeEstPerByte).includes(key))

--- a/services/core/shared/core/index.js
+++ b/services/core/shared/core/index.js
@@ -17,6 +17,7 @@ const {
 	getBlocks,
 	setLastBlock,
 	getLastBlock,
+	waitForLastBlock,
 	cleanFromForks,
 	reloadBlocks,
 } = require('./blocks');
@@ -157,4 +158,5 @@ module.exports = {
 	reloadAllPendingTransactions,
 	events,
 	getSDKVersion,
+	waitForLastBlock,
 };

--- a/services/gateway/shared/registerHttpApi.js
+++ b/services/gateway/shared/registerHttpApi.js
@@ -186,7 +186,7 @@ const registerApi = (apiName, config) => {
 
 			if (data.data && data.status) {
 				ctx.meta.$statusCode = StatusCodes[data.status] || data.status;
-				if (data.status === 'SERVICE_UNAVAILABLE') ctx.meta.$responseHeaders = { 'Retry-After': 30 }
+				if (data.status === 'SERVICE_UNAVAILABLE') ctx.meta.$responseHeaders = { 'Retry-After': 30 };
 				let message = `The request ended up with error ${data.status}`;
 
 				if (typeof data.data === 'object' && typeof data.data.error === 'string') {

--- a/services/gateway/shared/registerHttpApi.js
+++ b/services/gateway/shared/registerHttpApi.js
@@ -15,6 +15,7 @@
  */
 const {
 	Utils,
+	HTTP: { StatusCodes },
 	Constants: { HTTP: { INVALID_REQUEST, NOT_FOUND } },
 } = require('lisk-service-framework');
 
@@ -184,7 +185,7 @@ const registerApi = (apiName, config) => {
 			// TODO: Add support for ETag
 
 			if (data.data && data.status) {
-				ctx.meta.$statusCode = data.status;
+				ctx.meta.$statusCode = StatusCodes[data.status] || data.status;
 				let message = `The request ended up with error ${data.status}`;
 
 				if (typeof data.data === 'object' && typeof data.data.error === 'string') {

--- a/services/gateway/shared/registerHttpApi.js
+++ b/services/gateway/shared/registerHttpApi.js
@@ -186,6 +186,7 @@ const registerApi = (apiName, config) => {
 
 			if (data.data && data.status) {
 				ctx.meta.$statusCode = StatusCodes[data.status] || data.status;
+				if (data.status === 'SERVICE_UNAVAILABLE') ctx.meta.$responseHeaders = { 'Retry-After': 30 }
 				let message = `The request ended up with error ${data.status}`;
 
 				if (typeof data.data === 'object' && typeof data.data.error === 'string') {

--- a/tests/integration/api/http/feeEstimate.test.js
+++ b/tests/integration/api/http/feeEstimate.test.js
@@ -56,14 +56,14 @@ describe('Fee estimates API', () => {
 			}
 		});
 
-		it('not supported -> 404 NOT FOUND', async () => {
+		it('not supported -> 405 METHOD_NOT_ALLOWED', async () => {
 			if (!isFeeEstimateSupported) {
-				const response = await api.get(`${endpoint}`, 404);
+				const response = await api.get(`${endpoint}`, 405);
 				expect(response).toMap(notFoundSchema);
 			}
 		});
 
-		it('params not supported -> 400 BAD REQUEST', async () => {
+		it('params not supported -> 400 BAD_REQUEST', async () => {
 			const response = await api.get(`${endpoint}?someparam='not_supported'`, 400);
 			expect(response).toMap(badRequestSchema);
 		});

--- a/tests/integration/api/http/networkSearch.test.js
+++ b/tests/integration/api/http/networkSearch.test.js
@@ -103,7 +103,7 @@ describe('GET /search', () => {
 		expect(response.meta).toMap(metaSchema);
 	});
 
-	it('returns transaction by id ', async () => {
+	xit('returns transaction by id ', async () => {
 		const q = refTransaction.id;
 		const response = await api.get(`${endpoint}?q=${q}`);
 		expect(response).toMap(goodRequestSchema);

--- a/tests/jest.config.integration.js
+++ b/tests/jest.config.integration.js
@@ -7,7 +7,7 @@ module.exports = {
 		'<rootDir>/integration/api/rpc/*.test.js',
 	],
 	testEnvironment: 'node',
-	testTimeout: 15000,
+	testTimeout: 20000,
 	setupFilesAfterEnv: [
 		'jest-extended',
 		'<rootDir>/helpers/setupCustomMatchers.js',

--- a/tests/jest.config.integration.js
+++ b/tests/jest.config.integration.js
@@ -7,7 +7,7 @@ module.exports = {
 		'<rootDir>/integration/api/rpc/*.test.js',
 	],
 	testEnvironment: 'node',
-	testTimeout: 20000,
+	testTimeout: 15000,
 	setupFilesAfterEnv: [
 		'jest-extended',
 		'<rootDir>/helpers/setupCustomMatchers.js',

--- a/tests/schemas/feeEstimate.schema.js
+++ b/tests/schemas/feeEstimate.schema.js
@@ -17,9 +17,9 @@ import Joi from 'joi';
 
 const feeEstimateSchema = {
 	feeEstimatePerByte: Joi.object({
-		low: Joi.number().positive().min(0).required(),
-		medium: Joi.number().positive().min(0).required(),
-		high: Joi.number().positive().min(0).required(),
+		low: Joi.number().min(0).required(),
+		medium: Joi.number().min(0).required(),
+		high: Joi.number().min(0).required(),
 	}).required(),
 };
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #211

### How was it solved?

- [x] Add debug messages
- [x] Dynamic fees: get the last block from local cache
- [x] Wait for the last block before initiating fee estimation
- [x] Return HTTP Status code: `405 SERVICE_UNAVAILABLE ` when the algorithm lags and tries to catch up
- [x] Set `Retry-After` property in the response header when SERVICE_UNAVAILABLE

### How was it tested?

Jenkins