### PR TITLE
Update reclaim transaction warning - Closes #532

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -75,7 +75,7 @@ const getAccountByAddress = async address => {
 		const account = await apiClient.account.get(address);
 		return { data: [account] };
 	} catch (err) {
-		logger.warn(`Unable to currently fetch account information for address: ${address}. Network synchronization process might still be in progress for the Lisk Core node or the requested account has not been migrated yet.`);
+		logger.warn(`Unable to currently fetch account information for address: ${address}. The network synchronization process might still be in progress for the Lisk Core node or the requested account has not been migrated yet.`);
 		throw new Error('MISSING_ACCOUNT_IN_BLOCKCHAIN');
 	}
 };

--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -75,7 +75,7 @@ const getAccountByAddress = async address => {
 		const account = await apiClient.account.get(address);
 		return { data: [account] };
 	} catch (err) {
-		logger.warn(`Unable to currently fetch account information for address: ${address}. Network synchronization process might still be in progress for the Lisk Core node.`);
+		logger.warn(`Unable to currently fetch account information for address: ${address}. Network synchronization process might still be in progress for the Lisk Core node or the requested account has not been migrated yet.`);
 		throw new Error('MISSING_ACCOUNT_IN_BLOCKCHAIN');
 	}
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #532 

### How was it solved?
- [x] Update warn message to `Unable to currently fetch account information for address: ed3acca20c228ed8fb892a7df9030b5c40840653. Network synchronization process might still be in progress for the Lisk Core node or the requested account has not been migrated yet.
`

### How was it tested?
- [x] Local
