### PR TITLE
Remove multisignature properties for Non-Multisig accounts - Closes #280

### DIFF
--- a/services/core/shared/core/compat/sdk_v4/accounts.js
+++ b/services/core/shared/core/compat/sdk_v4/accounts.js
@@ -116,9 +116,10 @@ const getAccounts = async params => {
 
 const getMultisignatureGroups = async account => {
 	const multisignatureAccount = {};
-	multisignatureAccount.numberOfReqSignatures = account.keys.numberOfSignatures;
-	multisignatureAccount.members = [];
-	if (multisignatureAccount.numberOfReqSignatures) {
+	if (account.keys.numberOfSignatures) {
+		multisignatureAccount.numberOfReqSignatures = account.keys.numberOfSignatures;
+		multisignatureAccount.members = [];
+
 		await BluebirdPromise.map(
 			account.keys.mandatoryKeys, async publicKey => {
 				const accountByPublicKey = (await getAccounts({ publicKey })).data[0];


### PR DESCRIPTION
### What was the problem?
This PR resolves #280 

### How was it solved?
- [x] Add the `numberOfReqSignatures` param to an account only when keys exist for the same

### How was it tested?
Local + Jenkins
