### PR TITLE
Enable transaction broadcast - Closes #259

### DIFF
--- a/services/core/benchmark/benchmark.js
+++ b/services/core/benchmark/benchmark.js
@@ -113,10 +113,10 @@ const benchmark = async (args) => {
             fs.writeFile(`./${resultsDir}/result_${batchSize}.json`, JSON.stringify(results, null, 4), (err) => {
                 if (err) {
                     console.error(err);
-                    reject(err);
+                    return reject(err);
                 }
                 console.log(`Test results saved to: './${resultsDir}/result_${batchSize}.json'`);
-                resolve();
+                return resolve();
             });
         });
     }

--- a/services/core/benchmark/fileUtils.js
+++ b/services/core/benchmark/fileUtils.js
@@ -4,10 +4,10 @@ const writeJson = (path, obj) => new Promise((resolve, reject) => {
 	fs.writeFile(path, JSON.stringify(obj, null, 4), (err) => {
 		if (err) {
 			console.error(err);
-			reject(err);
+			return reject(err);
 		}
 		console.log(`File has been created: ${path}`);
-		resolve();
+		return resolve();
 	});
 });
 
@@ -15,9 +15,9 @@ const readJson = (path) => new Promise((resolve, reject) => {
 	fs.readFile(path, (err, data) => {
 		if (err) {
 			console.error(err);
-			reject(err);
+			return reject(err);
 		}
-		resolve(JSON.parse(data));
+		return resolve(JSON.parse(data));
 	});
 });
 

--- a/services/core/jobs/delegates.js
+++ b/services/core/jobs/delegates.js
@@ -14,9 +14,14 @@
  *
  */
 const logger = require('lisk-service-framework').Logger();
-
 const core = require('../shared/core');
