### PR TITLE
Improve block indexing - Closes #360

### DIFF
--- a/services/core/shared/core/compat/common/constants.js
+++ b/services/core/shared/core/compat/common/constants.js
@@ -25,6 +25,7 @@ let coreVersion = '1.0.0-alpha.0';
 let constants;
 let readyStatus;
 let registeredLiskModuleAssets;
+let isIndexReady = false;
 
 const networkFeeConstants = {
 	minFeePerByte: undefined,
@@ -101,6 +102,10 @@ const getRegisteredModuleAssets = () => registeredLiskModuleAssets;
 
 const getNetworkFeeConstants = () => networkFeeConstants;
 
+const setIndexReadyStatus = isReady => isIndexReady = isReady;
+
+const getIndexReadyStatus = () => isIndexReady;
+
 module.exports = {
 	getNetworkConstants,
 	setCoreVersion,
@@ -111,4 +116,6 @@ module.exports = {
 	setRegisteredmoduleAssets,
 	resolvemoduleAssets,
 	getNetworkFeeConstants,
+	setIndexReadyStatus,
+	getIndexReadyStatus,
 };

--- a/services/core/shared/core/compat/common/index.js
+++ b/services/core/shared/core/compat/common/index.js
@@ -29,6 +29,8 @@ const {
     setRegisteredmoduleAssets,
     resolvemoduleAssets,
     getNetworkFeeConstants,
+    setIndexReadyStatus,
+    getIndexReadyStatus,
 } = require('./constants');
 
 const {
@@ -52,6 +54,8 @@ module.exports = {
     setRegisteredmoduleAssets,
     resolvemoduleAssets,
     getNetworkFeeConstants,
+    setIndexReadyStatus,
+    getIndexReadyStatus,
 
     getBlockchainTime,
     getEpochUnixTime,

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -241,7 +241,7 @@ const getBlocks = async params => {
 const buildIndex = async (from, to) => {
 	logger.info('Building index of blocks');
 
-	if (from >= to) {
+	if (from > to) {
 		logger.warn(`Invalid interval of blocks to index: ${from} -> ${to}`);
 		return;
 	}

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -141,8 +141,11 @@ const indexNewBlocks = async blocks => {
 	const blocksDB = await getBlocksIndex();
 	if (blocks.data.length === 1) {
 		const [block] = blocks.data;
-		const resultSet = await blocksDB.find({ id: block.id });
-		if (!resultSet.length) indexBlocksQueue.add('indexBlocksQueue', { blocks: blocks.data });
+		const [blockInfo] = await blocksDB.find({ id: block.id });
+		if (!blockInfo || !blockInfo.isFinal) {
+			// Index if doesn't exist, or update if it isn't set to final
+			indexBlocksQueue.add('indexBlocksQueue', { blocks: blocks.data });
+		}
 
 		const highestIndexedHeight = await blocksCache.get('highestIndexedHeight');
 		if (block.height > highestIndexedHeight) await blocksCache.set('highestIndexedHeight', block.height);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -150,7 +150,7 @@ const indexNewBlocks = async blocks => {
 	const blocksDB = await getBlocksIndex();
 	if (blocks.data.length === 1) {
 		const [block] = blocks.data;
-		const [blockInfo] = await blocksDB.find({ id: block.id });
+		const [blockInfo] = await blocksDB.find({ height: block.height });
 		if (!blockInfo || !blockInfo.isFinal) {
 			// Index if doesn't exist, or update if it isn't set to final
 			indexBlocksQueue.add('indexBlocksQueue', { blocks: blocks.data });

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -285,13 +285,13 @@ const indexMissingBlocks = async (fromHeight, toHeight) => {
 	const indexedBlockCount = await blocksDB.count({ propBetweens });
 	if (indexedBlockCount < toHeight) {
 		const missingBlocksQueryStatement = `
-		SELECT
-			(SELECT COALESCE(MAX(height)+1, 1) FROM blocks WHERE height < b1.height) AS 'from',
-			(b1.height - 1) AS 'to'
-		FROM blocks b1
-		WHERE b1.height != 1
-			AND b1.height BETWEEN ${fromHeight} AND ${toHeight}
-			AND NOT EXISTS (SELECT 1 FROM blocks b2 WHERE b2.height = b1.height - 1)
+			SELECT
+				(SELECT COALESCE(MAX(b0.height)+1, 1) FROM blocks b0 WHERE b0.height < b1.height) AS 'from',
+				(b1.height - 1) AS 'to'
+			FROM blocks b1
+			WHERE b1.height BETWEEN ${fromHeight} AND ${toHeight}
+				AND b1.height != 1
+				AND NOT EXISTS (SELECT 1 FROM blocks b2 WHERE b2.height = b1.height - 1)
 		`;
 
 		const missingBlocksRanges = await blocksDB.rawQuery(missingBlocksQueryStatement);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -286,16 +286,12 @@ const indexMissingBlocks = async (fromHeight, toHeight) => {
 	if (indexedBlockCount < toHeight) {
 		const missingBlocksQueryStatement = `
 		SELECT
-			(SELECT COALESCE(MAX(height)+1, 1)
-			FROM blocks
-			WHERE height < b1.height) AS 'from',
-				b1.height - 1 AS 'to'
+			(SELECT COALESCE(MAX(height)+1, 1) FROM blocks WHERE height < b1.height) AS 'from',
+			(b1.height - 1) AS 'to'
 		FROM blocks b1
-		WHERE b1.height > ${fromHeight} AND b1.height < ${toHeight}
-			AND NOT EXISTS
-				(SELECT 1
-				FROM blocks b2
-				WHERE b2.height = b1.height - 1)
+		WHERE b1.height != 1
+			AND b1.height BETWEEN ${fromHeight} AND ${toHeight}
+			AND NOT EXISTS (SELECT 1 FROM blocks b2 WHERE b2.height = b1.height - 1)
 		`;
 
 		const missingBlocksRanges = await blocksDB.rawQuery(missingBlocksQueryStatement);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -185,7 +185,9 @@ const indexNewBlocks = async blocks => {
 			}
 		}
 		const highestIndexedHeight = await blocksCache.get('highestIndexedHeight');
-		if (block.height > highestIndexedHeight) await blocksCache.set('highestIndexedHeight', block.height);
+		if ((blockInfo && blockInfo.id !== block.id) || block.height > highestIndexedHeight) {
+			await blocksCache.set('highestIndexedHeight', block.height);
+		}
 	}
 };
 

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -347,6 +347,7 @@ const indexMissingBlocks = async (fromHeight, toHeight) => {
 		}
 	}
 
+	// eslint-disable-next-line consistent-return
 	waitForIt(async () => {
 		const currentHeight = (await coreApi.getNetworkStatus()).data.height;
 		const numBlocksIndexed = await blocksDB.count();

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -291,7 +291,7 @@ const indexMissingBlocks = async (fromHeight, toHeight) => {
 			WHERE height < b1.height) AS 'from',
 				b1.height - 1 AS 'to'
 		FROM blocks b1
-		WHERE b1.height != 1
+		WHERE b1.height > ${fromHeight} AND b1.height < ${toHeight}
 			AND NOT EXISTS
 				(SELECT 1
 				FROM blocks b2

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -171,6 +171,8 @@ const indexNewBlocks = async blocks => {
 				// 	limit: 1000,
 				// });
 				// await blocksDB.deleteIds(blocksToRemove.map(b => b.id));
+
+				// TODO: Remove the forked transactions / votes
 			}
 		}
 		const highestIndexedHeight = await blocksCache.get('highestIndexedHeight');

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -167,13 +167,13 @@ const indexNewBlocks = async blocks => {
 				// where: { height: `<= ${finalizedBlockHeight}` },
 			});
 
-			if (blockInfo && !blockInfo.isFinal) {
-				// TODO: Fork handling
+			if (blockInfo && blockInfo.id !== block.id) {
+				// Fork detected
+
 				// Remove all blocks at height greater than the incoming block, if fork detected
 				// (Risky affair, need signal based impl. for new incoming blocks)
 			}
 		}
-
 		const highestIndexedHeight = await blocksCache.get('highestIndexedHeight');
 		if (block.height > highestIndexedHeight) await blocksCache.set('highestIndexedHeight', block.height);
 	}

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -172,7 +172,7 @@ const indexNewBlocks = async blocks => {
 						from: block.height + 1,
 						to: highestIndexedBlock.height,
 					}],
-					limit: 1000,
+					limit: highestIndexedBlock.height - block.height,
 				});
 				await blocksDB.deleteIds(blocksToRemove.map(b => b.id));
 

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -165,12 +165,16 @@ const indexNewBlocks = async blocks => {
 			if (blockInfo && blockInfo.id !== block.id) {
 				// Fork detected
 
-				// TODO: Support non-equality in where clause
-				// const blocksToRemove = await blocksDB.find({
-				// 	where: { height: `> ${block.height}` },
-				// 	limit: 1000,
-				// });
-				// await blocksDB.deleteIds(blocksToRemove.map(b => b.id));
+				const [highestIndexedBlock] = await blocksDB.find({ sort: 'height:desc', limit: 1 });
+				const blocksToRemove = await blocksDB.find({
+					propBetweens: [{
+						property: 'height',
+						from: block.height + 1,
+						to: highestIndexedBlock.height,
+					}],
+					limit: 1000,
+				});
+				await blocksDB.deleteIds(blocksToRemove.map(b => b.id));
 
 				// TODO: Remove the forked transactions / votes
 			}

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -163,8 +163,8 @@ const indexNewBlocks = async blocks => {
 				blocks: nonFinalBlocks
 					.filter(b => b.height <= finalizedBlockHeight)
 					.map(b => ({ ...b, isFinal: true })),
-				setValues: { isFinal: true },
-				where: { height: `<= ${finalizedBlockHeight}` },
+				// setValues: { isFinal: true },
+				// where: { height: `<= ${finalizedBlockHeight}` },
 			});
 
 			if (blockInfo && !blockInfo.isFinal) {

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -73,6 +73,7 @@ const normalizeBlocks = async blocks => {
 			block.generatorAddress = account && account.address
 				? getHexAddressFromBase32(account.address) : undefined;
 			block.generatorUsername = account && account.username ? account.username : undefined;
+			block.isFinal = block.height <= getFinalizedHeight();
 			block.numberOfTransactions = block.payload.length;
 
 			block.size = 0;

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -22,7 +22,6 @@ const config = require('../../../../config');
 const {
 	indexAccountsbyPublicKey,
 	getIndexedAccountInfo,
-	getHexAddressFromBase32,
 } = require('./accounts');
 const { indexVotes } = require('./voters');
 const {

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -81,8 +81,7 @@ const normalizeBlocks = async blocks => {
 		blocks.map(block => ({ ...block.header, payload: block.payload })),
 		async block => {
 			const account = await getIndexedAccountInfo({ publicKey: block.generatorPublicKey.toString('hex') });
-			block.generatorAddress = account && account.address
-				? getHexAddressFromBase32(account.address) : undefined;
+			block.generatorAddress = account && account.address ? account.address : undefined;
 			block.generatorUsername = account && account.username ? account.username : undefined;
 			block.isFinal = block.height <= getFinalizedHeight();
 			block.numberOfTransactions = block.payload.length;

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -275,15 +275,15 @@ const buildIndex = async (from, to) => {
 	logger.info(`Finished building block index (${from}-${to})`);
 };
 
-const indexMissingBlocks = async currentHeight => {
+const indexMissingBlocks = async (fromHeight, toHeight) => {
 	const blocksDB = await getBlocksIndex();
 	const propBetweens = [{
 		property: 'height',
-		from: 1,
-		to: currentHeight,
+		from: fromHeight,
+		to: toHeight,
 	}];
 	const indexedBlockCount = await blocksDB.count({ propBetweens });
-	if (indexedBlockCount < currentHeight) {
+	if (indexedBlockCount < toHeight) {
 		const missingBlocksQueryStatement = `
 		SELECT
 			(SELECT COALESCE(MAX(height)+1, 1)
@@ -339,7 +339,7 @@ const init = async () => {
 			await buildIndex(blockIndexLowerRange, lowestIndexedHeight);
 		}
 
-		await indexMissingBlocks(currentHeight);
+		await indexMissingBlocks(genesisHeight, currentHeight);
 	} catch (err) {
 		logger.warn('Unable to update block index');
 		logger.warn(err.message);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -178,12 +178,7 @@ const indexNewBlocks = async blocks => {
 					limit: highestIndexedBlock.height - block.height,
 				});
 				const blockIDsToRemove = blocksToRemove.map(b => b.id);
-				await blocksDB.deleteIds({
-					whereIn: {
-						property: 'id',
-						values: blockIDsToRemove,
-					}
-				});
+				await blocksDB.deleteIds(blockIDsToRemove);
 
 				// Remove transactions in the forked blocks
 				await removeTransactionsByBlockIDs(blockIDsToRemove);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -149,7 +149,7 @@ const indexNewBlocks = async blocks => {
 	if (blocks.data.length === 1) {
 		const [block] = blocks.data;
 		const [blockInfo] = await blocksDB.find({ height: block.height });
-		if (!blockInfo || !blockInfo.isFinal) {
+		if (!blockInfo || (!blockInfo.isFinal && block.isFinal)) {
 			// Index if doesn't exist, or update if it isn't set to final
 			indexBlocksQueue.add('indexBlocksQueue', { blocks: blocks.data });
 

--- a/services/core/shared/core/compat/sdk_v5/schema/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/schema/blocks.js
@@ -21,11 +21,15 @@ module.exports = {
 		timestamp: { type: 'integer' },
 		generatorPublicKey: { type: 'string' },
 		size: { type: 'integer' },
+		isFinal: { type: 'boolean' },
 	},
 	indexes: {
+		id: { type: 'key' },
 		height: { type: 'range' },
 		timestamp: { type: 'range' },
 		generatorPublicKey: { type: 'key' },
+		size: { type: 'range' },
+		isFinal: { type: 'key' },
 	},
 	purge: {},
 };

--- a/services/core/shared/core/compat/sdk_v5/transactions.js
+++ b/services/core/shared/core/compat/sdk_v5/transactions.js
@@ -80,6 +80,17 @@ const indexTransactions = async blocks => {
 	if (publicKeysToIndex.length) await indexAccountsbyPublicKey(publicKeysToIndex);
 };
 
+const removeTransactionsByBlockIDs = async blockIDs => {
+	const transactionsDB = await getTransactionsIndex();
+	const forkedTransactions = await transactionsDB.find({ blockId: blockIDs });
+	await transactionsDB.deleteIds({
+		whereIn: {
+			property: 'blockId',
+			values: forkedTransactions.map(t => t.id),
+		}
+	});
+};
+
 const normalizeTransaction = tx => {
 	const [{ id, name }] = availableLiskModuleAssets
 		.filter(module => module.id === String(tx.moduleID).concat(':').concat(tx.assetID));
@@ -238,5 +249,6 @@ const getTransactionsByBlockId = async blockId => {
 module.exports = {
 	getTransactions,
 	indexTransactions,
+	removeTransactionsByBlockIDs,
 	getTransactionsByBlockId,
 };

--- a/services/core/shared/core/compat/sdk_v5/transactions.js
+++ b/services/core/shared/core/compat/sdk_v5/transactions.js
@@ -23,6 +23,7 @@ const {
 	getBase32AddressFromHex,
 	getAccountsBySearch,
 } = require('./accounts');
+const { removeVotesByTransactionIDs } = require('./voters');
 const { getRegisteredModuleAssets } = require('../common');
 const { parseToJSONCompatObj } = require('../../../jsonTools');
 
@@ -82,13 +83,15 @@ const indexTransactions = async blocks => {
 
 const removeTransactionsByBlockIDs = async blockIDs => {
 	const transactionsDB = await getTransactionsIndex();
-	const forkedTransactions = await transactionsDB.find({ blockId: blockIDs });
-	await transactionsDB.deleteIds({
+	const forkedTransactions = await transactionsDB.find({
 		whereIn: {
 			property: 'blockId',
-			values: forkedTransactions.map(t => t.id),
+			values: blockIDs,
 		}
 	});
+	const forkedTransactionIDs = forkedTransactions.map(t => t.id);
+	await transactionsDB.deleteIds(forkedTransactionIDs);
+	await removeVotesByTransactionIDs(forkedTransactionIDs);
 };
 
 const normalizeTransaction = tx => {

--- a/services/core/shared/core/compat/sdk_v5/transactions.js
+++ b/services/core/shared/core/compat/sdk_v5/transactions.js
@@ -87,7 +87,7 @@ const removeTransactionsByBlockIDs = async blockIDs => {
 		whereIn: {
 			property: 'blockId',
 			values: blockIDs,
-		}
+		},
 	});
 	const forkedTransactionIDs = forkedTransactions.map(t => t.id);
 	await transactionsDB.deleteIds(forkedTransactionIDs);

--- a/services/core/shared/core/compat/sdk_v5/voters.js
+++ b/services/core/shared/core/compat/sdk_v5/voters.js
@@ -62,6 +62,17 @@ const indexVotes = async blocks => {
 	if (allVotes.length) await votesDB.upsert(allVotes);
 };
 
+const removeVotesByTransactionIDs = async transactionIDs => {
+	const votesDB = await getVotesIndex();
+	const forkedVotes = await votesDB.find({
+		whereIn: {
+			property: 'id',
+			values: transactionIDs,
+		},
+	});
+	await votesDB.deleteIds(forkedVotes.map(v => v.tempId));
+};
+
 const normalizeVote = vote => parseToJSONCompatObj(vote);
 
 const getVoters = async params => {
@@ -129,4 +140,5 @@ const getVoters = async params => {
 module.exports = {
 	getVoters,
 	indexVotes,
+	removeVotesByTransactionIDs,
 };

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -253,9 +253,8 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 		return totalCount.count;
 	};
 
-	const rawQuery = async (queryStatement) => {
-		const result = await knex.raw(queryStatement);
-		const [resultSet] = result;
+	const rawQuery = async queryStatement => {
+		const [resultSet] = await knex.raw(queryStatement);
 		return resultSet;
 	};
 

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -253,11 +253,18 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 		return totalCount.count;
 	};
 
+	const rawQuery = async (rawQuery) => {
+		const result = await knex.raw(rawQuery);
+		const [resultSet,] = result;
+		return resultSet;
+	};
+
 	return {
 		upsert,
 		find,
 		deleteIds,
 		count,
+		rawQuery,
 	};
 };
 

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -201,7 +201,7 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 			.offset(offset);
 	};
 
-	const find = (params, columns) => new Promise((resolve, reject) => {
+	const find = (params = {}, columns) => new Promise((resolve, reject) => {
 		queryBuilder(params, columns).then(response => {
 			resolve(response);
 		}).catch(err => {
@@ -214,7 +214,7 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 		.whereIn(primaryKey, ids)
 		.del();
 
-	const count = async (params) => {
+	const count = async (params = {}) => {
 		const query = knex.count('id as count').table(tableName);
 		const queryParams = resolveQueryParams(params);
 

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -253,9 +253,9 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 		return totalCount.count;
 	};
 
-	const rawQuery = async (rawQuery) => {
-		const result = await knex.raw(rawQuery);
-		const [resultSet,] = result;
+	const rawQuery = async (queryStatement) => {
+		const result = await knex.raw(queryStatement);
+		const [resultSet] = result;
 		return resultSet;
 	};
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #360 

### How was it solved?
- [x] Extend `mysql.js` to support raw SQL queries
- [x] Add utility to determine missing blocks between a certain height range
- [x] Fix `buildIndex` method to allow indexing when `from` and `to` heights are equal (index single block)
- [x] Index the block finality status alongside the existing information
- [x] (Re-)index an incoming block only when it is not indexed or already existent but not finalised
- [x] Update indexed blocks' finality status upon new block arrival
- [x] Index handling upon fork detection for the below entities:
  - [x] `blocks`
  - [x] `transactions`
  - [x] `votes`
- [x] Add index ready flag
- [x] Add support for index ready status

### How was it tested?
Local
