### PR TITLE
Fix lastForgedHeight retrieval - Closes #610

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -179,6 +179,7 @@ const resolveDelegateInfo = async accounts => {
 
 				const [lastForgedBlock = {}] = await blocksDB.find({
 					generatorPublicKey: account.publicKey,
+					sort: 'height:desc',
 					limit: 1,
 				});
 				account.dpos.delegate.lastForgedHeight = lastForgedBlock.height || null;


### PR DESCRIPTION
### What was the problem?
This PR resolves #610 

### How was it solved?
- [x] Add sort as `height:desc` to get last forged block

### How was it tested?
- [x] Local
- [x] Jenkins
