### PR TITLE
Add Bittrex data source - Closes #465

### DIFF
--- a/services/market/config.js
+++ b/services/market/config.js
@@ -1,6 +1,6 @@
 /*
  * LiskHQ/lisk-service
- * Copyright © 2019 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -13,7 +13,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const config = {};
+const config = {
+    endpoints: {},
+};
 
 // Moleculer broker config
 config.transporter = process.env.SERVICE_BROKER || 'redis://localhost:6379/0';
@@ -46,5 +48,10 @@ config.log.file = process.env.SERVICE_LOG_FILE || 'false';
 
 // Set docker host if running inside the container
 config.log.docker_host = process.env.DOCKER_HOST || 'local';
+
+/**
+ * External endpoints
+ */
+config.endpoints.bittrex = 'https://api.bittrex.com/v3';
 
 module.exports = config;

--- a/services/market/config.js
+++ b/services/market/config.js
@@ -52,6 +52,7 @@ config.log.docker_host = process.env.DOCKER_HOST || 'local';
 /**
  * External endpoints
  */
+config.endpoints.redis = process.env.SERVICE_MARKET_REDIS || 'redis://localhost:6379/2';
 config.endpoints.bittrex = 'https://api.bittrex.com/v3';
 
 module.exports = config;

--- a/services/market/jobs/updatePricesBittrex.js
+++ b/services/market/jobs/updatePricesBittrex.js
@@ -1,6 +1,6 @@
 /*
  * LiskHQ/lisk-service
- * Copyright © 2019 Lisk Foundation
+ * Copyright © 2021 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -17,10 +17,11 @@ const logger = require('lisk-service-framework').Logger();
 
 module.exports = [
 	{
-		name: 'job.1',
-		description: 'Generic job template',
+		name: 'prices.retrieve.bittrex',
+		description: 'Fetches up-to-date market prices from Bittrex',
 		schedule: '* * * * *', // Every 1 min
 		controller: () => {
+			// TODO: Implement
 			const operationResult = (() => ([1, 2, 3, 4, 5]))();
 			logger.info(`Dummy job is done, processed ${operationResult.length} items`);
 		},

--- a/services/market/jobs/updatePricesBittrex.js
+++ b/services/market/jobs/updatePricesBittrex.js
@@ -14,16 +14,20 @@
  *
  */
 const logger = require('lisk-service-framework').Logger();
+const { reloadPricesFromBittrex } = require('../shared/market/sources');
 
 module.exports = [
 	{
 		name: 'prices.retrieve.bittrex',
 		description: 'Fetches up-to-date market prices from Bittrex',
 		schedule: '* * * * *', // Every 1 min
-		controller: () => {
-			// TODO: Implement
-			const operationResult = (() => ([1, 2, 3, 4, 5]))();
-			logger.info(`Dummy job is done, processed ${operationResult.length} items`);
+		init: async () => {
+			logger.debug('Initializing market prices from Bittrex');
+			await reloadPricesFromBittrex();
+		},
+		controller: async () => {
+			logger.debug('Updating market prices from Bittrex');
+			await reloadPricesFromBittrex();
 		},
 	},
 ];

--- a/services/market/package-lock.json
+++ b/services/market/package-lock.json
@@ -1569,6 +1569,11 @@
         }
       }
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",

--- a/services/market/package-lock.json
+++ b/services/market/package-lock.json
@@ -215,6 +215,11 @@
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",

--- a/services/market/package.json
+++ b/services/market/package.json
@@ -30,6 +30,7 @@
     "watch": "supervisor -w . -i ./node_modules app.js"
   },
   "dependencies": {
+    "bluebird": "^3.7.2",
     "lisk-service-framework": "http://static-data.lisk.io/lisk-service-framework-1.0.0-beta.0.tgz",
     "node-cron": "=2.0.3"
   },

