### PR TITLE
Make Jenkins CI run against Betanet 5

### DIFF
--- a/Jenkinsfile.deployment
+++ b/Jenkinsfile.deployment
@@ -39,13 +39,13 @@ pipeline {
 			when { branch 'development' }
 			environment {
 				ENABLE_HTTP_API='http-version1,http-version1-compat,http-status,http-test'
-				ENABLE_WS_API='rpc,rpc-v1,rpc-test,blockchain'
+				ENABLE_WS_API='rpc,rpc-v1,rpc-test,blockchain,rpc-v2'
 			}
 			steps {
 				ansiColor('xterm') {
 					dir('docker') {
-						sh 'make -f Makefile.deployment.betanet mrproper'
-						sh 'make -f Makefile.deployment.betanet up'
+						sh 'make -f Makefile.deployment.betanet5 mrproper'
+						sh 'make -f Makefile.deployment.betanet5 up'
 					}
 				}
 			}

--- a/Jenkinsfile.deployment
+++ b/Jenkinsfile.deployment
@@ -38,7 +38,7 @@ pipeline {
 			agent { node { label 'lisk-service-dev-v4' } }
 			when { branch 'development' }
 			environment {
-				ENABLE_HTTP_API='http-version1,http-version1-compat,http-status,http-test'
+				ENABLE_HTTP_API='http-version1,http-version1-compat,http-status,http-test,http-version2'
 				ENABLE_WS_API='rpc,rpc-v1,rpc-test,blockchain,rpc-v2'
 			}
 			steps {

--- a/docker/Makefile.deployment.betanet5
+++ b/docker/Makefile.deployment.betanet5
@@ -1,0 +1,29 @@
+.PHONY: clean coldstart mrproper up
+all: up
+
+compose := docker-compose \
+	-f docker-compose.yml \
+	-f lisk_service/docker-compose.core.yml \
+	-f lisk_service/docker-compose.gateway.yml \
+	-f lisk_service/docker-compose.gateway-ports.yml \
+	-f docker-compose.betanet5.yml
+
+up:
+	(ENABLE_HTTP_API=${ENABLE_HTTP_API} ENABLE_WS_API=${ENABLE_WS_API} $(compose) up --detach)
+
+down:
+	$(compose) down --volumes --remove-orphans
+
+cli-%:
+	$(compose) exec $* /bin/sh
+
+logs:
+	$(compose) logs
+
+logs-%:
+	$(compose) logs $*
+
+print-config:
+	$(compose) config
+
+mrproper: down

--- a/docker/docker-compose.betanet5.yml
+++ b/docker/docker-compose.betanet5.yml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+
+  core:
+    env_file:
+      - ./lisk_service/env/network/betanet5.env

--- a/docker/lisk_service/docker-compose.core.yml
+++ b/docker/lisk_service/docker-compose.core.yml
@@ -14,6 +14,8 @@ services:
     env_file:
       - ./lisk_service/env/common.env
       - ./lisk_service/env/core.env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   redis_core:
     image: redis:5-alpine

--- a/docker/lisk_service/env/network/betanet5.env
+++ b/docker/lisk_service/env/network/betanet5.env
@@ -1,0 +1,5 @@
+## External services
+
+# Lisk ecosystem configuration
+LISK_CORE_HTTP=http://host.docker.internal:5000
+LISK_CORE_WS=ws://host.docker.internal:8080


### PR DESCRIPTION
### What was the problem?
This PR changes the Jenkins job to run against betanet5 

### How was it solved?
<!--- Please describe your technical implementation -->
Modified Jenkinsfile.deployment, added relevant betanet5 docker compose and env files

### How was it tested?
<!--- Please describe how you tested your changes -->
Tested on Jenkins

### Notes
Also adds workaround for https://github.com/docker/for-linux/issues/264