### PR TITLE
Transaction/block filter support for half bounded ranges - Closes #435

### DIFF
--- a/services/core/shared/core/blocks.js
+++ b/services/core/shared/core/blocks.js
@@ -81,7 +81,8 @@ const getBlocks = async (params = {}) => {
 		total = blocks.meta.total || undefined;
 	} else if (params.blockId || (params.height && !params.height.includes(':'))) {
 		total = blocks.data.length;
-	} else if (params.height && params.height.includes(':')) {
+	} else if ((params.height && params.height.includes(':'))
+		|| (params.timestamp && params.timestamp.includes(':'))) {
 		total = blocks.meta.total;
 	} else {
 		total = (getLastBlock()).height;

--- a/services/core/shared/core/blocks.js
+++ b/services/core/shared/core/blocks.js
@@ -79,8 +79,10 @@ const getBlocks = async (params = {}) => {
 	let total;
 	if (params.generatorPublicKey) {
 		total = blocks.meta.total || undefined;
-	} else if (params.blockId || params.height) {
+	} else if (params.blockId || (params.height && !params.height.includes(':'))) {
 		total = blocks.data.length;
+	} else if (params.height && params.height.includes(':')) {
+		total = blocks.meta.total;
 	} else {
 		total = (getLastBlock()).height;
 	}

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -110,7 +110,7 @@ const indexAccountsByPublicKeyQueue = initializeQueue('indexAccountsByPublicKeyQ
 
 const normalizeAccount = account => {
 	account.address = getBase32AddressFromHex(account.address.toString('hex'));
-	account.isDelegate = !(account.dpos && Number(account.dpos.delegate.totalVotesReceived) === 0);
+	account.isDelegate = !(account.dpos && !account.dpos.delegate.username);
 	account.isMultisignature = !!(account.keys && account.keys.numberOfSignatures);
 	account.token.balance = Number(account.token.balance);
 	account.sequence.nonce = Number(account.sequence.nonce);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -236,7 +236,8 @@ const getBlocks = async params => {
 	if (params.height && typeof params.height === 'string' && params.height.includes(':')) {
 		const { height, ...remParams } = params;
 		params = remParams;
-		const [from, to] = height.split(':');
+		const from = height.split(':')[0] || 0;
+		const to = height.split(':')[1] || (await getLastBlock())[0].height;
 		if (from > to) return new Error('From height cannot be greater than to height');
 		if (!params.propBetweens) params.propBetweens = [];
 		params.propBetweens.push({
@@ -249,7 +250,8 @@ const getBlocks = async params => {
 	if (params.timestamp && params.timestamp.includes(':')) {
 		const { timestamp, ...remParams } = params;
 		params = remParams;
-		const [from, to] = timestamp.split(':');
+		const from = timestamp.split(':')[0] || 0;
+		const to = timestamp.split(':')[1] || Math.floor(Date.now() / 1000);
 		if (from > to) return new Error('From timestamp cannot be greater than to timestamp');
 		if (!params.propBetweens) params.propBetweens = [];
 		params.propBetweens.push({

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -237,6 +237,7 @@ const getBlocks = async params => {
 		const { height, ...remParams } = params;
 		params = remParams;
 		const [from, to] = height.split(':');
+		if (from && to && from > to) return new Error('From height cannot be greater than to height');
 		if (!params.propBetweens) params.propBetweens = [];
 		params.propBetweens.push({
 			property: 'height',
@@ -249,6 +250,7 @@ const getBlocks = async params => {
 		const { timestamp, ...remParams } = params;
 		params = remParams;
 		const [from, to] = timestamp.split(':');
+		if (from && to && from > to) return new Error('From timestamp cannot be greater than to timestamp');
 		if (!params.propBetweens) params.propBetweens = [];
 		params.propBetweens.push({
 			property: 'timestamp',

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -236,9 +236,7 @@ const getBlocks = async params => {
 	if (params.height && typeof params.height === 'string' && params.height.includes(':')) {
 		const { height, ...remParams } = params;
 		params = remParams;
-		const from = height.split(':')[0] || 0;
-		const to = height.split(':')[1] || (await getLastBlock())[0].height;
-		if (from > to) return new Error('From height cannot be greater than to height');
+		const [from, to] = height.split(':');
 		if (!params.propBetweens) params.propBetweens = [];
 		params.propBetweens.push({
 			property: 'height',
@@ -250,9 +248,7 @@ const getBlocks = async params => {
 	if (params.timestamp && params.timestamp.includes(':')) {
 		const { timestamp, ...remParams } = params;
 		params = remParams;
-		const from = timestamp.split(':')[0] || 0;
-		const to = timestamp.split(':')[1] || Math.floor(Date.now() / 1000);
-		if (from > to) return new Error('From timestamp cannot be greater than to timestamp');
+		const [from, to] = timestamp.split(':');
 		if (!params.propBetweens) params.propBetweens = [];
 		params.propBetweens.push({
 			property: 'timestamp',

--- a/services/core/shared/core/compat/sdk_v5/transactions.js
+++ b/services/core/shared/core/compat/sdk_v5/transactions.js
@@ -38,6 +38,8 @@ const getTransactionsIndex = () => mysqlIndex('transactions', transactionsIndexS
 
 const availableLiskModuleAssets = getRegisteredModuleAssets();
 
+const MAX_TRANSACTION_AMOUNT = '9223372036854775807';
+
 const resolveModuleAsset = (moduleAssetVal) => {
 	const [module, asset] = moduleAssetVal.split(':');
 	let response;
@@ -128,8 +130,8 @@ const validateParams = async params => {
 		if (!params.propBetweens) params.propBetweens = [];
 		params.propBetweens.push({
 			property: 'amount',
-			from: amount.split(':')[0],
-			to: amount.split(':')[1],
+			from: amount.split(':')[0] || 0,
+			to: amount.split(':')[1] || MAX_TRANSACTION_AMOUNT,
 		});
 	}
 

--- a/services/core/shared/core/compat/sdk_v5/transactions.js
+++ b/services/core/shared/core/compat/sdk_v5/transactions.js
@@ -38,8 +38,6 @@ const getTransactionsIndex = () => mysqlIndex('transactions', transactionsIndexS
 
 const availableLiskModuleAssets = getRegisteredModuleAssets();
 
-const MAX_TRANSACTION_AMOUNT = '9223372036854775807';
-
 const resolveModuleAsset = (moduleAssetVal) => {
 	const [module, asset] = moduleAssetVal.split(':');
 	let response;
@@ -130,8 +128,8 @@ const validateParams = async params => {
 		if (!params.propBetweens) params.propBetweens = [];
 		params.propBetweens.push({
 			property: 'amount',
-			from: amount.split(':')[0] || 0,
-			to: amount.split(':')[1] || MAX_TRANSACTION_AMOUNT,
+			from: amount.split(':')[0],
+			to: amount.split(':')[1],
 		});
 	}
 
@@ -142,8 +140,8 @@ const validateParams = async params => {
 		if (!params.propBetweens) params.propBetweens = [];
 		params.propBetweens.push({
 			property: 'timestamp',
-			from: Number(fromTimestamp) || 0,
-			to: Number(toTimestamp) || Math.floor(Date.now() / 1000),
+			from: Number(fromTimestamp),
+			to: Number(toTimestamp),
 		});
 	}
 

--- a/services/core/shared/core/compat/sdk_v5/transactions.js
+++ b/services/core/shared/core/compat/sdk_v5/transactions.js
@@ -140,8 +140,8 @@ const validateParams = async params => {
 		if (!params.propBetweens) params.propBetweens = [];
 		params.propBetweens.push({
 			property: 'timestamp',
-			from: Number(fromTimestamp),
-			to: Number(toTimestamp),
+			from: fromTimestamp,
+			to: toTimestamp,
 		});
 	}
 

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -165,16 +165,9 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 			const { propBetweens } = params;
 			propBetweens.forEach(
 				propBetween => {
-					if (propBetween.from && Boolean(propBetween.from)) {
-						query
-							.where(propBetween.property, '>=', propBetween.from);
-					}
-					if (propBetween.to && Boolean(propBetween.to)) {
-						query
-							.where(propBetween.property, '<=', propBetween.to);
-					}
-				},
-			);
+					if (propBetween.from) query.where(propBetween.property, '>=', propBetween.from);
+					if (propBetween.to) query.where(propBetween.property, '<=', propBetween.to);
+				});
 		}
 
 		if (params.sort) {
@@ -249,14 +242,8 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 			const { propBetweens } = params;
 			propBetweens.forEach(
 				propBetween => {
-					if (propBetween.from && Boolean(propBetween.from)) {
-						query
-							.where(propBetween.property, '>=', propBetween.from);
-					}
-					if (propBetween.to && Boolean(propBetween.to)) {
-						query
-							.where(propBetween.property, '<=', propBetween.to);
-					}
+					if (propBetween.from) query.where(propBetween.property, '>=', propBetween.from);
+					if (propBetween.to) query.where(propBetween.property, '<=', propBetween.to);
 				});
 		}
 

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -164,9 +164,17 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 		if (params.propBetweens) {
 			const { propBetweens } = params;
 			propBetweens.forEach(
-				propBetween => query
-					.where(propBetween.property, '>=', propBetween.from)
-					.where(propBetween.property, '<=', propBetween.to));
+				propBetween => {
+					if (propBetween.from && Boolean(propBetween.from)) {
+						query
+							.where(propBetween.property, '>=', propBetween.from);
+					}
+					if (propBetween.to && Boolean(propBetween.to)) {
+						query
+							.where(propBetween.property, '<=', propBetween.to);
+					}
+				},
+			);
 		}
 
 		if (params.sort) {
@@ -240,9 +248,16 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 		if (params.propBetweens) {
 			const { propBetweens } = params;
 			propBetweens.forEach(
-				propBetween => query
-					.where(propBetween.property, '>=', propBetween.from)
-					.where(propBetween.property, '<=', propBetween.to));
+				propBetween => {
+					if (propBetween.from && Boolean(propBetween.from)) {
+						query
+							.where(propBetween.property, '>=', propBetween.from);
+					}
+					if (propBetween.to && Boolean(propBetween.to)) {
+						query
+							.where(propBetween.property, '<=', propBetween.to);
+					}
+				});
 		}
 
 		if (params.whereIn) {

--- a/services/gateway/sources/version2/mappings/account.js
+++ b/services/gateway/sources/version2/mappings/account.js
@@ -65,11 +65,11 @@ module.exports = {
 			status: 'status,string',
 			rewards: 'rewards,string',
 		},
-		sentVotes: ['sentVotes', {
+		sentVotes: ['dpos.sentVotes', {
 			delegateAddress: '=,string',
 			amount: '=,string',
 		}],
-		unlocking: ['unlocking', {
+		unlocking: ['dpos.unlocking', {
 			delegateAddress: '=,string',
 			amount: '=,string',
 			height: {

--- a/services/gateway/sources/version2/mappings/account.js
+++ b/services/gateway/sources/version2/mappings/account.js
@@ -65,11 +65,11 @@ module.exports = {
 			status: 'status,string',
 			rewards: 'rewards,string',
 		},
-		sentVotes: ['dpos.sentVotes', {
+		sentVotes: ['sentVotes', {
 			delegateAddress: '=,string',
 			amount: '=,string',
 		}],
-		unlocking: ['dpos.unlocking', {
+		unlocking: ['unlocking', {
 			delegateAddress: '=,string',
 			amount: '=,string',
 			height: {

--- a/tests/integration/api_v2/http/blocks.test.js
+++ b/tests/integration/api_v2/http/blocks.test.js
@@ -116,7 +116,7 @@ describe('Blocks API', () => {
 
 	describe('Retrieve blocks list within timestamps', () => {
 		it('blocks within set timestamps are returned', async () => {
-			const from = moment(refBlock.timestamp).subtract(1, 'day').unix() * (10 ** 3);
+			const from = moment(refBlock.timestamp * 10 ** 3).subtract(1, 'day').unix();
 			const toTimestamp = refBlock.timestamp;
 			const response = await api.get(`${endpoint}?timestamp=${from}:${toTimestamp}&limit=100`);
 			expect(response).toMap(goodRequestSchema);
@@ -132,7 +132,7 @@ describe('Blocks API', () => {
 		});
 
 		it('blocks with half bounded range: fromTimestamp', async () => {
-			const from = moment(refBlock.timestamp).subtract(1, 'day').unix() * (10 ** 3);
+			const from = moment(refBlock.timestamp * 10 ** 3).subtract(1, 'day').unix();
 			const response = await api.get(`${endpoint}?timestamp=${from}:&limit=100`);
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
@@ -162,7 +162,7 @@ describe('Blocks API', () => {
 
 	describe('Retrieve blocks list within height range', () => {
 		it('blocks within set height are returned', async () => {
-			const minHeight = 1;
+			const minHeight = refBlock.height - 10;
 			const maxHeight = refBlock.height;
 			const response = await api.get(`${endpoint}?height=${minHeight}:${maxHeight}&limit=100`);
 			expect(response).toMap(goodRequestSchema);
@@ -178,7 +178,7 @@ describe('Blocks API', () => {
 		});
 
 		it('blocks with half bounded range: minHeight', async () => {
-			const minHeight = 1;
+			const minHeight = refBlock.height - 10;
 			const response = await api.get(`${endpoint}?height=${minHeight}:&limit=100`);
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);

--- a/tests/integration/api_v2/http/blocks.test.js
+++ b/tests/integration/api_v2/http/blocks.test.js
@@ -14,6 +14,8 @@
  *
  */
 /* eslint-disable quotes, quote-props, comma-dangle */
+import moment from 'moment';
+
 const config = require('../../../config');
 const { api } = require('../../../helpers/api');
 
@@ -109,6 +111,92 @@ describe('Blocks API', () => {
 		it('invalid query parameter -> 400', async () => {
 			const response = await api.get(`${endpoint}?block=12602944501676077162`, 400);
 			expect(response).toMap(wrongInputParamSchema);
+		});
+	});
+
+	describe('Retrieve blocks list within timestamps', () => {
+		it('blocks within set timestamps are returned', async () => {
+			const from = moment(refBlock.timestamp).subtract(1, 'day').unix() * (10 ** 3);
+			const toTimestamp = refBlock.timestamp;
+			const response = await api.get(`${endpoint}?timestamp=${from}:${toTimestamp}&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(block => {
+				expect(block).toMap(blockSchemaVersion5);
+				expect(block.timestamp).toBeGreaterThanOrEqual(from);
+				expect(block.timestamp).toBeLessThanOrEqual(toTimestamp);
+			});
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('blocks with half bounded range: fromTimestamp', async () => {
+			const from = moment(refBlock.timestamp).subtract(1, 'day').unix() * (10 ** 3);
+			const response = await api.get(`${endpoint}?timestamp=${from}:&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(block => {
+				expect(block).toMap(blockSchemaVersion5);
+				expect(block.timestamp).toBeGreaterThanOrEqual(from);
+			});
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('blocks with half bounded range: toTimestamp', async () => {
+			const toTimestamp = refBlock.timestamp;
+			const response = await api.get(`${endpoint}?timestamp=:${toTimestamp}&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(block => {
+				expect(block).toMap(blockSchemaVersion5);
+				expect(block.timestamp).toBeLessThanOrEqual(toTimestamp);
+			});
+			expect(response.meta).toMap(metaSchema);
+		});
+	});
+
+	describe('Retrieve blocks list within height range', () => {
+		it('blocks within set height are returned', async () => {
+			const minHeight = 1;
+			const maxHeight = refBlock.height;
+			const response = await api.get(`${endpoint}?height=${minHeight}:${maxHeight}&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(block => {
+				expect(block).toMap(blockSchemaVersion5);
+				expect(block.height).toBeGreaterThanOrEqual(minHeight);
+				expect(block.height).toBeLessThanOrEqual(maxHeight);
+			});
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('blocks with half bounded range: minHeight', async () => {
+			const minHeight = 1;
+			const response = await api.get(`${endpoint}?height=${minHeight}:&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(block => {
+				expect(block).toMap(blockSchemaVersion5);
+				expect(block.height).toBeGreaterThanOrEqual(minHeight);
+			});
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('blocks with half bounded range: maxHeight', async () => {
+			const maxHeight = refBlock.height;
+			const response = await api.get(`${endpoint}?height=:${maxHeight}&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(block => {
+				expect(block).toMap(blockSchemaVersion5);
+				expect(block.height).toBeLessThanOrEqual(maxHeight);
+			});
+			expect(response.meta).toMap(metaSchema);
 		});
 	});
 });

--- a/tests/integration/api_v2/http/blocks.test.js
+++ b/tests/integration/api_v2/http/blocks.test.js
@@ -122,6 +122,7 @@ describe('Blocks API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(block => {
 				expect(block).toMap(blockSchemaVersion5);
 				expect(block.timestamp).toBeGreaterThanOrEqual(from);
@@ -136,6 +137,7 @@ describe('Blocks API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(block => {
 				expect(block).toMap(blockSchemaVersion5);
 				expect(block.timestamp).toBeGreaterThanOrEqual(from);
@@ -149,6 +151,7 @@ describe('Blocks API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(block => {
 				expect(block).toMap(blockSchemaVersion5);
 				expect(block.timestamp).toBeLessThanOrEqual(toTimestamp);
@@ -165,6 +168,7 @@ describe('Blocks API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(block => {
 				expect(block).toMap(blockSchemaVersion5);
 				expect(block.height).toBeGreaterThanOrEqual(minHeight);
@@ -179,6 +183,7 @@ describe('Blocks API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(block => {
 				expect(block).toMap(blockSchemaVersion5);
 				expect(block.height).toBeGreaterThanOrEqual(minHeight);
@@ -192,6 +197,7 @@ describe('Blocks API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(block => {
 				expect(block).toMap(blockSchemaVersion5);
 				expect(block.height).toBeLessThanOrEqual(maxHeight);

--- a/tests/integration/api_v2/http/transactions.test.js
+++ b/tests/integration/api_v2/http/transactions.test.js
@@ -285,7 +285,7 @@ describe('Transactions API', () => {
 
 	describe('Retrieve transaction list within timestamps', () => {
 		it('transactions within set timestamps are returned', async () => {
-			const from = moment(refTransaction.block.timestamp).subtract(1, 'day').unix() * (10 ** 3);
+			const from = moment(refTransaction.block.timestamp * 10 ** 3).subtract(1, 'day').unix();
 			const toTimestamp = refTransaction.block.timestamp;
 			const response = await api.get(`${endpoint}?timestamp=${from}:${toTimestamp}&limit=100`);
 			expect(response).toMap(goodRequestSchema);
@@ -301,7 +301,7 @@ describe('Transactions API', () => {
 		});
 
 		it('transactions with half bounded range: fromTimestamp', async () => {
-			const from = moment(refTransaction.block.timestamp).subtract(1, 'day').unix() * (10 ** 3);
+			const from = moment(refTransaction.block.timestamp * 10 ** 3).subtract(1, 'day').unix();
 			const response = await api.get(`${endpoint}?timestamp=${from}:&limit=100`);
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);

--- a/tests/integration/api_v2/http/transactions.test.js
+++ b/tests/integration/api_v2/http/transactions.test.js
@@ -298,5 +298,74 @@ describe('Transactions API', () => {
 			});
 			expect(response.meta).toMap(metaSchema);
 		});
+
+		it('transactions with half bounded range: fromTimestamp', async () => {
+			const from = moment(refTransaction.block.timestamp).subtract(1, 'day').unix() * (10 ** 3);
+			const response = await api.get(`${endpoint}?timestamp=${from}:&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(transaction => {
+				expect(transaction).toMap(transactionSchemaVersion5);
+				expect(transaction.block.timestamp).toBeGreaterThanOrEqual(from);
+			});
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('transactions with half bounded range: toTimestamp', async () => {
+			const toTimestamp = refTransaction.block.timestamp;
+			const response = await api.get(`${endpoint}?timestamp=:${toTimestamp}&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(transaction => {
+				expect(transaction).toMap(transactionSchemaVersion5);
+				expect(transaction.block.timestamp).toBeLessThanOrEqual(toTimestamp);
+			});
+			expect(response.meta).toMap(metaSchema);
+		});
+	});
+
+	describe('Retrieve transaction list within amount range', () => {
+		it('transactions within set amount range are returned', async () => {
+			const minAmount = 0;
+			const maxAmount = BigInt(refTransaction.asset.amount);
+			const response = await api.get(`${endpoint}?amount=${minAmount}:${maxAmount}&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(transaction => {
+				expect(transaction).toMap(transactionSchemaVersion5);
+				expect(BigInt(transaction.asset.amount)).toBeGreaterThanOrEqual(minAmount);
+				expect(BigInt(transaction.asset.amount)).toBeLessThanOrEqual(maxAmount);
+			});
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('transactions with half bounded range: minAmount', async () => {
+			const minAmount = 0;
+			const response = await api.get(`${endpoint}?amount=${minAmount}:&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(transaction => {
+				expect(transaction).toMap(transactionSchemaVersion5);
+				expect(BigInt(transaction.asset.amount)).toBeGreaterThanOrEqual(minAmount);
+			});
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('transactions with half bounded range: maxAmount', async () => {
+			const maxAmount = BigInt(refTransaction.asset.amount);
+			const response = await api.get(`${endpoint}?amount=:${maxAmount}&limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			response.data.forEach(transaction => {
+				expect(transaction).toMap(transactionSchemaVersion5);
+				expect(BigInt(transaction.asset.amount)).toBeLessThanOrEqual(maxAmount);
+			});
+			expect(response.meta).toMap(metaSchema);
+		});
 	});
 });

--- a/tests/integration/api_v2/http/transactions.test.js
+++ b/tests/integration/api_v2/http/transactions.test.js
@@ -291,6 +291,7 @@ describe('Transactions API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
 				expect(transaction.block.timestamp).toBeGreaterThanOrEqual(from);
@@ -305,6 +306,7 @@ describe('Transactions API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
 				expect(transaction.block.timestamp).toBeGreaterThanOrEqual(from);
@@ -318,6 +320,7 @@ describe('Transactions API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
 				expect(transaction.block.timestamp).toBeLessThanOrEqual(toTimestamp);
@@ -334,6 +337,7 @@ describe('Transactions API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
 				expect(BigInt(transaction.asset.amount)).toBeGreaterThanOrEqual(minAmount);
@@ -348,6 +352,7 @@ describe('Transactions API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
 				expect(BigInt(transaction.asset.amount)).toBeGreaterThanOrEqual(minAmount);
@@ -361,6 +366,7 @@ describe('Transactions API', () => {
 			expect(response).toMap(goodRequestSchema);
 			expect(response.data).toBeInstanceOf(Array);
 			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
 				expect(BigInt(transaction.asset.amount)).toBeLessThanOrEqual(maxAmount);

--- a/tests/integration/api_v2/rpc/blocks.test.js
+++ b/tests/integration/api_v2/rpc/blocks.test.js
@@ -181,5 +181,64 @@ describe('Method get.blocks', () => {
 				expect(blockItem.timestamp).toBeLessThanOrEqual(to);
 			});
 		});
+
+		it('Blocks with from... timestamp -> ok', async () => {
+			const from = 0;
+			const response = await getBlocks({ timestamp: `${from}:` });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data[0]).toMap(blockSchemaVersion5);
+			result.data.forEach((blockItem) => {
+				expect(blockItem.timestamp).toBeGreaterThanOrEqual(from);
+			});
+		});
+
+		it('Blocks with ...to timestamp -> ok', async () => {
+			const to = Math.floor(Date.now() / 1000);
+			const response = await getBlocks({ timestamp: `:${to}` });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data[0]).toMap(blockSchemaVersion5);
+			result.data.forEach((blockItem) => {
+				expect(blockItem.timestamp).toBeLessThanOrEqual(to);
+			});
+		});
+	});
+
+	describe('is able to retireve block lists within height range', () => {
+		it('Blocks with min...max height -> ok', async () => {
+			const minHeight = 1;
+			const maxHeight = refBlock.height;
+			const response = await getBlocks({ height: `${minHeight}:${maxHeight}` });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data[0]).toMap(blockSchemaVersion5);
+			result.data.forEach((blockItem) => {
+				expect(blockItem.height).toBeGreaterThanOrEqual(minHeight);
+				expect(blockItem.height).toBeLessThanOrEqual(maxHeight);
+			});
+		});
+
+		it('Blocks with min... height -> ok', async () => {
+			const minHeight = 0;
+			const response = await getBlocks({ height: `${minHeight}:` });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data[0]).toMap(blockSchemaVersion5);
+			result.data.forEach((blockItem) => {
+				expect(blockItem.height).toBeGreaterThanOrEqual(minHeight);
+			});
+		});
+
+		it('Blocks with ...max height -> ok', async () => {
+			const maxHeight = refBlock.height;
+			const response = await getBlocks({ height: `:${maxHeight}` });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data[0]).toMap(blockSchemaVersion5);
+			result.data.forEach((blockItem) => {
+				expect(blockItem.height).toBeLessThanOrEqual(maxHeight);
+			});
+		});
 	});
 });

--- a/tests/integration/api_v2/rpc/blocks.test.js
+++ b/tests/integration/api_v2/rpc/blocks.test.js
@@ -175,8 +175,11 @@ describe('Method get.blocks', () => {
 			const response = await getBlocks({ timestamp: `${from}:${to}` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
-			expect(result.data[0]).toMap(blockSchemaVersion5);
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			result.data.forEach((blockItem) => {
+				expect(blockItem).toMap(blockSchemaVersion5);
 				expect(blockItem.timestamp).toBeGreaterThanOrEqual(from);
 				expect(blockItem.timestamp).toBeLessThanOrEqual(to);
 			});
@@ -187,8 +190,11 @@ describe('Method get.blocks', () => {
 			const response = await getBlocks({ timestamp: `${from}:` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
-			expect(result.data[0]).toMap(blockSchemaVersion5);
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			result.data.forEach((blockItem) => {
+				expect(blockItem).toMap(blockSchemaVersion5);
 				expect(blockItem.timestamp).toBeGreaterThanOrEqual(from);
 			});
 		});
@@ -198,8 +204,11 @@ describe('Method get.blocks', () => {
 			const response = await getBlocks({ timestamp: `:${to}` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
-			expect(result.data[0]).toMap(blockSchemaVersion5);
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			result.data.forEach((blockItem) => {
+				expect(blockItem).toMap(blockSchemaVersion5);
 				expect(blockItem.timestamp).toBeLessThanOrEqual(to);
 			});
 		});
@@ -212,8 +221,11 @@ describe('Method get.blocks', () => {
 			const response = await getBlocks({ height: `${minHeight}:${maxHeight}` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
-			expect(result.data[0]).toMap(blockSchemaVersion5);
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			result.data.forEach((blockItem) => {
+				expect(blockItem).toMap(blockSchemaVersion5);
 				expect(blockItem.height).toBeGreaterThanOrEqual(minHeight);
 				expect(blockItem.height).toBeLessThanOrEqual(maxHeight);
 			});
@@ -224,8 +236,11 @@ describe('Method get.blocks', () => {
 			const response = await getBlocks({ height: `${minHeight}:` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
-			expect(result.data[0]).toMap(blockSchemaVersion5);
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			result.data.forEach((blockItem) => {
+				expect(blockItem).toMap(blockSchemaVersion5);
 				expect(blockItem.height).toBeGreaterThanOrEqual(minHeight);
 			});
 		});
@@ -235,8 +250,11 @@ describe('Method get.blocks', () => {
 			const response = await getBlocks({ height: `:${maxHeight}` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
-			expect(result.data[0]).toMap(blockSchemaVersion5);
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			result.data.forEach((blockItem) => {
+				expect(blockItem).toMap(blockSchemaVersion5);
 				expect(blockItem.height).toBeLessThanOrEqual(maxHeight);
 			});
 		});

--- a/tests/integration/api_v2/rpc/blocks.test.js
+++ b/tests/integration/api_v2/rpc/blocks.test.js
@@ -14,6 +14,8 @@
  *
  */
 /* eslint-disable quotes, quote-props, comma-dangle */
+import moment from 'moment';
+
 const util = require('util');
 
 const config = require('../../../config');
@@ -170,8 +172,8 @@ describe('Method get.blocks', () => {
 
 	describe('is able to retireve block lists by timestamp', () => {
 		it('Blocks with from...to timestamp -> ok', async () => {
-			const from = 0;
-			const to = Math.floor(Date.now() / 1000);
+			const from = moment(refBlock.timestamp * 10 ** 3).subtract(1, 'day').unix();;
+			const to = refBlock.timestamp;
 			const response = await getBlocks({ timestamp: `${from}:${to}` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
@@ -186,7 +188,7 @@ describe('Method get.blocks', () => {
 		});
 
 		it('Blocks with from... timestamp -> ok', async () => {
-			const from = 0;
+			const from = moment(refBlock.timestamp * 10 ** 3).subtract(1, 'day').unix();;
 			const response = await getBlocks({ timestamp: `${from}:` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
@@ -200,7 +202,7 @@ describe('Method get.blocks', () => {
 		});
 
 		it('Blocks with ...to timestamp -> ok', async () => {
-			const to = Math.floor(Date.now() / 1000);
+			const to = refBlock.timestamp;
 			const response = await getBlocks({ timestamp: `:${to}` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
@@ -216,7 +218,7 @@ describe('Method get.blocks', () => {
 
 	describe('is able to retireve block lists within height range', () => {
 		it('Blocks with min...max height -> ok', async () => {
-			const minHeight = 1;
+			const minHeight = refBlock.height - 10;
 			const maxHeight = refBlock.height;
 			const response = await getBlocks({ height: `${minHeight}:${maxHeight}` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
@@ -232,7 +234,7 @@ describe('Method get.blocks', () => {
 		});
 
 		it('Blocks with min... height -> ok', async () => {
-			const minHeight = 0;
+			const minHeight = refBlock.height - 10;
 			const response = await getBlocks({ height: `${minHeight}:` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;

--- a/tests/integration/api_v2/rpc/blocks.test.js
+++ b/tests/integration/api_v2/rpc/blocks.test.js
@@ -172,7 +172,7 @@ describe('Method get.blocks', () => {
 
 	describe('is able to retireve block lists by timestamp', () => {
 		it('Blocks with from...to timestamp -> ok', async () => {
-			const from = moment(refBlock.timestamp * 10 ** 3).subtract(1, 'day').unix();;
+			const from = moment(refBlock.timestamp * 10 ** 3).subtract(1, 'day').unix();
 			const to = refBlock.timestamp;
 			const response = await getBlocks({ timestamp: `${from}:${to}` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
@@ -188,7 +188,7 @@ describe('Method get.blocks', () => {
 		});
 
 		it('Blocks with from... timestamp -> ok', async () => {
-			const from = moment(refBlock.timestamp * 10 ** 3).subtract(1, 'day').unix();;
+			const from = moment(refBlock.timestamp * 10 ** 3).subtract(1, 'day').unix();
 			const response = await getBlocks({ timestamp: `${from}:` });
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;

--- a/tests/integration/api_v2/rpc/transactions.test.js
+++ b/tests/integration/api_v2/rpc/transactions.test.js
@@ -227,7 +227,7 @@ describe('Method get.transactions', () => {
 
 	describe('is able to retrieve list of transactions using timestamps', () => {
 		it('from to -> ok', async () => {
-			const from = moment(refTransaction.block.timestamp * 10 ** 3).subtract(1, 'day').unix();;
+			const from = moment(refTransaction.block.timestamp * 10 ** 3).subtract(1, 'day').unix();
 			const toTimestamp = refTransaction.block.timestamp;
 			const response = await requestTransactions({ timestamp: `${from}:${toTimestamp}` });
 
@@ -246,7 +246,7 @@ describe('Method get.transactions', () => {
 		});
 
 		it('Half bounded range from -> ok', async () => {
-			const from = moment(refTransaction.block.timestamp * 10 ** 3).subtract(1, 'day').unix();;
+			const from = moment(refTransaction.block.timestamp * 10 ** 3).subtract(1, 'day').unix();
 			const response = await requestTransactions({ timestamp: `${from}:` });
 
 			expect(response).toMap(jsonRpcEnvelopeSchema);

--- a/tests/integration/api_v2/rpc/transactions.test.js
+++ b/tests/integration/api_v2/rpc/transactions.test.js
@@ -241,5 +241,89 @@ describe('Method get.transactions', () => {
 			});
 			expect(result.meta).toMap(metaSchema);
 		});
+
+		it('Half bounded range from -> ok', async () => {
+			const from = 0;
+			const response = await requestTransactions({ timestamp: `${from}:` });
+
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.result).toMap(resultEnvelopeSchema);
+			result.data.forEach(transaction => {
+				expect(transaction).toMap(transactionSchemaVersion5);
+				expect(transaction.block.timestamp).toBeGreaterThanOrEqual(from);
+			});
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('Half bounded range to -> ok', async () => {
+			const toTimestamp = refTransaction.block.timestamp;
+			const response = await requestTransactions({ timestamp: `:${toTimestamp}` });
+
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.result).toMap(resultEnvelopeSchema);
+			result.data.forEach(transaction => {
+				expect(transaction).toMap(transactionSchemaVersion5);
+				expect(transaction.block.timestamp).toBeLessThanOrEqual(toTimestamp);
+			});
+			expect(result.meta).toMap(metaSchema);
+		});
+	});
+
+	describe('is able to retrieve list of transactions using amount range', () => {
+		it('min max amount -> ok', async () => {
+			const minAmount = 0;
+			const maxAmount = BigInt(refTransaction.asset.amount);
+			const response = await requestTransactions({ amount: `${minAmount}:${maxAmount}` });
+
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.result).toMap(resultEnvelopeSchema);
+			result.data.forEach(transaction => {
+				expect(transaction).toMap(transactionSchemaVersion5);
+				expect(BigInt(transaction.asset.amount)).toBeGreaterThanOrEqual(minAmount);
+				expect(BigInt(transaction.asset.amount)).toBeLessThanOrEqual(maxAmount);
+			});
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('Half bounded range minAmount -> ok', async () => {
+			const minAmount = 0;
+			const response = await requestTransactions({ amount: `${minAmount}:` });
+
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.result).toMap(resultEnvelopeSchema);
+			result.data.forEach(transaction => {
+				expect(transaction).toMap(transactionSchemaVersion5);
+				expect(BigInt(transaction.asset.amount)).toBeGreaterThanOrEqual(minAmount);
+			});
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('Half bounded range maxAmount -> ok', async () => {
+			const maxAmount = BigInt(refTransaction.asset.amount);
+			const response = await requestTransactions({ amount: `:${maxAmount}` });
+
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.result).toMap(resultEnvelopeSchema);
+			result.data.forEach(transaction => {
+				expect(transaction).toMap(transactionSchemaVersion5);
+				expect(BigInt(transaction.asset.amount)).toBeLessThanOrEqual(maxAmount);
+			});
+			expect(result.meta).toMap(metaSchema);
+		});
 	});
 });

--- a/tests/integration/api_v2/rpc/transactions.test.js
+++ b/tests/integration/api_v2/rpc/transactions.test.js
@@ -13,6 +13,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import moment from 'moment';
+
 const config = require('../../../config');
 const { request } = require('../../../helpers/socketIoRpcRequest');
 
@@ -225,7 +227,7 @@ describe('Method get.transactions', () => {
 
 	describe('is able to retrieve list of transactions using timestamps', () => {
 		it('from to -> ok', async () => {
-			const from = 0;
+			const from = moment(refTransaction.block.timestamp * 10 ** 3).subtract(1, 'day').unix();;
 			const toTimestamp = refTransaction.block.timestamp;
 			const response = await requestTransactions({ timestamp: `${from}:${toTimestamp}` });
 
@@ -244,7 +246,7 @@ describe('Method get.transactions', () => {
 		});
 
 		it('Half bounded range from -> ok', async () => {
-			const from = 0;
+			const from = moment(refTransaction.block.timestamp * 10 ** 3).subtract(1, 'day').unix();;
 			const response = await requestTransactions({ timestamp: `${from}:` });
 
 			expect(response).toMap(jsonRpcEnvelopeSchema);

--- a/tests/integration/api_v2/rpc/transactions.test.js
+++ b/tests/integration/api_v2/rpc/transactions.test.js
@@ -233,6 +233,7 @@ describe('Method get.transactions', () => {
 			const { result } = response;
 			expect(result.data).toBeInstanceOf(Array);
 			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			expect(response.result).toMap(resultEnvelopeSchema);
 			result.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
@@ -250,6 +251,7 @@ describe('Method get.transactions', () => {
 			const { result } = response;
 			expect(result.data).toBeInstanceOf(Array);
 			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			expect(response.result).toMap(resultEnvelopeSchema);
 			result.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
@@ -266,6 +268,7 @@ describe('Method get.transactions', () => {
 			const { result } = response;
 			expect(result.data).toBeInstanceOf(Array);
 			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			expect(response.result).toMap(resultEnvelopeSchema);
 			result.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
@@ -285,6 +288,7 @@ describe('Method get.transactions', () => {
 			const { result } = response;
 			expect(result.data).toBeInstanceOf(Array);
 			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			expect(response.result).toMap(resultEnvelopeSchema);
 			result.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
@@ -302,6 +306,7 @@ describe('Method get.transactions', () => {
 			const { result } = response;
 			expect(result.data).toBeInstanceOf(Array);
 			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			expect(response.result).toMap(resultEnvelopeSchema);
 			result.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);
@@ -318,6 +323,7 @@ describe('Method get.transactions', () => {
 			const { result } = response;
 			expect(result.data).toBeInstanceOf(Array);
 			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
 			expect(response.result).toMap(resultEnvelopeSchema);
 			result.data.forEach(transaction => {
 				expect(transaction).toMap(transactionSchemaVersion5);

--- a/tests/schemas/transaction.schema.js
+++ b/tests/schemas/transaction.schema.js
@@ -59,7 +59,7 @@ const transactionSchemaVersion5 = {
 	fee: Joi.string().required(),
 	height: Joi.number().integer().min(1).required(),
 	nonce: Joi.string().optional(),
-	signatures: Joi.array().items(Joi.string().optional()).required(),
+	signatures: Joi.array().items(Joi.string().allow('').optional()).required(),
 	asset: Joi.object().required(),
 	sender: Joi.object(sender).optional(),
 	block: Joi.object(block).optional(),


### PR DESCRIPTION
### What was the problem?
This PR resolves #435 

### How was it solved?
- [x] Support half bounded ranges for transactions
  - [x] Support for `amount`
  - [x] Support for `timestamp`
- [x] Support half bounded ranges for blocks
  - [x] Support for `height`
  - [x] Support for `timestamp`
- [x] Integration tests for above scenarios:
  - [x] `rpc/http` for transactions
  - [x] `rpc/http` for blocks

### How was it tested?
- [x] Local
- [x] Jenkins