### PR TITLE
Improve delegate filtering - Closes #329

### DIFF
--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -147,6 +147,8 @@ const getDelegates = async params => {
 		delegates.data = filterBy(allDelegates, 'secondPublicKey');
 	} else if (params.username) {
 		delegates.data = filterBy(allDelegates, 'username');
+	} else if (params.status) {
+		delegates.data = filterBy(allDelegates, 'status');
 	} else if (params.search) {
 		delegates.data = allDelegates.filter((acc) => (acc.username
 			&& String(acc.username).match(new RegExp(params.search, 'i'))));

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -136,8 +136,10 @@ const getDelegates = async params => {
 		return comparator;
 	};
 
-	const filterBy = (list, entity) => list.filter((acc) => (acc[entity]
-		&& acc[entity] === params[entity]));
+	const filterBy = (list, entity) => list.filter((acc) => params[entity].includes(',')
+		? (acc[entity] && params[entity].split(',').includes(acc[entity]))
+		: (acc[entity] && acc[entity] === params[entity]),
+	);
 
 	if (params.address) {
 		delegates.data = filterBy(allDelegates, 'address');

--- a/services/gateway/apis/http-version1/methods/delegates.js
+++ b/services/gateway/apis/http-version1/methods/delegates.js
@@ -30,7 +30,7 @@ module.exports = {
 		status: {
 			optional: true,
 			type: 'string',
-			pattern: /\b(?:active|standby|banned|punished|non-eligible)\b/
+			pattern: /^(?:\b(?:active|standby|banned|punished|non-eligible)\b|\b(?:active|standby|banned|punished|non-eligible|,){3,}\b){1}$/,
 		},
 		search: { optional: true, type: 'string', min: 1 },
 		limit: { optional: true, type: 'number', min: 1, max: 101, default: 10 },

--- a/services/gateway/apis/http-version1/methods/delegates.js
+++ b/services/gateway/apis/http-version1/methods/delegates.js
@@ -30,7 +30,7 @@ module.exports = {
 		status: {
 			optional: true,
 			type: 'string',
-			enum: ['active', 'standby', 'banned', 'punished', 'non-eligible'],
+			pattern: /\b(?:active|standby|banned|punished|non-eligible)\b/
 		},
 		search: { optional: true, type: 'string', min: 1 },
 		limit: { optional: true, type: 'number', min: 1, max: 101, default: 10 },

--- a/services/gateway/apis/http-version1/methods/delegates.js
+++ b/services/gateway/apis/http-version1/methods/delegates.js
@@ -27,6 +27,11 @@ module.exports = {
 		publickey: { optional: true, type: 'string', min: 1 },
 		secpubkey: { optional: true, type: 'string', min: 1 },
 		username: { optional: true, type: 'string', min: 1 },
+		status: {
+			optional: true,
+			type: 'string',
+			enum: ['active', 'standby', 'banned', 'punished', 'non-eligible'],
+		},
 		search: { optional: true, type: 'string', min: 1 },
 		limit: { optional: true, type: 'number', min: 1, max: 101, default: 10 },
 		offset: { optional: true, type: 'number', min: 0, default: 0 },

--- a/services/gateway/sources/version1/delegates.js
+++ b/services/gateway/sources/version1/delegates.js
@@ -23,6 +23,7 @@ module.exports = {
 		publicKey: 'publickey',
 		secondPublicKey: 'secpubkey',
 		username: '=',
+		status: '=',
 		offset: '=',
 		limit: '=',
 		search: '=',

--- a/tests/integration/api/http/delegates.test.js
+++ b/tests/integration/api/http/delegates.test.js
@@ -130,6 +130,34 @@ describe('Delegates API', () => {
 		});
 	});
 
+	describe('GET /delegates?status', () => {
+		it('filter active delegates -> ok', async () => {
+			const response = await api.get(`${endpoint}?status=active`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeArrayOfSize(10);
+			response.data.map(delegate => expect(delegate)
+				.toMap(delegateSchema, { status: 'active' }));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('filter standby delegates -> ok', async () => {
+			const response = await api.get(`${endpoint}?status=standby`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeArrayOfSize(10);
+			response.data.map(delegate => expect(delegate)
+				.toMap(delegateSchema, { status: 'standby' }));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('filter delegates by combination -> ok', async () => {
+			const response = await api.get(`${endpoint}?status=active,standby&offset=95`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeArrayOfSize(10);
+			response.data.map(delegate => expect(delegate).toMap(delegateSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+	});
+
 	describe('GET /delegates/latest_registrations', () => {
 		xit('limit = 100 -> ok', async () => {
 			const response = await api.get(`${endpoint}/latest_registrations?limit=100`);

--- a/tests/integration/api/http/delegates.test.js
+++ b/tests/integration/api/http/delegates.test.js
@@ -156,6 +156,11 @@ describe('Delegates API', () => {
 			response.data.map(delegate => expect(delegate).toMap(delegateSchema));
 			expect(response.meta).toMap(metaSchema);
 		});
+
+		it('wrong status input -> 400', async () => {
+			const response = await api.get(`${endpoint}?status=falseValue`, 400);
+			expect(response).toMap(notFoundSchema);
+		});
 	});
 
 	describe('GET /delegates/latest_registrations', () => {

--- a/tests/integration/api/rpc/delegates.test.js
+++ b/tests/integration/api/rpc/delegates.test.js
@@ -188,7 +188,7 @@ describe('Method get.delegates', () => {
 		});
 	});
 
-	describe.only('returns delegates based on status', () => {
+	describe('returns delegates based on status', () => {
 		it('returns active delegates by status', async () => {
 			const response = await getDelegates({ status: 'active' });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
@@ -209,7 +209,7 @@ describe('Method get.delegates', () => {
 			expect(result.meta).toMap(metaSchema, { count: 10, offset: 0 });
 		});
 
-		it('returns standby delegates by status', async () => {
+		it('returns both active and standby delegates by status', async () => {
 			const response = await getDelegates({ status: 'active,standby', offset: 95 });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;

--- a/tests/integration/api/rpc/delegates.test.js
+++ b/tests/integration/api/rpc/delegates.test.js
@@ -218,6 +218,11 @@ describe('Method get.delegates', () => {
 			result.data.forEach(delegate => expect(delegate).toMap(delegateSchema));
 			expect(result.meta).toMap(metaSchema, { count: 10, offset: 95 });
 		});
+
+		it('returns INVALID_PARAMS (-32602) with wrong delegate status value', async () => {
+			const response = await getDelegates({ status: 'falseValue', });
+			expect(response).toMap(invalidParamsSchema);
+		});
 	});
 
 	describe('returns INVALID_PARAMS', () => {

--- a/tests/integration/api/rpc/delegates.test.js
+++ b/tests/integration/api/rpc/delegates.test.js
@@ -220,7 +220,7 @@ describe('Method get.delegates', () => {
 		});
 
 		it('returns INVALID_PARAMS (-32602) with wrong delegate status value', async () => {
-			const response = await getDelegates({ status: 'falseValue', });
+			const response = await getDelegates({ status: 'falseValue' });
 			expect(response).toMap(invalidParamsSchema);
 		});
 	});

--- a/tests/integration/api/rpc/delegates.test.js
+++ b/tests/integration/api/rpc/delegates.test.js
@@ -188,6 +188,38 @@ describe('Method get.delegates', () => {
 		});
 	});
 
+	describe.only('returns delegates based on status', () => {
+		it('returns active delegates by status', async () => {
+			const response = await getDelegates({ status: 'active' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result).toMap(resultEnvelopeSchema);
+			expect(result.data).toBeArrayOfSize(10);
+			result.data.forEach(delegate => expect(delegate).toMap(delegateSchema, { status: 'active' }));
+			expect(result.meta).toMap(metaSchema, { count: 10, offset: 0 });
+		});
+
+		it('returns standby delegates by status', async () => {
+			const response = await getDelegates({ status: 'standby' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result).toMap(resultEnvelopeSchema);
+			expect(result.data).toBeArrayOfSize(10);
+			result.data.forEach(delegate => expect(delegate).toMap(delegateSchema, { status: 'standby' }));
+			expect(result.meta).toMap(metaSchema, { count: 10, offset: 0 });
+		});
+
+		it('returns standby delegates by status', async () => {
+			const response = await getDelegates({ status: 'active,standby', offset: 95 });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result).toMap(resultEnvelopeSchema);
+			expect(result.data).toBeArrayOfSize(10);
+			result.data.forEach(delegate => expect(delegate).toMap(delegateSchema));
+			expect(result.meta).toMap(metaSchema, { count: 10, offset: 95 });
+		});
+	});
+
 	describe('returns INVALID_PARAMS', () => {
 		// current response is -32600 as invalid parameter response
 		it('returns INVALID_PARAMS (-32602) when invalid param name', async () => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #329 

### How was it solved?
- [x] Introduce `status` request params for the endpoints `/api/v1/delegates` and `get.delegates`
- [x] Validate `status`. Allow values only from the following list. Also, allow as comma separated multivalues.
  - [x] `active`
  - [x] `standby`
  - [x] `banned`
  - [x] `punished`
  - [x] `non-eligible`
- [x] Filter the delegates based on the `status` value(s)

### How was it tested?
Local
