### PR TITLE
Fix non-indexed transaction calls - Closes # 316

### DIFF
--- a/services/core/config.js
+++ b/services/core/config.js
@@ -94,7 +94,7 @@ config.cacheNumOfBlocks = Number(process.env.CACHE_N_BLOCKS) || 202;
  * The block index may trigger indexing of other entities that are part of the block
  * such as transactions, accounts, votes etc.
  */
-config.indexNumOfBlocks = Number(process.env.INDEX_N_BLOCKS) || 202;
+config.indexNumOfBlocks = Number(process.env.INDEX_N_BLOCKS || 202);
 
 
 /**

--- a/services/core/methods/controllers/delegates.js
+++ b/services/core/methods/controllers/delegates.js
@@ -95,7 +95,7 @@ const getNextForgers = async params => {
 const getLatestRegistrations = async params => {
 	const registrationsRes = await CoreService.getTransactions(Object.assign(params, {
 		type: 'REGISTERDELEGATE',
-		// sort: 'timestamp:desc',
+		sort: 'timestamp:desc',
 	}));
 
 	const registrations = registrationsRes.data;

--- a/services/core/methods/controllers/delegates.js
+++ b/services/core/methods/controllers/delegates.js
@@ -95,7 +95,7 @@ const getNextForgers = async params => {
 const getLatestRegistrations = async params => {
 	const registrationsRes = await CoreService.getTransactions(Object.assign(params, {
 		type: 'REGISTERDELEGATE',
-		sort: 'timestamp:desc',
+		// sort: 'timestamp:desc',
 	}));
 
 	const registrations = registrationsRes.data;

--- a/services/core/shared/core/compat/sdk_v4/blocks.js
+++ b/services/core/shared/core/compat/sdk_v4/blocks.js
@@ -145,7 +145,8 @@ const init = async () => {
 	try {
 		currentHeight = (await coreApi.getNetworkStatus()).data.height;
 
-		let blockIndexLowerRange = currentHeight - config.indexNumOfBlocks;
+		let blockIndexLowerRange = config.indexNumOfBlocks > 0
+			? currentHeight - config.indexNumOfBlocks : 1;
 		const lastNumOfBlocks = await bIdCache.get('lastNumOfBlocks');
 
 		if (Number(lastNumOfBlocks) === Number(config.indexNumOfBlocks)) {
@@ -157,11 +158,8 @@ const init = async () => {
 			await bIdCache.set('lastIndexedHeight', blockIndexLowerRange);
 		}
 
-		if (Number.isInteger(blockIndexLowerRange)) {
-			await buildIndex(blockIndexLowerRange, currentHeight);
-		} else {
-			await buildIndex(0, currentHeight);
-		}
+		await buildIndex(blockIndexLowerRange, currentHeight);
+
 	} catch (err) {
 		logger.warn('Unable to build block cache');
 		logger.warn(err.message);

--- a/services/core/shared/core/compat/sdk_v4/blocks.js
+++ b/services/core/shared/core/compat/sdk_v4/blocks.js
@@ -159,7 +159,6 @@ const init = async () => {
 		}
 
 		await buildIndex(blockIndexLowerRange, currentHeight);
-
 	} catch (err) {
 		logger.warn('Unable to build block cache');
 		logger.warn(err.message);

--- a/services/core/shared/core/compat/sdk_v4/transactions.js
+++ b/services/core/shared/core/compat/sdk_v4/transactions.js
@@ -26,6 +26,8 @@ const {
 const config = require('../../../../config');
 const redis = require('../../../redis');
 
+const { mapParams } = require('./mappings');
+
 const MAX_TX_LIMIT_PP = 100;
 
 const bIdCache = CacheRedis('blockIdToTimestamp', config.endpoints.redis);
@@ -77,6 +79,8 @@ const getTransactions = async params => {
 
 	if (params.fromTimestamp || params.toTimestamp
 		|| (params.sort && params.sort.includes('timestamp'))) {
+		params = mapParams(params, '/transactions');
+
 		let timestampSortOrder = 'desc';
 		if (params.sort) [, timestampSortOrder] = params.sort.split(':');
 		const blockIds = await timestampDb.findByRange('timestamp',

--- a/services/core/shared/core/compat/sdk_v4/transactions.js
+++ b/services/core/shared/core/compat/sdk_v4/transactions.js
@@ -80,6 +80,8 @@ const getTransactions = async params => {
 	if (params.fromTimestamp || params.toTimestamp
 		|| (params.sort && params.sort.includes('timestamp'))) {
 		params = mapParams(params, '/transactions');
+		if (!params.fromTimestamp) params.fromTimestamp = 0;
+		if (!params.toTimestamp) params.toTimestamp = Math.floor(Date.now() / 1000);
 
 		let timestampSortOrder = 'desc';
 		if (params.sort) [, timestampSortOrder] = params.sort.split(':');

--- a/services/core/shared/core/compat/sdk_v4/voters.js
+++ b/services/core/shared/core/compat/sdk_v4/voters.js
@@ -37,7 +37,7 @@ const getVoters = async (params) => {
 				voter = {
 					...voter,
 					balance: voters.data.balance,
-					username: voters.data.username,
+					username: voters.data.username || undefined,
 				};
 			} else {
 				const voterInfo = (await getAccounts({ address: voter.address }))
@@ -45,7 +45,7 @@ const getVoters = async (params) => {
 				voter = {
 					...voter,
 					balance: voterInfo.balance,
-					username: voterInfo.username,
+					username: voterInfo.username || undefined,
 				};
 			}
 			voter.amount = voter.votes


### PR DESCRIPTION
### What was the problem?
This PR resolves #316 

### How was it solved?
- [x] Translate transaction type param prior to index search
- [x] Assign default `fromTimestamp` and `toTimestamp` values, if missing, prior index search
- [x] Add indexing for delegate registrations
- [x] Filter out non-existent usernames in the response (`/voters`)

### How was it tested?
Local