-// const delegateCache = require('../shared/core/delegateCache');
+
+const setTimeoutPromise = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const sleepAndExec = async (fn, delay = 1000) => {
+	await setTimeoutPromise(delay);
+	return fn();
+};
 
 module.exports = [
 	{
@@ -26,7 +31,7 @@ module.exports = [
 		updateOnInit: true,
 		init: async () => {
 			logger.debug('Scheduling initial list update...');
-			await core.reloadDelegateCache();
+			await sleepAndExec(core.reloadDelegateCache);
 			await core.reloadNextForgersCache();
 		},
 		controller: () => {

--- a/services/core/methods/controllers/transactions.js
+++ b/services/core/methods/controllers/transactions.js
@@ -150,9 +150,10 @@ const getPendingTransactions = async params => {
 	};
 };
 
-const postTransactions = async () => {
+const postTransactions = async (params) => {
 	// TODO: Place holder to post the transaction creation request
-	return;
+	const { transaction } = params;
+	return transaction;
 };
 
 module.exports = {

--- a/services/core/methods/controllers/transactions.js
+++ b/services/core/methods/controllers/transactions.js
@@ -150,11 +150,7 @@ const getPendingTransactions = async params => {
 	};
 };
 
-const postTransactions = async (params) => {
-	// TODO: Place holder to post the transaction creation request
-	const { transaction } = params;
-	return transaction;
-};
+const postTransactions = async (params) => CoreService.postTransactions(params);
 
 module.exports = {
 	getTransactions,

--- a/services/core/methods/controllers/transactions.js
+++ b/services/core/methods/controllers/transactions.js
@@ -150,10 +150,16 @@ const getPendingTransactions = async params => {
 	};
 };
 
+const postTransactions = async () => {
+	// TODO: Place holder to post the transaction creation request
+	return;
+};
+
 module.exports = {
 	getTransactions,
 	getLastTransactions,
 	getTransactionsStatisticsDay,
 	getTransactionsStatisticsMonth,
 	getPendingTransactions,
+	postTransactions,
 };

--- a/services/core/methods/transactions.js
+++ b/services/core/methods/transactions.js
@@ -20,6 +20,7 @@ const {
 	getTransactionsStatisticsDay,
 	getTransactionsStatisticsMonth,
 	getPendingTransactions,
+	postTransactions,
 } = require('./controllers/transactions');
 
 module.exports = [
@@ -70,6 +71,11 @@ module.exports = [
 	{
 		name: 'transactions.pending',
 		controller: getPendingTransactions,
+		params: {},
+	},
+	{
+		name: 'transactions.post',
+		controller: postTransactions,
 		params: {},
 	},
 ];

--- a/services/core/methods/transactions.js
+++ b/services/core/methods/transactions.js
@@ -76,6 +76,8 @@ module.exports = [
 	{
 		name: 'transactions.post',
 		controller: postTransactions,
-		params: {},
+		params: {
+			transaction: { type: 'string', optional: false },
+		},
 	},
 ];

--- a/services/core/shared/core/compat/common/wsRequest.js
+++ b/services/core/shared/core/compat/common/wsRequest.js
@@ -26,6 +26,8 @@ const getApiClient = async () => {
         }
         return clientCache;
     } catch (err) {
+        if (err.code === 'ECONNREFUSED') throw new Error('ECONNREFUSED: Unable to reach a network node');
+
         return {
             data: { error: 'Action not supported' },
             status: 'METHOD_NOT_ALLOWED',

--- a/services/core/shared/core/compat/sdk_v2/index.js
+++ b/services/core/shared/core/compat/sdk_v2/index.js
@@ -107,6 +107,7 @@ module.exports = {
 	updateFinalizedHeight,
 	getPendingTransactions: nop,
 	loadAllPendingTransactions: nop,
+	postTransactions: nop,
 	events,
 	init,
 };

--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -116,7 +116,7 @@ const getPendingTransactions = async () => {
 
 const postTransaction = async transaction => {
     const apiClient = await getApiClient();
-    const response = await apiClient.transaction.send(apiClient.transaction.decode(Buffer.from(transaction, 'hex')));
+    const response = await apiClient._channel.invoke('app:postTransaction', { transaction });
     return response;
 };
 

--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -114,6 +114,12 @@ const getPendingTransactions = async () => {
     return { data: transactions };
 };
 
+const postTransaction = async transaction => {
+    const apiClient = await getApiClient();
+    const response = await apiClient.transaction.send(apiClient.transaction.decode(Buffer.from(transaction, 'hex')));
+    return response;
+};
+
 module.exports = {
     getBlockByID,
     getBlocksByIDs,
@@ -127,4 +133,5 @@ module.exports = {
     getPeers,
     getForgers,
     getPendingTransactions,
+    postTransaction,
 };

--- a/services/core/shared/core/compat/sdk_v5/index.js
+++ b/services/core/shared/core/compat/sdk_v5/index.js
@@ -38,6 +38,10 @@ const {
 } = require('./transactions');
 
 const {
+    postTransactions,
+} = require('./postTransactions');
+
+const {
     getForgers,
 } = require('./forgers');
 const {
@@ -94,6 +98,8 @@ module.exports = {
 
     getTransactions,
     getTransactionsByBlockId,
+
+    postTransactions,
 
     getPendingTransactions,
     loadAllPendingTransactions,

--- a/services/core/shared/core/compat/sdk_v5/postTransactions.js
+++ b/services/core/shared/core/compat/sdk_v5/postTransactions.js
@@ -1,0 +1,27 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const coreApi = require('./coreApi');
+
+const postTransactions = async (params) => {
+	const signedTxBinary = params.transaction;
+	const response = await coreApi.postTransaction(signedTxBinary);
+
+	return response;
+};
+
+module.exports = {
+	postTransactions,
+};

--- a/services/core/shared/core/compat/sdk_v5/postTransactions.js
+++ b/services/core/shared/core/compat/sdk_v5/postTransactions.js
@@ -15,7 +15,7 @@
  */
 const coreApi = require('./coreApi');
 
-const postTransactions = async (params) => {
+const postTransactions = async params => {
 	const signedTxBinary = params.transaction;
 	const response = await coreApi.postTransaction(signedTxBinary);
 	return response;

--- a/services/core/shared/core/compat/sdk_v5/postTransactions.js
+++ b/services/core/shared/core/compat/sdk_v5/postTransactions.js
@@ -18,7 +18,6 @@ const coreApi = require('./coreApi');
 const postTransactions = async (params) => {
 	const signedTxBinary = params.transaction;
 	const response = await coreApi.postTransaction(signedTxBinary);
-
 	return response;
 };
 

--- a/services/core/shared/core/index.js
+++ b/services/core/shared/core/index.js
@@ -27,6 +27,7 @@ const {
 	reloadAllPendingTransactions,
 	getTransactionById,
 	getTransactionsByBlockId,
+	postTransactions,
 } = require('./transactions');
 
 const {
@@ -133,6 +134,7 @@ module.exports = {
 	getTransactions,
 	getTransactionById,
 	getTransactionsByBlockId,
+	postTransactions,
 	getMultisignatureGroups,
 	getMultisignatureMemberships,
 	getIncomingTxsCount,

--- a/services/core/shared/core/transactions.js
+++ b/services/core/shared/core/transactions.js
@@ -62,13 +62,14 @@ const getTransactions = async params => {
 	return transactions;
 };
 
+const postTransactions = async (params) => {
+	const response = await coreApi.postTransactions(params);
+	return response;
+};
+
 const initPendingTransactionsList = (() => coreApi.loadAllPendingTransactions())();
 
 const reload = () => coreApi.loadAllPendingTransactions();
-
-const postTransactions = async (params) => {
-	console.log(params);
-};
 
 module.exports = {
 	getTransactions,

--- a/services/core/shared/core/transactions.js
+++ b/services/core/shared/core/transactions.js
@@ -65,7 +65,7 @@ const getTransactions = async params => {
 const postTransactions = async (params) => {
 	try {
 		const response = await coreApi.postTransactions(params);
-		if (response.transactionId) return {
+		return {
 			message: 'Transaction payload was successfully passed to the network node',
 			transactionId: response.transactionId,
 		};

--- a/services/core/shared/core/transactions.js
+++ b/services/core/shared/core/transactions.js
@@ -63,8 +63,22 @@ const getTransactions = async params => {
 };
 
 const postTransactions = async (params) => {
-	const response = await coreApi.postTransactions(params);
-	return response;
+	try {
+		const response = await coreApi.postTransactions(params);
+		if (response.transactionId)
+			return { message: 'Transaction payload was successfully passed to the network node' };
+	} catch (err) {
+		return {
+			data: { error: 'Transaction payload was rejected by the network node' },
+			status: 'BAD_REQUEST',
+		};
+	}
+
+	// TODO: Figure out the logic to send the response
+	return {
+		data: { error: 'Unable to reach a network node' },
+		status: 'INTERNAL_SERVER_ERROR',
+	};
 };
 
 const initPendingTransactionsList = (() => coreApi.loadAllPendingTransactions())();

--- a/services/core/shared/core/transactions.js
+++ b/services/core/shared/core/transactions.js
@@ -70,6 +70,11 @@ const postTransactions = async (params) => {
 			transactionId: response.transactionId,
 		};
 	} catch (err) {
+		if (err.message.includes('ECONNREFUSED')) return {
+			data: { error: 'Unable to reach a network node' },
+			status: 'INTERNAL_SERVER_ERROR',
+		};
+
 		return {
 			data: { error: `Transaction payload was rejected by the network node: ${err.message}` },
 			status: 'BAD_REQUEST',

--- a/services/core/shared/core/transactions.js
+++ b/services/core/shared/core/transactions.js
@@ -65,19 +65,16 @@ const getTransactions = async params => {
 const postTransactions = async (params) => {
 	try {
 		const response = await coreApi.postTransactions(params);
-		if (response.transactionId) return { message: 'Transaction payload was successfully passed to the network node' };
+		if (response.transactionId) return {
+			message: 'Transaction payload was successfully passed to the network node',
+			transactionId: response.transactionId,
+		};
 	} catch (err) {
 		return {
-			data: { error: 'Transaction payload was rejected by the network node' },
+			data: { error: `Transaction payload was rejected by the network node: ${err.message}` },
 			status: 'BAD_REQUEST',
 		};
 	}
-
-	// TODO: Figure out the logic to send the response
-	return {
-		data: { error: 'Unable to reach a network node' },
-		status: 'INTERNAL_SERVER_ERROR',
-	};
 };
 
 const initPendingTransactionsList = (() => coreApi.loadAllPendingTransactions())();

--- a/services/core/shared/core/transactions.js
+++ b/services/core/shared/core/transactions.js
@@ -65,8 +65,7 @@ const getTransactions = async params => {
 const postTransactions = async (params) => {
 	try {
 		const response = await coreApi.postTransactions(params);
-		if (response.transactionId)
-			return { message: 'Transaction payload was successfully passed to the network node' };
+		if (response.transactionId) return { message: 'Transaction payload was successfully passed to the network node' };
 	} catch (err) {
 		return {
 			data: { error: 'Transaction payload was rejected by the network node' },

--- a/services/core/shared/core/transactions.js
+++ b/services/core/shared/core/transactions.js
@@ -62,7 +62,7 @@ const getTransactions = async params => {
 	return transactions;
 };
 
-const postTransactions = async (params) => {
+const postTransactions = async params => {
 	try {
 		const response = await coreApi.postTransactions(params);
 		return {

--- a/services/core/shared/core/transactions.js
+++ b/services/core/shared/core/transactions.js
@@ -66,6 +66,10 @@ const initPendingTransactionsList = (() => coreApi.loadAllPendingTransactions())
 
 const reload = () => coreApi.loadAllPendingTransactions();
 
+const postTransactions = async (params) => {
+	console.log(params);
+};
+
 module.exports = {
 	getTransactions,
 	getPendingTransactions,
@@ -73,4 +77,5 @@ module.exports = {
 	reloadAllPendingTransactions: reload,
 	getTransactionById: coreApi.getTransactionById,
 	getTransactionsByBlockId: coreApi.getTransactionsByBlockId,
+	postTransactions,
 };

--- a/services/gateway/apis/http-version2/methods/postTransactions.js
+++ b/services/gateway/apis/http-version2/methods/postTransactions.js
@@ -25,10 +25,6 @@ module.exports = {
 	params: {
 		transaction: { optional: false, type: 'string', min: 1 },
 	},
-	paramsRequired: true,
-	validParamPairings: [
-		['transaction'],
-	],
 	source: transactionsSource,
 	envelope,
 };

--- a/services/gateway/apis/http-version2/methods/postTransactions.js
+++ b/services/gateway/apis/http-version2/methods/postTransactions.js
@@ -22,7 +22,7 @@ module.exports = {
 	rpcMethod: 'post.transactions',
 	tags: ['Transactions'],
 	params: {
-		transaction: { optional: false, type: 'string', min: 1 },
+		transaction: { optional: false, type: 'string', min: 1, pattern: /^\b[0-9a-fA-F]+\b$/ },
 	},
 	source: transactionsSource,
 };

--- a/services/gateway/apis/http-version2/methods/postTransactions.js
+++ b/services/gateway/apis/http-version2/methods/postTransactions.js
@@ -1,0 +1,28 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const transactionsSource = require('../../../sources/version2/postTransactions');
+const envelope = require('../../../sources/version2/mappings/stdEnvelope');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/transactions',
+	httpMethod: 'POST',
+	rpcMethod: 'post.transactions',
+	tags: ['Transactions'],
+	params: {},
+	source: transactionsSource,
+	envelope,
+};

--- a/services/gateway/apis/http-version2/methods/postTransactions.js
+++ b/services/gateway/apis/http-version2/methods/postTransactions.js
@@ -22,7 +22,13 @@ module.exports = {
 	httpMethod: 'POST',
 	rpcMethod: 'post.transactions',
 	tags: ['Transactions'],
-	params: {},
+	params: {
+		transaction: { optional: false, type: 'string', min: 1 },
+	},
+	paramsRequired: true,
+	validParamPairings: [
+		['transaction'],
+	],
 	source: transactionsSource,
 	envelope,
 };

--- a/services/gateway/apis/http-version2/methods/postTransactions.js
+++ b/services/gateway/apis/http-version2/methods/postTransactions.js
@@ -14,7 +14,6 @@
  *
  */
 const transactionsSource = require('../../../sources/version2/postTransactions');
-const envelope = require('../../../sources/version2/mappings/stdEnvelope');
 
 module.exports = {
 	version: '2.0',
@@ -26,5 +25,4 @@ module.exports = {
 		transaction: { optional: false, type: 'string', min: 1 },
 	},
 	source: transactionsSource,
-	envelope,
 };

--- a/services/gateway/app.js
+++ b/services/gateway/app.js
@@ -93,7 +93,7 @@ broker.createService({
 			// Configure the Access-Control-Allow-Origin CORS header
 			origin: '*',
 			// Configures the Access-Control-Allow-Methods CORS header.
-			methods: ["GET", "POST"],
+			methods: ['GET', 'POST'],
 		},
 
 		// Used server instance. If null, it will create a new HTTP(s)(2) server

--- a/services/gateway/app.js
+++ b/services/gateway/app.js
@@ -92,6 +92,8 @@ broker.createService({
 		cors: {
 			// Configure the Access-Control-Allow-Origin CORS header
 			origin: '*',
+			// Configures the Access-Control-Allow-Methods CORS header.
+			methods: ["GET", "POST"],
 		},
 
 		// Used server instance. If null, it will create a new HTTP(s)(2) server

--- a/services/gateway/sources/version2/postTransactions.js
+++ b/services/gateway/sources/version2/postTransactions.js
@@ -19,5 +19,7 @@ module.exports = {
 	params: {
 		transaction: '=,string',
 	},
-	definition: {},
+	definition: {
+		message: '=',
+	},
 };

--- a/services/gateway/sources/version2/postTransactions.js
+++ b/services/gateway/sources/version2/postTransactions.js
@@ -18,7 +18,9 @@ const transaction = require('./mappings/transaction');
 module.exports = {
 	type: 'moleculer',
 	method: 'core.transactions.post',
-	params: {},
+	params: {
+		transaction: '=',
+	},
 	definition: {
 		data: ['data', transaction],
 		meta: {

--- a/services/gateway/sources/version2/postTransactions.js
+++ b/services/gateway/sources/version2/postTransactions.js
@@ -17,7 +17,7 @@ const transaction = require('./mappings/transaction');
 
 module.exports = {
 	type: 'moleculer',
-	method: 'core.transactions.send',
+	method: 'core.transactions.post',
 	params: {},
 	definition: {
 		data: ['data', transaction],

--- a/services/gateway/sources/version2/postTransactions.js
+++ b/services/gateway/sources/version2/postTransactions.js
@@ -21,5 +21,6 @@ module.exports = {
 	},
 	definition: {
 		message: '=',
+		transactionId: '=',
 	},
 };

--- a/services/gateway/sources/version2/postTransactions.js
+++ b/services/gateway/sources/version2/postTransactions.js
@@ -1,0 +1,31 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const transaction = require('./mappings/transaction');
+
+module.exports = {
+	type: 'moleculer',
+	method: 'core.transactions.send',
+	params: {},
+	definition: {
+		data: ['data', transaction],
+		meta: {
+			count: '=,number',
+			offset: '=,number',
+			total: '=,number',
+		},
+		links: {},
+	},
+};

--- a/services/gateway/sources/version2/postTransactions.js
+++ b/services/gateway/sources/version2/postTransactions.js
@@ -17,7 +17,7 @@ module.exports = {
 	type: 'moleculer',
 	method: 'core.transactions.post',
 	params: {
-		transaction: '=',
+		transaction: '=,string',
 	},
 	definition: {},
 };

--- a/services/gateway/sources/version2/postTransactions.js
+++ b/services/gateway/sources/version2/postTransactions.js
@@ -13,21 +13,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const transaction = require('./mappings/transaction');
-
 module.exports = {
 	type: 'moleculer',
 	method: 'core.transactions.post',
 	params: {
 		transaction: '=',
 	},
-	definition: {
-		data: ['data', transaction],
-		meta: {
-			count: '=,number',
-			offset: '=,number',
-			total: '=,number',
-		},
-		links: {},
-	},
+	definition: {},
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #259 

### How was it solved?
- [x] Configure the Access-Control-Allow-Methods CORS header to only permit `GET` and `POST` requests
- [x] Add gateway support the following endpoints:
  - [x] HTTP: `POST /transactions`
  - [x] RPC: `post.transactions`
- [x] Validate the transaction binary payload to be in `hex` format
- [x] Add support in core to submit the signed transaction binary to the Lisk Core, sent within the request body
- [x] Delay delegate cache initialization at init to avoid indexing errors

### How was it tested?
Local
