### PR TITLE
Vote endpoints without a param causes wrong HTTP response - Closes #233

### DIFF
--- a/services/gateway/apis/http-version1-compat/methods/voters.js
+++ b/services/gateway/apis/http-version1-compat/methods/voters.js
@@ -31,6 +31,13 @@ module.exports = {
 		limit: { optional: true, min: 1, max: 100, type: 'number' },
 		offset: { optional: true, min: 0, type: 'number' },
 	},
+	paramsRequired: true,
+	validParamPairings: [
+		['address'],
+		['username'],
+		['publickey'],
+		['secpubkey'],
+	],
 	get schema() {
 		const votersSchema = {};
 		votersSchema[this.swaggerApiPath] = { get: {} };

--- a/services/gateway/apis/http-version1-compat/methods/votes.js
+++ b/services/gateway/apis/http-version1-compat/methods/votes.js
@@ -31,6 +31,13 @@ module.exports = {
 		limit: { optional: true, min: 1, max: 100, type: 'number' },
 		offset: { optional: true, min: 0, type: 'number' },
 	},
+	paramsRequired: true,
+	validParamPairings: [
+		['address'],
+		['username'],
+		['publickey'],
+		['secpubkey'],
+	],
 	get schema() {
 		const votesSchema = {};
 		votesSchema[this.swaggerApiPath] = { get: {} };

--- a/services/gateway/apis/http-version1/methods/votesReceived.js
+++ b/services/gateway/apis/http-version1/methods/votesReceived.js
@@ -31,6 +31,13 @@ module.exports = {
 		limit: { optional: true, min: 1, max: 100, type: 'number' },
 		offset: { optional: true, min: 0, type: 'number' },
 	},
+	paramsRequired: true,
+	validParamPairings: [
+		['address'],
+		['username'],
+		['publickey'],
+		['secpubkey'],
+	],
 	get schema() {
 		const votersSchema = {};
 		votersSchema[this.swaggerApiPath] = { get: {} };

--- a/services/gateway/apis/http-version1/methods/votesSent.js
+++ b/services/gateway/apis/http-version1/methods/votesSent.js
@@ -30,8 +30,14 @@ module.exports = {
 		secpubkey: { optional: true, type: 'string', min: 64, max: 64 },
 		limit: { optional: true, min: 1, max: 100, type: 'number' },
 		offset: { optional: true, min: 0, type: 'number' },
-		onefrom: ['address', 'username', 'publickey', 'secpubkey'],
 	},
+	paramsRequired: true,
+	validParamPairings: [
+		['address'],
+		['username'],
+		['publickey'],
+		['secpubkey'],
+	],
 	get schema() {
 		const votesSchema = {};
 		votesSchema[this.swaggerApiPath] = { get: {} };

--- a/services/gateway/apis/http-version1/methods/votesSent.js
+++ b/services/gateway/apis/http-version1/methods/votesSent.js
@@ -30,6 +30,7 @@ module.exports = {
 		secpubkey: { optional: true, type: 'string', min: 64, max: 64 },
 		limit: { optional: true, min: 1, max: 100, type: 'number' },
 		offset: { optional: true, min: 0, type: 'number' },
+		onefrom: ['address', 'username', 'publickey', 'secpubkey'],
 	},
 	get schema() {
 		const votesSchema = {};

--- a/services/gateway/shared/paramValidator.js
+++ b/services/gateway/shared/paramValidator.js
@@ -82,14 +82,21 @@ const validateInputParams = (rawInputParams = {}, specs) => {
 	const specParams = specs.params || {};
 	const inputParams = rawInputParams;
 
-	const oneParamFrom = specParams.onefrom || [];
+	const paramPairings = specs.validParamPairings || [];
 	const inputParamKeys = Object.getOwnPropertyNames(inputParams);
-	if (!oneParamFrom.some(key => inputParamKeys.includes(key))) return { onefrom: oneParamFrom };
 
-	const paramReport = parseParams({
+	const paramReport = { required: [] };
+	if (
+		specs.paramsRequired
+		&& !inputParamKeys.some(key => paramPairings.some(entry => entry.includes(key)))
+	) paramReport.required = paramPairings;
+
+	if (paramReport.required.length) return paramReport;
+
+	Object.assign(paramReport, parseParams({
 		swaggerParams: parseAllParams(specParams, inputParams),
 		inputParams: { ...parseDefaultParams(specParams), ...inputParams },
-	});
+	}));
 
 	paramReport.missing = checkMissingParams(specParams, inputParams);
 

--- a/services/gateway/shared/paramValidator.js
+++ b/services/gateway/shared/paramValidator.js
@@ -57,7 +57,7 @@ const parseParams = (p) => {
 
 const validateInputParams = (rawInputParams = {}, specs) => {
 	const validateFromParamPairings = (paramsRequired, inputParamKeys, paramPairings) => {
-		if (paramsRequired && !inputParamKeys.length) return paramPairings;
+		if (!paramsRequired) return [];
 
 		const relevantPairings = paramPairings
 			.filter(pairing => inputParamKeys.some(key => pairing.includes(key)));

--- a/services/gateway/shared/paramValidator.js
+++ b/services/gateway/shared/paramValidator.js
@@ -72,8 +72,6 @@ const validateInputParams = (rawInputParams = {}, specs) => {
 			return acc;
 		}, {});
 
-	const specParams = specs.params || {};
-
 	const looseSpecParams = (specPar) => Object.keys(specPar).reduce((acc, cur) => {
 		if (specPar[cur].type === 'number' || specPar[cur].type === 'boolean') {
 			acc[cur] = { convert: true, ...specPar[cur] };
@@ -81,7 +79,12 @@ const validateInputParams = (rawInputParams = {}, specs) => {
 		return acc;
 	}, {}); // adds convert: true
 
+	const specParams = specs.params || {};
 	const inputParams = rawInputParams;
+
+	const oneParamFrom = specParams.onefrom || [];
+	const inputParamKeys = Object.getOwnPropertyNames(inputParams);
+	if (!oneParamFrom.some(key => inputParamKeys.includes(key))) return { onefrom: oneParamFrom };
 
 	const paramReport = parseParams({
 		swaggerParams: parseAllParams(specParams, inputParams),

--- a/services/gateway/shared/paramValidator.js
+++ b/services/gateway/shared/paramValidator.js
@@ -56,6 +56,15 @@ const parseParams = (p) => {
 };
 
 const validateInputParams = (rawInputParams = {}, specs) => {
+	const validateFromParamPairings = (paramsRequired, inputParamKeys, paramPairings) => {
+		const result = paramsRequired
+			&& !inputParamKeys.some(key => paramPairings.some(entry => entry.includes(key)))
+			? paramPairings
+			: [];
+
+		return result;
+	};
+
 	const checkMissingParams = (routeParams, requestParams) => {
 		const requiredParamList = Object.keys(routeParams)
 			.filter(o => routeParams[o].required === true);
@@ -85,18 +94,14 @@ const validateInputParams = (rawInputParams = {}, specs) => {
 	const paramPairings = specs.validParamPairings || [];
 	const inputParamKeys = Object.getOwnPropertyNames(inputParams);
 
-	const paramReport = { required: [] };
-	if (
-		specs.paramsRequired
-		&& !inputParamKeys.some(key => paramPairings.some(entry => entry.includes(key)))
-	) paramReport.required = paramPairings;
-
-	if (paramReport.required.length) return paramReport;
-
-	Object.assign(paramReport, parseParams({
+	const paramReport = parseParams({
 		swaggerParams: parseAllParams(specParams, inputParams),
 		inputParams: { ...parseDefaultParams(specParams), ...inputParams },
-	}));
+	});
+
+	paramReport.required = validateFromParamPairings(
+		specs.paramsRequired, inputParamKeys, paramPairings);
+	if (paramReport.required.length) return paramReport;
 
 	paramReport.missing = checkMissingParams(specParams, inputParams);
 

--- a/services/gateway/shared/paramValidator.js
+++ b/services/gateway/shared/paramValidator.js
@@ -56,7 +56,7 @@ const parseParams = (p) => {
 };
 
 const validateInputParams = (rawInputParams = {}, specs) => {
-	const validateFromParamPairings = (paramsRequired, inputParamKeys, paramPairings) => {
+	const validateFromParamPairings = (paramsRequired = false, inputParamKeys, paramPairings) => {
 		if (!paramsRequired) return [];
 
 		const relevantPairings = paramPairings

--- a/services/gateway/shared/paramValidator.js
+++ b/services/gateway/shared/paramValidator.js
@@ -101,12 +101,12 @@ const validateInputParams = (rawInputParams = {}, specs) => {
 
 	paramReport.required = validateFromParamPairings(
 		specs.paramsRequired, inputParamKeys, paramPairings);
-	if (paramReport.required.length) return paramReport;
 
 	paramReport.missing = checkMissingParams(specParams, inputParams);
 
 	if (paramReport.missing.length > 0) return paramReport;
 	if (Object.keys(paramReport.unknown).length > 0) return paramReport;
+	if (paramReport.required.length) return paramReport;
 
 	paramReport.invalid = validator.validate(
 		dropEmptyProps(inputParams),

--- a/services/gateway/shared/paramValidator.js
+++ b/services/gateway/shared/paramValidator.js
@@ -57,12 +57,13 @@ const parseParams = (p) => {
 
 const validateInputParams = (rawInputParams = {}, specs) => {
 	const validateFromParamPairings = (paramsRequired, inputParamKeys, paramPairings) => {
-		const result = paramsRequired
-			&& !inputParamKeys.some(key => paramPairings.some(entry => entry.includes(key)))
-			? paramPairings
-			: [];
+		if (paramsRequired && !inputParamKeys.length) return paramPairings;
 
-		return result;
+		const relevantPairings = paramPairings.filter(pairing => inputParamKeys.some(key => pairing.includes(key)));
+		if (relevantPairings.length === 0) return paramPairings;
+
+		const result = relevantPairings.some(pairing => pairing.every(param => inputParamKeys.includes(param)));
+		return result ? [] : paramPairings;
 	};
 
 	const checkMissingParams = (routeParams, requestParams) => {

--- a/services/gateway/shared/paramValidator.js
+++ b/services/gateway/shared/paramValidator.js
@@ -59,10 +59,12 @@ const validateInputParams = (rawInputParams = {}, specs) => {
 	const validateFromParamPairings = (paramsRequired, inputParamKeys, paramPairings) => {
 		if (paramsRequired && !inputParamKeys.length) return paramPairings;
 
-		const relevantPairings = paramPairings.filter(pairing => inputParamKeys.some(key => pairing.includes(key)));
+		const relevantPairings = paramPairings
+			.filter(pairing => inputParamKeys.some(key => pairing.includes(key)));
 		if (relevantPairings.length === 0) return paramPairings;
 
-		const result = relevantPairings.some(pairing => pairing.every(param => inputParamKeys.includes(param)));
+		const result = relevantPairings
+			.some(pairing => pairing.every(param => inputParamKeys.includes(param)));
 		return result ? [] : paramPairings;
 	};
 

--- a/services/gateway/shared/registerHttpApi.js
+++ b/services/gateway/shared/registerHttpApi.js
@@ -160,11 +160,6 @@ const registerApi = (apiName, config) => {
 			const routeAlias = `${req.method.toUpperCase()} ${req.$alias.path}`;
 			const paramReport = validate(req.$params, methodPaths[routeAlias]);
 
-			if (paramReport.required.length) {
-				sendResponse(INVALID_REQUEST[0], `Require one of the following parameter(s): ${paramReport.required.join(', ')}`);
-				return;
-			}
-
 			if (paramReport.missing.length > 0) {
 				sendResponse(INVALID_REQUEST[0], `Missing parameter(s): ${paramReport.missing.join(', ')}`);
 				return;
@@ -173,6 +168,11 @@ const registerApi = (apiName, config) => {
 			const unknownList = Object.keys(paramReport.unknown);
 			if (unknownList.length > 0) {
 				sendResponse(INVALID_REQUEST[0], `Unknown input parameter(s): ${unknownList.join(', ')}`);
+				return;
+			}
+
+			if (paramReport.required.length) {
+				sendResponse(INVALID_REQUEST[0], `Require one of the following parameter(s): ${paramReport.required.join(', ')}`);
 				return;
 			}
 

--- a/services/gateway/shared/registerHttpApi.js
+++ b/services/gateway/shared/registerHttpApi.js
@@ -160,6 +160,11 @@ const registerApi = (apiName, config) => {
 			const routeAlias = `${req.method.toUpperCase()} ${req.$alias.path}`;
 			const paramReport = validate(req.$params, methodPaths[routeAlias]);
 
+			if (paramReport.onefrom.length) {
+				sendResponse(INVALID_REQUEST[0], `Require one of the following parameter(s): ${paramReport.onefrom.join(', ')}`);
+				return;
+			}
+
 			if (paramReport.missing.length > 0) {
 				sendResponse(INVALID_REQUEST[0], `Missing parameter(s): ${paramReport.missing.join(', ')}`);
 				return;

--- a/services/gateway/shared/registerHttpApi.js
+++ b/services/gateway/shared/registerHttpApi.js
@@ -160,8 +160,8 @@ const registerApi = (apiName, config) => {
 			const routeAlias = `${req.method.toUpperCase()} ${req.$alias.path}`;
 			const paramReport = validate(req.$params, methodPaths[routeAlias]);
 
-			if (paramReport.onefrom.length) {
-				sendResponse(INVALID_REQUEST[0], `Require one of the following parameter(s): ${paramReport.onefrom.join(', ')}`);
+			if (paramReport.required.length) {
+				sendResponse(INVALID_REQUEST[0], `Require one of the following parameter(s): ${paramReport.required.join(', ')}`);
 				return;
 			}
 

--- a/services/gateway/shared/registerHttpApi.js
+++ b/services/gateway/shared/registerHttpApi.js
@@ -172,7 +172,7 @@ const registerApi = (apiName, config) => {
 			}
 
 			if (paramReport.required.length) {
-				sendResponse(INVALID_REQUEST[0], `Require one of the following parameter(s): ${paramReport.required.join(', ')}`);
+				sendResponse(INVALID_REQUEST[0], `Require one of the following parameter combination(s): ${paramReport.required.join(', ')}`);
 				return;
 			}
 

--- a/services/gateway/shared/registerRpcApi.js
+++ b/services/gateway/shared/registerRpcApi.js
@@ -163,7 +163,7 @@ const registerApi = (apiNames, config) => {
 					}
 
 					if (paramReport.required.length) {
-						throw new MoleculerClientError({ code: INVALID_PARAMS[0], message: `Require one of the following parameter(s): ${paramReport.required.join(', ')}` });
+						throw new MoleculerClientError({ code: INVALID_PARAMS[0], message: `Require one of the following parameter combination(s): ${paramReport.required.join(', ')}` });
 					}
 
 					const invalidList = paramReport.invalid;

--- a/services/gateway/shared/registerRpcApi.js
+++ b/services/gateway/shared/registerRpcApi.js
@@ -162,6 +162,10 @@ const registerApi = (apiNames, config) => {
 						throw new MoleculerClientError({ code: INVALID_PARAMS[0], message: `Unknown input parameter(s): ${unknownList.join(', ')}` });
 					}
 
+					if (paramReport.required.length) {
+						throw new MoleculerClientError({ code: INVALID_PARAMS[0], message: `Require one of the following parameter(s): ${paramReport.required.join(', ')}` });
+					}
+
 					const invalidList = paramReport.invalid;
 					if (invalidList.length > 0) {
 						throw new MoleculerClientError({ code: INVALID_PARAMS[0], message: `Invalid input parameter values: ${invalidList.map(o => o.message).join(', ')}` });

--- a/services/gateway/shared/registerRpcApi.js
+++ b/services/gateway/shared/registerRpcApi.js
@@ -15,7 +15,7 @@
  */
 const {
 	Utils,
-	Constants: { JSON_RPC: { INVALID_PARAMS } },
+	Constants: { JSON_RPC: { INVALID_PARAMS, INVALID_REQUEST } },
 } = require('lisk-service-framework');
 
 const { MoleculerClientError } = require('moleculer').Errors;
@@ -163,7 +163,7 @@ const registerApi = (apiNames, config) => {
 					}
 
 					if (paramReport.required.length) {
-						throw new MoleculerClientError({ code: INVALID_PARAMS[0], message: `Require one of the following parameter combination(s): ${paramReport.required.join(', ')}` });
+						throw new MoleculerClientError({ code: INVALID_REQUEST[0], message: `Require one of the following parameter combination(s): ${paramReport.required.join(', ')}` });
 					}
 
 					const invalidList = paramReport.invalid;

--- a/tests/integration/api/http/votesReceived.test.js
+++ b/tests/integration/api/http/votesReceived.test.js
@@ -149,8 +149,7 @@ const {
 				expect(response).toMap(wrongInputParamSchema);
 			});
 
-			// TODO: Fails CI pipeline
-			xit('Returns BAD_REQUEST (400) when requested without required params', async () => {
+			it('Returns BAD_REQUEST (400) when requested without required params', async () => {
 				const response = await api.get(`${endpoint}`, 400);
 				expect(response).toMap(badRequestSchema);
 			});

--- a/tests/integration/api/http/votesSent.test.js
+++ b/tests/integration/api/http/votesSent.test.js
@@ -149,8 +149,7 @@ const {
 				expect(response).toMap(wrongInputParamSchema);
 			});
 
-			// TODO: Fails CI pipeline
-			xit('Returns BAD_REQUEST (400) when requested without required params', async () => {
+			it('Returns BAD_REQUEST (400) when requested without required params', async () => {
 				const response = await api.get(`${endpoint}`, 400);
 				expect(response).toMap(badRequestSchema);
 			});

--- a/tests/integration/api/rpc/votesReceived.test.js
+++ b/tests/integration/api/rpc/votesReceived.test.js
@@ -149,8 +149,13 @@ const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v1`;
 			});
 		});
 
+		it('Returns INVALID_PARAMS (-32602) when request unsatisfies param pairings', async () => {
+			const response = await getVoters({});
+			expect(response).toMap(invalidParamsSchema);
+		});
+
 		it('Returns INVALID_PARAMS (-32602) when requested with limit = 0', async () => {
-			const response = await getVoters({ limit: 0 });
+			const response = await getVoters({ address: refDelegate.address, limit: 0 });
 			expect(response).toMap(invalidParamsSchema);
 		});
 

--- a/tests/integration/api/rpc/votesReceived.test.js
+++ b/tests/integration/api/rpc/votesReceived.test.js
@@ -149,11 +149,6 @@ const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v1`;
 			});
 		});
 
-		it('Returns INVALID_PARAMS (-32602) when request unsatisfies param pairings', async () => {
-			const response = await getVoters({});
-			expect(response).toMap(invalidParamsSchema);
-		});
-
 		it('Returns INVALID_PARAMS (-32602) when requested with limit = 0', async () => {
 			const response = await getVoters({ address: refDelegate.address, limit: 0 });
 			expect(response).toMap(invalidParamsSchema);
@@ -171,8 +166,7 @@ const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v1`;
 			expect(response).toMap(invalidParamsSchema);
 		});
 
-		// TODO: Fails CI pipeline
-		xit('Returns BAD_REQUEST (400) when requested without required params', async () => {
+		it('Returns INVALID_REQUEST (-32600) when requested without required params', async () => {
 			const response = await getVoters({});
 			expect(response).toMap(invalidRequestSchema);
 		});

--- a/tests/integration/api/rpc/votesSent.test.js
+++ b/tests/integration/api/rpc/votesSent.test.js
@@ -150,7 +150,7 @@ const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v1`;
 		});
 
 		it('Returns INVALID_PARAMS (-32602) when requested with limit = 0', async () => {
-			const response = await getVotes({ limit: 0 });
+			const response = await getVotes({ address: refDelegate.address, limit: 0 });
 			expect(response).toMap(invalidParamsSchema);
 		});
 

--- a/tests/integration/api/rpc/votesSent.test.js
+++ b/tests/integration/api/rpc/votesSent.test.js
@@ -151,7 +151,6 @@ const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v1`;
 
 		it('Returns INVALID_PARAMS (-32602) when request unsatisfies param pairings', async () => {
 			const response = await getVotes({});
-			console.log(response);
 			expect(response).toMap(invalidParamsSchema);
 		});
 

--- a/tests/integration/api/rpc/votesSent.test.js
+++ b/tests/integration/api/rpc/votesSent.test.js
@@ -149,11 +149,6 @@ const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v1`;
 			});
 		});
 
-		it('Returns INVALID_PARAMS (-32602) when request unsatisfies param pairings', async () => {
-			const response = await getVotes({});
-			expect(response).toMap(invalidParamsSchema);
-		});
-
 		it('Returns INVALID_PARAMS (-32602) when requested with limit = 0', async () => {
 			const response = await getVotes({ address: refDelegate.address, limit: 0 });
 			expect(response).toMap(invalidParamsSchema);
@@ -171,8 +166,7 @@ const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v1`;
 			expect(response).toMap(invalidParamsSchema);
 		});
 
-		// TODO: Fails CI pipeline
-		xit('Returns BAD_REQUEST (400) when requested without required params', async () => {
+		it('Returns INVALID_REQUEST (-32600) when requested without required params', async () => {
 			const response = await getVotes({});
 			expect(response).toMap(invalidRequestSchema);
 		});

--- a/tests/integration/api/rpc/votesSent.test.js
+++ b/tests/integration/api/rpc/votesSent.test.js
@@ -149,6 +149,12 @@ const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v1`;
 			});
 		});
 
+		it('Returns INVALID_PARAMS (-32602) when request unsatisfies param pairings', async () => {
+			const response = await getVotes({});
+			console.log(response);
+			expect(response).toMap(invalidParamsSchema);
+		});
+
 		it('Returns INVALID_PARAMS (-32602) when requested with limit = 0', async () => {
 			const response = await getVotes({ address: refDelegate.address, limit: 0 });
 			expect(response).toMap(invalidParamsSchema);


### PR DESCRIPTION
### What was the problem?
This PR resolves #233 

### How was it solved?
- [x] Add validation for required param from a pool of optional request parameters
- [x] Add validation to check if complementary parameters exist for a user-specified request param
- [x] Add corresponding integration test cases

### How was it tested?
Local + Jenkins
