### PR TITLE
Fix vote weight calculation - Closes #381

### DIFF
--- a/services/core/events/blockchain.js
+++ b/services/core/events/blockchain.js
@@ -60,6 +60,7 @@ module.exports = [
 		description: 'Track round change updates',
 		controller: callback => {
 			signals.get('newBlock').add(async () => {
+				await core.reloadDelegateCache();
 				await core.reloadNextForgersCache();
 				const forgers = await core.getNextForgers({ limit: 25 });
 				callback(forgers);

--- a/services/core/events/blockchain.js
+++ b/services/core/events/blockchain.js
@@ -60,7 +60,6 @@ module.exports = [
 		description: 'Track round change updates',
 		controller: callback => {
 			signals.get('newBlock').add(async () => {
-				await core.reloadDelegateCache();
 				await core.reloadNextForgersCache();
 				const forgers = await core.getNextForgers({ limit: 25 });
 				callback(forgers);

--- a/services/core/methods/controllers/accounts.js
+++ b/services/core/methods/controllers/accounts.js
@@ -30,10 +30,11 @@ const getDataForAccounts = async params => {
 		? await CoreService.getDelegates({ sort: 'rank:asc', ...params })
 		: await CoreService.getAccounts({ limit: 10, offset: 0, sort: 'balance:desc', ...params });
 
-	const response = {};
-	response.data = [];
-	response.meta = {};
-	response.links = {};
+	const response = {
+		data: [],
+		meta: {},
+		links: {},
+	};
 
 	const accountDataCopy = parseToJSONCompatObj(accounts.data);
 
@@ -56,6 +57,7 @@ const getDataForAccounts = async params => {
 
 		response.data = accountDataCopy;
 		response.meta.count = accountDataCopy.length;
+		response.meta.total = accounts.meta.total;
 		response.meta.offset = parseInt(params.offset || 0, 10);
 	}
 

--- a/services/core/shared/core/compat/sdk_v4/delegates.js
+++ b/services/core/shared/core/compat/sdk_v4/delegates.js
@@ -49,7 +49,7 @@ const getDelegates = async params => {
 		delegate.vote = delegate.delegateWeight;
 		delegate.isBanned = delegate.delegate.isBanned;
 		delegate.pomHeights = delegate.delegate.pomHeights
-			.sort((a, b) => a - b).reverse().slice(0, 5)
+			.sort((a, b) => b - a).slice(0, 5)
 			.map(height => ({ start: height, end: height + punishmentHeight }));
 		delegate.lastForgedHeight = delegate.delegate.lastForgedHeight;
 		delegate.consecutiveMissedBlocks = delegate.delegate.consecutiveMissedBlocks;

--- a/services/core/shared/core/compat/sdk_v4/delegates.js
+++ b/services/core/shared/core/compat/sdk_v4/delegates.js
@@ -38,10 +38,10 @@ const getDelegates = async params => {
 		};
 
 		const adder = (acc, curr) => BigInt(acc) + BigInt(curr.amount);
-		const totalVotes = delegate.votes.reduce(adder, 0n);
+		const totalVotes = delegate.votes.reduce(adder, BigInt(0));
 		const selfVote = delegate.votes.find(vote => vote.delegateAddress === delegate.address);
-		const selfVoteAmount = selfVote ? BigInt(selfVote.amount) : 0n;
-		const cap = selfVoteAmount * 10n;
+		const selfVoteAmount = selfVote ? BigInt(selfVote.amount) : BigInt(0);
+		const cap = selfVoteAmount * BigInt(10);
 
 		delegate.totalVotesReceived = totalVotes - selfVoteAmount;
 		const voteWeight = BigInt(totalVotes) > cap ? cap : delegate.totalVotesReceived;

--- a/services/core/shared/core/compat/sdk_v4/delegates.js
+++ b/services/core/shared/core/compat/sdk_v4/delegates.js
@@ -31,7 +31,7 @@ const getDelegates = async params => {
 	if (response.data) delegates.data = response.data;
 	if (response.meta) delegates.meta = response.meta;
 
-	delegates.data.map((delegate, index) => {
+	delegates.data.map((delegate) => {
 		delegate.account = {
 			address: delegate.address,
 			publicKey: delegate.publicKey,
@@ -53,10 +53,6 @@ const getDelegates = async params => {
 			.map(height => ({ start: height, end: height + punishmentHeight }));
 		delegate.lastForgedHeight = delegate.delegate.lastForgedHeight;
 		delegate.consecutiveMissedBlocks = delegate.delegate.consecutiveMissedBlocks;
-
-		// Required for proper indexing in PouchDB
-		// Rank appropriately recalculated in the abstraction layer based on delegateWeight/address
-		delegate.rank = params.offset + index + 1;
 
 		return delegate;
 	});

--- a/services/core/shared/core/compat/sdk_v4/delegates.js
+++ b/services/core/shared/core/compat/sdk_v4/delegates.js
@@ -43,7 +43,7 @@ const getDelegates = async params => {
 		const selfVoteAmount = selfVote ? BigInt(selfVote.amount) : BigInt(0);
 		const cap = selfVoteAmount * BigInt(10);
 
-		delegate.totalVotesReceived = totalVotes - selfVoteAmount;
+		delegate.totalVotesReceived = BigInt(delegate.totalVotesReceived);
 		const voteWeight = BigInt(totalVotes) > cap ? cap : delegate.totalVotesReceived;
 		delegate.delegateWeight = voteWeight;
 		delegate.vote = delegate.delegateWeight;

--- a/services/core/shared/core/compat/sdk_v5/delegates.js
+++ b/services/core/shared/core/compat/sdk_v5/delegates.js
@@ -49,10 +49,11 @@ const getDelegates = async (params) => {
                 });
             }
             const adder = (acc, curr) => BigInt(acc) + BigInt(curr.amount);
-            const totalVotes = delegate.dpos.sentVotes.reduce(adder, 0n);
-            const selfVote = delegate.dpos.sentVotes.find(vote => vote.delegateAddress === delegate.address);
-            const selfVoteAmount = selfVote ? BigInt(selfVote.amount) : 0n;
-            const cap = selfVoteAmount * 10n;
+            const totalVotes = delegate.dpos.sentVotes.reduce(adder, BigInt(0));
+            const selfVote = delegate.dpos.sentVotes
+                .find(vote => vote.delegateAddress === delegate.address);
+            const selfVoteAmount = selfVote ? BigInt(selfVote.amount) : BigInt(0);
+            const cap = selfVoteAmount * BigInt(10);
 
             delegate.totalVotesReceived = totalVotes - selfVoteAmount;
             const voteWeight = BigInt(totalVotes) > cap ? cap : delegate.totalVotesReceived;

--- a/services/core/shared/core/compat/sdk_v5/delegates.js
+++ b/services/core/shared/core/compat/sdk_v5/delegates.js
@@ -55,7 +55,7 @@ const getDelegates = async (params) => {
             const selfVoteAmount = selfVote ? BigInt(selfVote.amount) : BigInt(0);
             const cap = selfVoteAmount * BigInt(10);
 
-            delegate.totalVotesReceived = totalVotes - selfVoteAmount;
+            delegate.totalVotesReceived = BigInt(delegate.dpos.delegate.totalVotesReceived);
             const voteWeight = BigInt(totalVotes) > cap ? cap : delegate.totalVotesReceived;
 
             delegate.delegateWeight = voteWeight;

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -243,8 +243,6 @@ const resolveNextForgers = async () => {
 const reloadNextForgersCache = async () => {
 	await loadAllNextForgers();
 	await resolveNextForgers();
-	await computeDelegateRank();
-	await computeDelegateStatus();
 };
 
 const reload = async () => {

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -243,6 +243,8 @@ const resolveNextForgers = async () => {
 const reloadNextForgersCache = async () => {
 	await loadAllNextForgers();
 	await resolveNextForgers();
+	await computeDelegateRank();
+	await computeDelegateStatus();
 };
 
 const reload = async () => {

--- a/services/core/shared/core/events.js
+++ b/services/core/shared/core/events.js
@@ -18,16 +18,16 @@ const core = require('./compat');
 const signals = require('../signals');
 const { reloadNextForgersCache, getNextForgers } = require('./delegates');
 const { calculateEstimateFeeByteNormal, calculateEstimateFeeByteQuick } = require('./dynamicFees');
-const { performLastBlockUpdate } = require('./blocks');
+const { performLastBlockUpdate, getLastBlock } = require('./blocks');
 
 const config = require('../../config.js');
 
 const logger = Logger();
 
 const events = {
-	newBlock: async data => {
-		signals.get('newBlock').dispatch(data);
-		performLastBlockUpdate();
+	newBlock: async () => {
+		await performLastBlockUpdate();
+		signals.get('newBlock').dispatch(getLastBlock());
 	},
 	newRound: async () => {
 		await reloadNextForgersCache();


### PR DESCRIPTION
### What was the problem?
This PR resolves #381 

### How was it solved?
- [x] Delegate `voteWeight` calculation logic now uses `BigInt` instead of `Number` for both:
  - [x] SDKv4
  - [x] SDKv5
- [x] Parse `BigInt` values to `String` type before serialization
- [x] Fix `totalVotesReceived` for delegates in both:
  - [x] SDKv4
  - [x] SDKv5
- [x] Added `total` in meta for accounts response
- [x] Update logic for `update.block` event
- [x] Reload the list of all delegates with every block arrival for Rank and Status re-computation,

### How was it tested?
Local
