### PR TITLE
Fix delegate properties - Closes #550

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -46,11 +46,13 @@ const coreApi = require('./coreApi');
 const mysqlIndex = require('../../../indexdb/mysql');
 
 const accountsIndexSchema = require('./schema/accounts');
+const blocksIndexSchema = require('./schema/blocks');
 const transactionsIndexSchema = require('./schema/transactions');
 
 const { ValidationException } = require('../../../exceptions');
 
 const getAccountsIndex = () => mysqlIndex('accounts', accountsIndexSchema);
+const getBlocksIndex = () => mysqlIndex('blocks', blocksIndexSchema);
 const getTransactionsIndex = () => mysqlIndex('transactions', transactionsIndexSchema);
 
 // A boolean mapping against the genesis account addresses to indicate migration status
@@ -146,6 +148,10 @@ const resolveDelegateInfo = async accounts => {
 		accounts,
 		async account => {
 			if (account.isDelegate) {
+				const blocksDB = await getBlocksIndex();
+				const transactionsDB = await getTransactionsIndex();
+				const delegateRegTxModuleAssetId = '5:0';
+
 				account.account = {
 					address: account.address,
 					publicKey: account.publicKey,
@@ -156,8 +162,8 @@ const resolveDelegateInfo = async accounts => {
 						rewards,
 						producedBlocks,
 					} = await getIndexedAccountInfo({ publicKey: account.publicKey });
-					account.rewards = rewards;
-					account.producedBlocks = producedBlocks;
+					account.rewards = rewards || 0;
+					account.producedBlocks = producedBlocks || 0;
 				}
 
 				const adder = (acc, curr) => BigInt(acc) + BigInt(curr.amount);
@@ -176,6 +182,22 @@ const resolveDelegateInfo = async accounts => {
 				account.pomHeights = account.dpos.delegate.pomHeights
 					.sort((a, b) => b - a).slice(0, 5)
 					.map(height => ({ start: height, end: height + punishmentHeight }));
+
+				[delegateRegTx = {}] = await transactionsDB.find({
+					senderPublicKey: account.publicKey,
+					moduleAssetId: delegateRegTxModuleAssetId,
+				});
+
+				[lastForgedBlock = {}] = await blocksDB.find({
+					generatorPublicKey: account.publicKey,
+					limit: 1,
+				});
+
+				account.dpos.delegate = {
+					...account.dpos.delegate,
+					registrationHeight: delegateRegTx.height || null,
+					lastForgedHeight: lastForgedBlock.height || null,
+				};
 			}
 			return account;
 		},

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -183,12 +183,12 @@ const resolveDelegateInfo = async accounts => {
 					.sort((a, b) => b - a).slice(0, 5)
 					.map(height => ({ start: height, end: height + punishmentHeight }));
 
-				[delegateRegTx = {}] = await transactionsDB.find({
+				const [delegateRegTx = {}] = await transactionsDB.find({
 					senderPublicKey: account.publicKey,
 					moduleAssetId: delegateRegTxModuleAssetId,
 				});
 
-				[lastForgedBlock = {}] = await blocksDB.find({
+				const [lastForgedBlock = {}] = await blocksDB.find({
 					generatorPublicKey: account.publicKey,
 					limit: 1,
 				});

--- a/services/gateway/sources/version2/mappings/account.js
+++ b/services/gateway/sources/version2/mappings/account.js
@@ -57,6 +57,7 @@ module.exports = {
 				end: '=,number',
 			}],
 			consecutiveMissedBlocks: '=,number',
+			registrationHeight: '=,number',
 			lastForgedHeight: '=,number',
 			isBanned: '=,boolean',
 			totalVotesReceived: '=,string',
@@ -81,7 +82,6 @@ module.exports = {
 		}],
 	},
 	legacy: {
-		// TODO: Verify field mappings with e2e setup
 		address: 'legacy.address,string',
 		balance: 'legacy.balance,string',
 	},

--- a/services/market/shared/market/priceUpdater.js
+++ b/services/market/shared/market/priceUpdater.js
@@ -97,6 +97,8 @@ const calcTargetPairPrices = (rawPricesBySource, targetPairings = targetPairs) =
 						}
 					});
 			}
+			// Prefer a direct targetPair match from the source prices over calculated rates
+			finalPrices[targetPair].sort((a, b) => a.sources.length - b.sources.length);
 		});
 	});
 

--- a/services/market/tests/unit/pricesUpdater.test.js
+++ b/services/market/tests/unit/pricesUpdater.test.js
@@ -65,8 +65,8 @@ describe('Market prices', () => {
 		]);
 
 		expect(targetPairPrices.BTC_USD).toEqual([
-			{ code: 'BTC_USD', from: 'BTC', to: 'USD', rate: '34770.0000', updateTimestamp: 1622414485, sources: ['cx1', 'fx1'] },
 			{ code: 'BTC_USD', from: 'BTC', to: 'USD', rate: '35000.0000', updateTimestamp: 1622414485, sources: ['cx2'] },
+			{ code: 'BTC_USD', from: 'BTC', to: 'USD', rate: '34770.0000', updateTimestamp: 1622414485, sources: ['cx1', 'fx1'] },
 		]);
 
 		expect(targetPairPrices.BTC_CHF).toEqual([

--- a/tests/schemas/api_v2/account.schema.js
+++ b/tests/schemas/api_v2/account.schema.js
@@ -32,6 +32,7 @@ const delegateSchema = {
 	isBanned: Joi.boolean().optional(),
 	status: Joi.string().valid(...validDelegateStatuses).optional(),
 	pomHeights: Joi.array().items(pomHeightSchema).optional(),
+	registrationHeight: Joi.number().integer().min(0).optional(),
 	lastForgedHeight: Joi.number().integer().min(0).optional(),
 	consecutiveMissedBlocks: Joi.number().integer().optional(),
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #550 

### How was it solved?
- [x] `producedBlocks` is set to `0` for non-forging delegate accounts
- [x]  `rewards` is set to `0` for non-forging delegate accounts
- [x] `registrationHeight` is now returned for delegate accounts
- [x] `lastForgedHeight` is set to `null` for non-forging delegates
- [x] `lastForgedHeight` is set based on the `blocks` index
- [x] `registrationHeight` is returned only after the complete blockchain is successfully indexed
- [x] `registrationHeight` for a delegate defaults to the genesis block height, if no delegate registration transaction is available in the index
- [x] Set higher preference for a direct `targetPair` match from the source prices over calculated rates

### How was it tested?
Local + Jenkins
