### PR TITLE
Fix latest_registrations retrieval - Closes #315

### DIFF
--- a/services/core/methods/controllers/delegates.js
+++ b/services/core/methods/controllers/delegates.js
@@ -95,7 +95,7 @@ const getNextForgers = async params => {
 const getLatestRegistrations = async params => {
 	const registrationsRes = await CoreService.getTransactions(Object.assign(params, {
 		type: 'REGISTERDELEGATE',
-		sort: 'timestamp:desc',
+		// sort: 'timestamp:desc',
 	}));
 
 	const registrations = registrationsRes.data;


### PR DESCRIPTION
### What was the problem?
This PR resolves #315 

### How was it solved?
- [x] Remove the `sort` param while requesting for the relevant transactions

### How was it tested?
Local
