### PR TITLE
Genesis block accounts indexing - Closes #421

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
 				dir('./docker') {
 					sh '''
 						make -f Makefile.core.jenkins down
-						make -f Makefile.core.jenkins up
+						ENABLE_HTTP_API=http-version1,http-version1-compat,http-status,http-version2 ENABLE_WS_API=rpc,rpc-v1,blockchain,rpc-v2 make -f Makefile.core.jenkins up
 						ready=1
 						retries=0
 						set +e

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
 				dir('./docker') {
 					sh '''
 						make -f Makefile.core.jenkins down
-						ENABLE_HTTP_API=http-status,http-version2 ENABLE_WS_API=rpc-v2 make -f Makefile.core.jenkins up
+						make -f Makefile.core.jenkins up
 						ready=1
 						retries=0
 						set +e

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline {
 				dir('./docker') {
 					sh '''
 						make -f Makefile.core.jenkins down
-						ENABLE_HTTP_API=http-version1,http-version1-compat,http-status,http-version2 ENABLE_WS_API=rpc,rpc-v1,blockchain,rpc-v2 make -f Makefile.core.jenkins up
+						ENABLE_HTTP_API=http-status,http-version2 ENABLE_WS_API=rpc-v2 make -f Makefile.core.jenkins up
 						ready=1
 						retries=0
 						set +e

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -251,15 +251,6 @@ const indexAccountsbyPublicKey = async (publicKeysToIndex) => {
 	await indexAccountsByPublicKeyQueue.add('indexAccountsByPublicKeyQueue', { accounts: accountsToIndex });
 };
 
-const indexGenesisAccounts = async genesisHeight => {
-	const genesisBlock = (await coreApi.getBlockByHeight(genesisHeight)).data[0];
-
-	const genesisAccountAddresses = genesisBlock.header.asset.accounts
-		.map(account => account.address.toString('hex'));
-
-	await indexAccountsbyAddress(genesisAccountAddresses);
-};
-
 const getMultisignatureMemberships = async () => []; // TODO
 
 module.exports = {
@@ -272,5 +263,4 @@ module.exports = {
 	getAccountsBySearch,
 	getBase32AddressFromHex,
 	getHexAddressFromBase32,
-	indexGenesisAccounts,
 };

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -229,7 +229,11 @@ const indexAccountsbyAddress = async (addressesToIndex) => {
 	const accountsToIndex = await BluebirdPromise.map(
 		addressesToIndex,
 		async address => {
+			const accountFromDB = await getIndexedAccountInfo({
+				address: getBase32AddressFromHex(address),
+			});
 			const account = (await getAccountsFromCore({ address })).data[0];
+			if (accountFromDB && accountFromDB.publicKey) account.publicKey = accountFromDB.publicKey;
 			return account;
 		},
 		{ concurrency: addressesToIndex.length },

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -255,7 +255,7 @@ const indexGenesisAccounts = async genesisHeight => {
 	const genesisBlock = (await coreApi.getBlockByHeight(genesisHeight)).data[0];
 
 	const genesisAccountAddresses = genesisBlock.header.asset.accounts
-		.map(account => account = account.address.toString('hex'));
+		.map(account => account.address.toString('hex'));
 
 	await indexAccountsbyAddress(genesisAccountAddresses);
 };

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -267,4 +267,5 @@ module.exports = {
 	getAccountsBySearch,
 	getBase32AddressFromHex,
 	getHexAddressFromBase32,
+	getHexAddressFromPublicKey,
 };

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -251,6 +251,15 @@ const indexAccountsbyPublicKey = async (publicKeysToIndex) => {
 	await indexAccountsByPublicKeyQueue.add('indexAccountsByPublicKeyQueue', { accounts: accountsToIndex });
 };
 
+const indexGenesisAccounts = async genesisHeight => {
+	const genesisBlock = (await coreApi.getBlockByHeight(genesisHeight)).data[0];
+
+	const genesisAccountAddresses = genesisBlock.header.asset.accounts
+		.map(account => account = account.address.toString('hex'));
+
+	await indexAccountsbyAddress(genesisAccountAddresses);
+};
+
 const getMultisignatureMemberships = async () => []; // TODO
 
 module.exports = {
@@ -263,4 +272,5 @@ module.exports = {
 	getAccountsBySearch,
 	getBase32AddressFromHex,
 	getHexAddressFromBase32,
+	indexGenesisAccounts,
 };

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -22,6 +22,7 @@ const config = require('../../../../config');
 const {
 	indexAccountsbyPublicKey,
 	getIndexedAccountInfo,
+	indexGenesisAccounts,
 } = require('./accounts');
 const { indexVotes } = require('./voters');
 const {
@@ -375,7 +376,7 @@ const indexMissingBlocks = async (fromHeight, toHeight) => {
 const init = async () => {
 	await getBlocksIndex();
 	try {
-		const genesisHeight = 1;
+		const genesisHeight = 0;
 		const currentHeight = (await coreApi.getNetworkStatus()).data.height;
 
 		const blockIndexLowerRange = config.indexNumOfBlocks > 0
@@ -385,6 +386,9 @@ const init = async () => {
 
 		// Index genesis block first
 		await getBlocks({ height: genesisHeight });
+
+		// Index genesis accounts
+		await indexGenesisAccounts(genesisHeight);
 
 		const highestIndexedHeight = await blocksCache.get('highestIndexedHeight') || blockIndexLowerRange;
 

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -335,7 +335,8 @@ const buildIndex = async (from, to) => {
 		const sortedBlocks = blocks.sort((a, b) => a.height - b.height);
 
 		const topHeightFromBatch = (sortedBlocks.pop()).height;
-		const bottomHeightFromBatch = (sortedBlocks.shift()).height;
+		const bottomHeightFromBatch = sortedBlocks.length
+			? (sortedBlocks.shift()).height : topHeightFromBatch;
 		const lowestIndexedHeight = await blocksCache.get('lowestIndexedHeight');
 		if (bottomHeightFromBatch < lowestIndexedHeight || lowestIndexedHeight === 0) await blocksCache.set('lowestIndexedHeight', bottomHeightFromBatch);
 		if (topHeightFromBatch > highestIndexedHeight) await blocksCache.set('highestIndexedHeight', topHeightFromBatch);
@@ -383,8 +384,8 @@ const indexMissingBlocks = async (fromHeight, toHeight) => {
 			setIndexReadyStatus(true);
 			return getIndexReadyStatus();
 		}
-			setIndexReadyStatus(false);
-			throw new Error('Block indexing is still processing...');
+		setIndexReadyStatus(false);
+		throw new Error('Block indexing still in progress...');
 	}, 5000);
 };
 

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -297,7 +297,9 @@ const getBlocks = async params => {
 
 const indexGenesisBlock = async genesisHeight => {
 	const [genesisBlock] = await getBlockByHeight(genesisHeight);
-	const accountAddressesToIndex = genesisBlock.asset.accounts.map(account => account.address);
+	const accountAddressesToIndex = genesisBlock.asset.accounts
+		.filter(account => account.address > 16) // To filter out reclaim accounts
+		.map(account => account.address);
 	indexAccountsbyAddress(accountAddressesToIndex);
 	await indexTransactions([genesisBlock]);
 };
@@ -384,15 +386,15 @@ const init = async () => {
 	await getBlocksIndex();
 	try {
 		const genesisHeight = 0;
+		// Index genesis block
+		await indexGenesisBlock(genesisHeight);
+
 		const currentHeight = (await coreApi.getNetworkStatus()).data.height;
 
 		const blockIndexLowerRange = config.indexNumOfBlocks > 0
 			? currentHeight - config.indexNumOfBlocks : genesisHeight;
 		if (config.indexNumOfBlocks === 0) setIsSyncFullBlockchain(true);
 		const blockIndexHigherRange = currentHeight;
-
-		// Index genesis block
-		await indexGenesisBlock(genesisHeight);
 
 		const highestIndexedHeight = await blocksCache.get('highestIndexedHeight') || blockIndexLowerRange;
 

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -374,7 +374,7 @@ const indexMissingBlocks = async (fromHeight, toHeight) => {
 
 	// eslint-disable-next-line consistent-return
 	waitForIt(async () => {
-		let indexReadyStatus = false;
+		let indexReadyStatus;
 		do {
 			/* eslint-disable no-await-in-loop */
 			const currentHeight = (await coreApi.getNetworkStatus()).data.height;

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -422,8 +422,6 @@ const init = async () => {
 	}
 };
 
-init();
-
 module.exports = {
 	init,
 	getBlocks,

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -374,19 +374,17 @@ const indexMissingBlocks = async (fromHeight, toHeight) => {
 
 	// eslint-disable-next-line consistent-return
 	waitForIt(async () => {
-		let indexReadyStatus;
-		do {
-			/* eslint-disable no-await-in-loop */
-			const currentHeight = (await coreApi.getNetworkStatus()).data.height;
-			const numBlocksIndexed = await blocksDB.count();
-			const [lastIndexedBlock] = await blocksDB.find({ sort: 'height:desc', limit: 1 });
-			/* eslint-enable no-await-in-loop */
-			if (numBlocksIndexed >= currentHeight && lastIndexedBlock.height >= currentHeight) {
-				indexReadyStatus = true;
-				setIndexReadyStatus(indexReadyStatus);
-				return getIndexReadyStatus();
-			}
-		} while (indexReadyStatus !== true);
+		/* eslint-disable no-await-in-loop */
+		const currentHeight = (await coreApi.getNetworkStatus()).data.height;
+		const numBlocksIndexed = await blocksDB.count();
+		const [lastIndexedBlock] = await blocksDB.find({ sort: 'height:desc', limit: 1 });
+		/* eslint-enable no-await-in-loop */
+		if (numBlocksIndexed >= currentHeight && lastIndexedBlock.height >= currentHeight) {
+			setIndexReadyStatus(true);
+			return getIndexReadyStatus();
+		}
+			setIndexReadyStatus(false);
+			throw new Error('Block indexing is still processing...');
 	}, 5000);
 };
 

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -374,7 +374,7 @@ const indexMissingBlocks = async (fromHeight, toHeight) => {
 
 	// eslint-disable-next-line consistent-return
 	waitForIt(async () => {
-		const readyStatus = false;
+		let indexReadyStatus = false;
 		do {
 			/* eslint-disable no-await-in-loop */
 			const currentHeight = (await coreApi.getNetworkStatus()).data.height;
@@ -382,10 +382,11 @@ const indexMissingBlocks = async (fromHeight, toHeight) => {
 			const [lastIndexedBlock] = await blocksDB.find({ sort: 'height:desc', limit: 1 });
 			/* eslint-enable no-await-in-loop */
 			if (numBlocksIndexed >= currentHeight && lastIndexedBlock.height >= currentHeight) {
-				setIndexReadyStatus(true);
+				indexReadyStatus = true;
+				setIndexReadyStatus(indexReadyStatus);
 				return getIndexReadyStatus();
 			}
-		} while (readyStatus !== true);
+		} while (indexReadyStatus !== true);
 	}, 5000);
 };
 

--- a/services/core/shared/core/compat/sdk_v5/transactions.js
+++ b/services/core/shared/core/compat/sdk_v5/transactions.js
@@ -25,7 +25,7 @@ const {
 	getIndexedAccountInfo,
 	getBase32AddressFromHex,
 	getAccountsBySearch,
-	getHexAddressFromBase32,
+	getHexAddressFromPublicKey,
 } = require('./accounts');
 const { removeVotesByTransactionIDs } = require('./voters');
 const { getRegisteredModuleAssets } = require('../common');
@@ -264,7 +264,7 @@ const getTransactions = async params => {
 				transaction.blockId = indexedTxInfo.blockId;
 				const account = await getIndexedAccountInfo({ publicKey: transaction.senderPublicKey });
 				transaction.senderId = account && account.address ? account.address
-					: getBase32AddressFromHex(getHexAddressFromBase32(transaction.senderPublicKey));
+					: getBase32AddressFromHex(getHexAddressFromPublicKey(transaction.senderPublicKey));
 				transaction.username = account && account.username ? account.username : undefined;
 				transaction.isPending = false;
 

--- a/services/core/shared/core/compat/sdk_v5/transactions.js
+++ b/services/core/shared/core/compat/sdk_v5/transactions.js
@@ -25,6 +25,7 @@ const {
 	getIndexedAccountInfo,
 	getBase32AddressFromHex,
 	getAccountsBySearch,
+	getHexAddressFromBase32,
 } = require('./accounts');
 const { removeVotesByTransactionIDs } = require('./voters');
 const { getRegisteredModuleAssets } = require('../common');
@@ -262,7 +263,8 @@ const getTransactions = async params => {
 				transaction.height = indexedTxInfo.height;
 				transaction.blockId = indexedTxInfo.blockId;
 				const account = await getIndexedAccountInfo({ publicKey: transaction.senderPublicKey });
-				transaction.senderId = account && account.address ? account.address : undefined;
+				transaction.senderId = account && account.address ? account.address
+					: getBase32AddressFromHex(getHexAddressFromBase32(transaction.senderPublicKey));
 				transaction.username = account && account.username ? account.username : undefined;
 				transaction.isPending = false;
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #421 

### How was it solved?

- [x] `Indexing` related issues
  - [x] Index genesis block during `init`
  - [x] Index all accounts present in genesis block
  - [x] Fix for updating `setIndexReadyStatus` once blockchain is indexed
- [x] `Transactions` related bugs
  - [x] Fix missing sender address in some transactions
 - [x] `Accounts` related bugs
   - [x] Fix account indexing `indexAccountsByAddress` (Avoid overwriting `publicKey`)
   - [x] `producedBlocks` and `rewards` enabled in delegate response based on `setIndexReadyStatus`

### How was it tested?
- [x] Local
- [x] Jenkins
