### PR TITLE
Make votes endpoint follow the specification - Closes #407 #408

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/voters.js
+++ b/services/core/shared/core/compat/sdk_v5/voters.js
@@ -139,8 +139,8 @@ const getVoters = async params => {
 		username: accountInfo && accountInfo.username ? accountInfo.username : undefined,
 		votesUsed: votes.data.votes.length,
 	};
-
-	votes.meta.total = resultSet.length;
+	votes.data.votes = votes.data.votes.slice(params.offset, params.offset + params.limit);
+	votes.meta.total = votes.data.account.votesUsed;
 	votes.meta.count = votes.data.votes.length;
 	votes.meta.offset = params.offset;
 	return votes;

--- a/services/core/shared/core/compat/sdk_v5/voters.js
+++ b/services/core/shared/core/compat/sdk_v5/voters.js
@@ -100,7 +100,7 @@ const getVoters = async params => {
 		const { publicKey, ...remParams } = params;
 		params = remParams;
 
-		params.receivedAddress = extractAddressFromPublicKey(publicKey);
+		params.receivedAddress = getBase32AddressFromHex(extractAddressFromPublicKey(publicKey));
 	}
 
 	const resultSet = await votesDB.find({ sort: 'timestamp:desc', receivedAddress: params.receivedAddress });

--- a/services/core/shared/core/compat/sdk_v5/votes.js
+++ b/services/core/shared/core/compat/sdk_v5/votes.js
@@ -74,8 +74,6 @@ const getVotes = async params => {
 	};
 
 	voter.meta.total = voter.data.votes.length;
-	voter.meta.count = voter.data.votes.length;
-	voter.meta.offset = params.offset;
 	return voter;
 };
 

--- a/services/core/shared/core/compat/sdk_v5/votes.js
+++ b/services/core/shared/core/compat/sdk_v5/votes.js
@@ -16,10 +16,12 @@
 const BluebirdPromise = require('bluebird');
 const { getAddressFromPublicKey } = require('@liskhq/lisk-cryptography');
 
-const { getAccounts, getIndexedAccountInfo } = require('./accounts');
+const { getAccounts, getIndexedAccountInfo, getBase32AddressFromHex } = require('./accounts');
 const { parseToJSONCompatObj } = require('../../../jsonTools');
 
 const normalizeVote = vote => parseToJSONCompatObj(vote);
