### PR TITLE
Use default npmjs registry for service/core - Closes #122

### DIFF
--- a/services/core/.npmrc
+++ b/services/core/.npmrc
@@ -1,2 +1,1 @@
 message = "Version %s"
-registry = "https://npm.lisk.io"

--- a/services/core/package-lock.json
+++ b/services/core/package-lock.json
@@ -1973,9 +1973,9 @@
       }
     },
     "@liskhq/lisk-cryptography": {
-      "version": "2.5.0-alpha.0",
-      "resolved": "https://npm.lisk.io/@liskhq%2flisk-cryptography/-/lisk-cryptography-2.5.0-alpha.0.tgz",
-      "integrity": "sha512-56Tsxf/yQDMliv5BGbgMM4l+FFHGwjGjBtjO7K7kbf1BkL6R7zi/vVVlDyiTt149t6KFrxFTew2ZT06H3rANFQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@liskhq/lisk-cryptography/-/lisk-cryptography-2.5.0.tgz",
+      "integrity": "sha512-ZqRUd148gsz6e4gjWvViGJg79EU3on7sOB7cr3DJtImIxO5uiJyzen4lxVX1GF9f1xBn8RPmiDtHkZF4wEVkFg==",
       "requires": {
         "buffer-reverse": "1.0.1",
         "ed2curve": "0.3.0",
@@ -1985,20 +1985,20 @@
       }
     },
     "@liskhq/lisk-transactions": {
-      "version": "4.0.0-alpha.1",
-      "resolved": "https://npm.lisk.io/@liskhq%2flisk-transactions/-/lisk-transactions-4.0.0-alpha.1.tgz",
-      "integrity": "sha512-XUY3p4KmrOURpUSGyN4NZo9n7G1h4bx/7eKkNpchq8OGJdQuom/3jtDXTmol+nqrtDnJuknQ3U/D4iYXA94nIQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@liskhq/lisk-transactions/-/lisk-transactions-4.0.0.tgz",
+      "integrity": "sha512-LbBrcy8avp5Fnewh0ZGO6WJLHIRU9BjK0b5jusjYxAOu6Sk9uW0yftV0zqqaV6g4w0bin7IqwDYmqvjokbZLgQ==",
       "requires": {
-        "@liskhq/lisk-cryptography": "2.5.0-alpha.0",
-        "@liskhq/lisk-validator": "0.4.0-alpha.0"
+        "@liskhq/lisk-cryptography": "^2.5.0",
+        "@liskhq/lisk-validator": "^0.4.0"
       }
     },
     "@liskhq/lisk-validator": {
-      "version": "0.4.0-alpha.0",
-      "resolved": "https://npm.lisk.io/@liskhq%2flisk-validator/-/lisk-validator-0.4.0-alpha.0.tgz",
-      "integrity": "sha512-1Q3KujBnQOr7b8n/l5gM7OTcpiLpu31K1cn8mQekSO2sVxt0eVEuArI52MImfH2IOGdhTpifUgtjQt0J7lHwEA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@liskhq/lisk-validator/-/lisk-validator-0.4.0.tgz",
+      "integrity": "sha512-68lKrjJx6HakcINgcvM6nyImb3Mmk+KdFbifHXEo5fvbRXJrzUOt9g8wbrSc8M07k6nN3C6MVpXLBSJIqgh7Aw==",
       "requires": {
-        "@liskhq/lisk-cryptography": "2.5.0-alpha.0",
+        "@liskhq/lisk-cryptography": "^2.5.0",
         "@types/node": "12.12.11",
         "@types/semver": "7.1.0",
         "@types/validator": "12.0.1",
@@ -2009,7 +2009,7 @@
       "dependencies": {
         "semver": {
           "version": "7.1.3",
-          "resolved": "https://npm.lisk.io/semver/-/semver-7.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
           "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
         }
       }
@@ -2154,7 +2154,7 @@
     },
     "@types/semver": {
       "version": "7.1.0",
-      "resolved": "https://npm.lisk.io/@types%2fsemver/-/semver-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
       "integrity": "sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==",
       "requires": {
         "@types/node": "*"
@@ -2168,7 +2168,7 @@
     },
     "@types/validator": {
       "version": "12.0.1",
-      "resolved": "https://npm.lisk.io/@types%2fvalidator/-/validator-12.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-12.0.1.tgz",
       "integrity": "sha512-l57fIANZLMe8DArz+SDb+7ATXnDm15P7u2wHBw5mb0aSMd+UuvmvhouBF2hdLgQPDMJ39sh9g2MJO4GkZ0VAdQ=="
     },
     "@types/yargs": {
@@ -2250,7 +2250,7 @@
     },
     "ajv": {
       "version": "6.12.0",
-      "resolved": "https://npm.lisk.io/ajv/-/ajv-6.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
       "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -3408,7 +3408,7 @@
     },
     "ed2curve": {
       "version": "0.3.0",
-      "resolved": "https://npm.lisk.io/ed2curve/-/ed2curve-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.3.0.tgz",
       "integrity": "sha512-8w2fmmq3hv9rCrcI7g9hms2pMunQr1JINfcjwR9tAyZqhtyaMN991lF/ZfHfr5tzZQ8c7y7aBgZbjfbd0fjFwQ==",
       "requires": {
         "tweetnacl": "1.x.x"
@@ -7465,9 +7465,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
       "optional": true
     },
     "nanomatch": {
@@ -10090,12 +10090,12 @@
     },
     "validator": {
       "version": "12.2.0",
-      "resolved": "https://npm.lisk.io/validator/-/validator-12.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
       "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
     },
     "varuint-bitcoin": {
       "version": "1.1.2",
-      "resolved": "https://npm.lisk.io/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
       "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
       "requires": {
         "safe-buffer": "^5.1.1"

--- a/services/core/package.json
+++ b/services/core/package.json
@@ -33,7 +33,7 @@
     "test:unit": "./node_modules/.bin/jest --config=jest.config.js --detectOpenHandles --forceExit"
   },
   "dependencies": {
-    "@liskhq/lisk-transactions": "^4.0.0-alpha.1",
+    "@liskhq/lisk-transactions": "^4.0.0",
     "async": "^3.2.0",
     "big-number": "=2.0.0",
     "bluebird": "^3.7.2",


### PR DESCRIPTION
### What was the problem?
This PR resolves #122 

### How was it solved?
- [x] Remove custom registry config from `lisk-service/services/core/.npmrc`
- [x] Update `lisk-service/services/core/package.json` to use stable version of `@liskhq/lisk-transactions`

### How was it tested?
Local + Jenkins
