### PR TITLE
Add support for HTTP ETag - Closes #443

### DIFF
--- a/services/gateway/app.js
+++ b/services/gateway/app.js
@@ -77,6 +77,7 @@ broker.createService({
 		host,
 		port,
 		path: '/api',
+		etag: 'strong',
 		use: [],
 
 		cors: {


### PR DESCRIPTION
### What was the problem?
This PR resolves #443 

### How was it solved?
- [x] ETag is generated and added to the response.

### How was it tested?
- [x] Local (tested different scenarios)