+
+const extractAddressFromPublicKey = pk => (getAddressFromPublicKey(Buffer.from(pk, 'hex'))).toString('hex');
 
 const getVotes = async params => {
 	const voter = {
@@ -45,7 +47,7 @@ const getVotes = async params => {
 		const { publicKey, ...remParams } = params;
 		params = remParams;
 
-		params.sentAddress = (getAddressFromPublicKey(Buffer.from(publicKey, 'hex'))).toString('hex');
+		params.sentAddress = getBase32AddressFromHex(extractAddressFromPublicKey(publicKey));
 	}
 
 	const response = await getAccounts({ id: params.sentAddress });

--- a/services/gateway/apis/http-version2/methods/votesReceived.js
+++ b/services/gateway/apis/http-version2/methods/votesReceived.js
@@ -26,7 +26,7 @@ module.exports = {
 	params: {
 		address: { optional: true, type: 'string', min: 3, max: 41 },
 		username: { optional: true, type: 'string', min: 3, max: 20 },
-		publickey: { optional: true, type: 'string', min: 64, max: 64 },
+		publicKey: { optional: true, type: 'string', min: 64, max: 64 },
 		limit: { optional: true, min: 1, max: 100, type: 'number', default: 10 },
 		offset: { optional: true, min: 0, type: 'number', default: 0 },
 	},
@@ -34,7 +34,7 @@ module.exports = {
 	validParamPairings: [
 		['address'],
 		['username'],
-		['publickey'],
+		['publicKey'],
 	],
 	get schema() {
 		const votersSchema = {};

--- a/services/gateway/apis/http-version2/methods/votesSent.js
+++ b/services/gateway/apis/http-version2/methods/votesSent.js
@@ -26,7 +26,7 @@ module.exports = {
 	params: {
 		address: { optional: true, type: 'string', min: 3, max: 41 },
 		username: { optional: true, type: 'string', min: 3, max: 20 },
-		publickey: { optional: true, type: 'string', min: 64, max: 64 },
+		publicKey: { optional: true, type: 'string', min: 64, max: 64 },
 		limit: { optional: true, min: 1, max: 100, type: 'number', default: 10 },
 		offset: { optional: true, min: 0, type: 'number', default: 0 },
 	},
@@ -34,7 +34,7 @@ module.exports = {
 	validParamPairings: [
 		['address'],
 		['username'],
-		['publickey'],
+		['publicKey'],
 	],
 	get schema() {
 		const votesSchema = {};

--- a/services/gateway/apis/http-version2/methods/votesSent.js
+++ b/services/gateway/apis/http-version2/methods/votesSent.js
@@ -27,8 +27,6 @@ module.exports = {
 		address: { optional: true, type: 'string', min: 3, max: 41 },
 		username: { optional: true, type: 'string', min: 3, max: 20 },
 		publicKey: { optional: true, type: 'string', min: 64, max: 64 },
-		limit: { optional: true, min: 1, max: 100, type: 'number', default: 10 },
-		offset: { optional: true, min: 0, type: 'number', default: 0 },
 	},
 	paramsRequired: true,
 	validParamPairings: [

--- a/services/gateway/sources/version2/voters.js
+++ b/services/gateway/sources/version2/voters.js
@@ -21,7 +21,7 @@ module.exports = {
 	params: {
 		address: '=,string',
 		username: '=,string',
-		publicKey: 'publickey,string',
+		publicKey: '=,string',
 		limit: '=,number',
 		offset: '=,number',
 	},

--- a/services/gateway/sources/version2/votes.js
+++ b/services/gateway/sources/version2/votes.js
@@ -21,7 +21,7 @@ module.exports = {
 	params: {
 		address: '=,string',
 		username: '=,string',
-		publicKey: 'publickey,string',
+		publicKey: '=,string',
 		limit: '=,number',
 		offset: '=,number',
 	},

--- a/services/gateway/sources/version2/votes.js
+++ b/services/gateway/sources/version2/votes.js
@@ -22,8 +22,6 @@ module.exports = {
 		address: '=,string',
 		username: '=,string',
 		publicKey: '=,string',
-		limit: '=,number',
-		offset: '=,number',
 	},
 	definition: {
 		data: {

--- a/tests/integration/api_v2/http/votesReceived.test.js
+++ b/tests/integration/api_v2/http/votesReceived.test.js
@@ -57,7 +57,7 @@ const {
 
 			it('Returns list of voters when requested for existing account by publickey', async () => {
 				if (refDelegate.summary.publicKey) {
-					const response = await api.get(`${endpoint}?publickey=${refDelegate.summary.publicKey}`);
+					const response = await api.get(`${endpoint}?publicKey=${refDelegate.summary.publicKey}`);
 					expect(response.data).toMap(voterSchemaVersion5);
 					expect(response.meta).toMap(metaSchema);
 				}

--- a/tests/integration/api_v2/http/votesSent.test.js
+++ b/tests/integration/api_v2/http/votesSent.test.js
@@ -57,33 +57,10 @@ const {
 
 			it('Returns list of votes when requested for existing account by publickey', async () => {
 				if (refDelegate.summary.publicKey) {
-					const response = await api.get(`${endpoint}?publickey=${refDelegate.summary.publicKey}`);
+					const response = await api.get(`${endpoint}?publicKey=${refDelegate.summary.publicKey}`);
 					expect(response.data).toMap(voteSchemaVersion5);
 					expect(response.meta).toMap(metaSchema);
 				}
-			});
-
-			it('Returns list of votes when requested with offset', async () => {
-				const response = await api.get(`${endpoint}?address=${refDelegate.summary.address}&offset=1`);
-				expect(response.data).toMap(voteSchemaVersion5);
-				expect(response.meta).toMap(metaSchema);
-			});
-
-			it('Returns list of votes when requested with limit', async () => {
-				const response = await api.get(`${endpoint}?address=${refDelegate.summary.address}&limit=1`);
-				expect(response.data).toMap(voteSchemaVersion5);
-				expect(response.meta).toMap(metaSchema);
-			});
-
-			it('Returns list of votes when requested with offset & limit', async () => {
-				const response = await api.get(`${endpoint}?address=${refDelegate.summary.address}&offset=1&limit=1`);
-				expect(response.data).toMap(voteSchemaVersion5);
-				expect(response.meta).toMap(metaSchema);
-			});
-
-			it('Returns BAD_REQUEST (400) when requested with limit = 0', async () => {
-				const response = await api.get(`${endpoint}?limit=0`, 400);
-				expect(response).toMap(badRequestSchema);
 			});
 
 			it('Returns NOT_FOUND (404) when requested with wrong address', async () => {

--- a/tests/integration/api_v2/rpc/votesReceived.test.js
+++ b/tests/integration/api_v2/rpc/votesReceived.test.js
@@ -63,7 +63,7 @@ const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v2`;
 
 		it('Returns list of voters when requested for existing account by publickey', async () => {
 			if (refDelegate.summary.publicKey) {
-				const response = await getVoters({ publickey: refDelegate.summary.publicKey });
+				const response = await getVoters({ publicKey: refDelegate.summary.publicKey });
 				expect(response).toMap(jsonRpcEnvelopeSchema);
 				const { result } = response;
 				expect(result.data).toMap(voterSchemaVersion5);

--- a/tests/integration/api_v2/rpc/votesSent.test.js
+++ b/tests/integration/api_v2/rpc/votesSent.test.js
@@ -62,43 +62,12 @@ const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v2`;
 
 		it('Returns list of votes when requested for existing account by publickey', async () => {
 			if (refDelegate.summary.publicKey) {
-				const response = await getVotes({ publickey: refDelegate.summary.publicKey });
+				const response = await getVotes({ publicKey: refDelegate.summary.publicKey });
 				expect(response).toMap(jsonRpcEnvelopeSchema);
 				const { result } = response;
 				expect(result.data).toMap(voteSchemaVersion5);
 				expect(result.meta).toMap(metaSchema);
 			}
-		});
-
-		it('Returns list of votes when requested with offset', async () => {
-			const response = await getVotes({ address: refDelegate.summary.address, offset: 1 });
-			expect(response).toMap(jsonRpcEnvelopeSchema);
-			const { result } = response;
-			expect(result.data).toMap(voteSchemaVersion5);
-			expect(result.meta).toMap(metaSchema);
-		});
-
-		it('Returns list of votes when requested with limit', async () => {
-			const response = await getVotes({ address: refDelegate.summary.address, limit: 1 });
-			expect(response).toMap(jsonRpcEnvelopeSchema);
-			const { result } = response;
-			expect(result.data).toMap(voteSchemaVersion5);
-			expect(result.meta).toMap(metaSchema);
-		});
-
-		it('Returns list of votes when requested with offset & limit', async () => {
-			const response = await getVotes({
-				address: refDelegate.summary.address, offset: 1, limit: 1,
-			});
-			expect(response).toMap(jsonRpcEnvelopeSchema);
-			const { result } = response;
-			expect(result.data).toMap(voteSchemaVersion5);
-			expect(result.meta).toMap(metaSchema);
-		});
-
-		it('Returns INVALID_PARAMS (-32602) when requested with limit = 0', async () => {
-			const response = await getVotes({ address: refDelegate.summary.address, limit: 0 });
-			expect(response).toMap(invalidParamsSchema);
 		});
 
 		it('Returns empty response when requested with wrong address', async () => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #407 

### How was it solved?
- [x] Match votes_received API to support following params:
  - [x] Retrieval by following account info (`address`, `username`, `publicKey`)
  - [x] Limit and offset works properly
- [x] Match votes_sent API to support following params:
  - [x] Retrieval by following account info (`address`, `username`, `publicKey`)
  - [x] Limit and offset removed from votes_sent and returns all votes sent
- [x] Update failing tests

 
### How was it tested?
- [x] Locally
- [x] Jenkins