--- a/services/market/package.json
+++ b/services/market/package.json
@@ -31,6 +31,7 @@
     "test:functional": "./node_modules/.bin/jest --config=jest.config.functional.js --detectOpenHandles --forceExit"
   },
   "dependencies": {
+    "bluebird": "^3.7.2",
     "joi": "^17.4.0",
     "lisk-service-framework": "https://github.com/LiskHQ/lisk-service/raw/ef65aa995325768e00248a97a6febd6a346b7027/framework/dist/lisk-service-framework-1.0.2.tgz",
     "moleculer": "^0.14.13",

--- a/services/market/shared/market/index.js
+++ b/services/market/shared/market/index.js
@@ -15,7 +15,6 @@
  */
 const { getMarketPrices } = require('./market');
 
-
 module.exports = {
     getMarketPrices,
 };

--- a/services/market/shared/market/sources/bittrex.js
+++ b/services/market/shared/market/sources/bittrex.js
@@ -1,0 +1,72 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const { HTTP, Logger } = require('lisk-service-framework');
+
+const requestLib = HTTP.request;
+const logger = Logger();
+
+const config = require('../../../config.js');
+
+const apiEndpoint = config.endpoints.bittrex;
+
+const symbolMap = {
+    LSK_BTC: 'LSK-BTC',
+    BTC_USD: 'BTC-USD',
+    BTC_EUR: 'BTC-EUR',
+};
+
+const fetchAllMarketTickers = async () => {
+    try {
+        const response = await requestLib(`${apiEndpoint}/markets/tickers`);
+        if (typeof response === 'string') return JSON.parse(response).data;
+        return response.data;
+    } catch (err) {
+        logger.error(err.message);
+        logger.error(err.stack);
+        return err;
+    }
+};
+
+const filterTickers = (tickers) => {
+    const allowedMarketSymbols = Object.values(symbolMap);
+    const filteredTickers = tickers.filter(ticker => allowedMarketSymbols.includes(ticker.symbol));
+    return filteredTickers;
+};
+
+const standardizeTickers = (tickers) => {
+    const transformedPrices = Object.entries(symbolMap).map(([k, v]) => {
+        const [currentTicker] = tickers.filter(ticker => ticker.symbol === v);
+        const [from, to] = k.split('_');
+        const price = {
+            code: k,
+            from,
+            to,
+            rate: currentTicker.lastTradeRate,
+            sources: ['bittrex'],
+        };
+        return price;
+    });
+    return transformedPrices;
+};
+
+const getLatestMarketPrices = async () => {
+    const tickers = await fetchAllMarketTickers();
+    const filteredTickers = filterTickers(tickers);
+    const transformedPrices = standardizeTickers(filteredTickers);
+    return transformedPrices;
+};
+
+module.exports = getLatestMarketPrices;

--- a/services/market/shared/market/sources/bittrex.js
+++ b/services/market/shared/market/sources/bittrex.js
@@ -73,10 +73,8 @@ const reloadPricesFromBittrex = async () => {
     return transformedPrices;
 };
 
-const getPricesFromBittrex = async () => {
-    // TODO: Read from cache, when implemented
-    return reloadPricesFromBittrex();
-};
+// TODO: Read from cache, when implemented
+const getPricesFromBittrex = async () => reloadPricesFromBittrex();
 
 module.exports = {
     reloadPricesFromBittrex,

--- a/services/market/shared/market/sources/bittrex.js
+++ b/services/market/shared/market/sources/bittrex.js
@@ -55,7 +55,7 @@ const standardizeTickers = (tickers) => {
             from,
             to,
             rate: currentTicker.lastTradeRate,
-            updateTimestamp: Date.now(),
+            updateTimestamp: Math.floor(Date.now() / 1000),
             sources: ['bittrex'],
         };
         return price;
@@ -63,11 +63,22 @@ const standardizeTickers = (tickers) => {
     return transformedPrices;
 };
 
-const getLatestMarketPrices = async () => {
+const reloadPricesFromBittrex = async () => {
     const tickers = await fetchAllMarketTickers();
     const filteredTickers = filterTickers(tickers);
     const transformedPrices = standardizeTickers(filteredTickers);
+
+    // TODO: Write to the cache
+
     return transformedPrices;
 };
 
-module.exports = getLatestMarketPrices;
+const getPricesFromBittrex = async () => {
+    // TODO: Read from cache, when implemented
+    return reloadPricesFromBittrex();
+};
+
+module.exports = {
+    reloadPricesFromBittrex,
+    getPricesFromBittrex,
+};

--- a/services/market/shared/market/sources/bittrex.js
+++ b/services/market/shared/market/sources/bittrex.js
@@ -55,6 +55,7 @@ const standardizeTickers = (tickers) => {
             from,
             to,
             rate: currentTicker.lastTradeRate,
+            updateTimestamp: Date.now(),
             sources: ['bittrex'],
         };
         return price;

--- a/services/market/shared/market/sources/index.js
+++ b/services/market/shared/market/sources/index.js
@@ -13,9 +13,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { getMarketPrices } = require('./market');
-
+const { getPricesFromBittrex, reloadPricesFromBittrex } = require('./bittrex');
 
 module.exports = {
-    getMarketPrices,
+    getPricesFromBittrex,
+    reloadPricesFromBittrex,
 };

--- a/services/market/shared/market/sources/index.js
+++ b/services/market/shared/market/sources/index.js
@@ -16,6 +16,6 @@
 const { getPricesFromBittrex, reloadPricesFromBittrex } = require('./bittrex');
 
 module.exports = {
-    getPricesFromBittrex,
     reloadPricesFromBittrex,
+    getPricesFromBittrex,
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #465 

### How was it solved?
- [x] Create job `prices.retrieve.bittrex` to retrieve data from `bittrex` API
- [x] Transform price data as per the requirement
- [x] Store/update transformed data from `bittrex` into `redis` cache with every update
- [x] Add method `getPricesFromBittrex` to retrieve latest prices from the cache

### How was it tested?
Local + Jenkins
