### PR TITLE
Add support for HTTP 'Cache-Control' - Closes #632

### DIFF
--- a/docker/lisk-service/env/gateway.env
+++ b/docker/lisk-service/env/gateway.env
@@ -5,3 +5,7 @@ HOST=0.0.0.0
 # Enabled APIs
 ENABLE_HTTP_API=http-version1,http-version1-compat,http-status,http-version2
 ENABLE_WS_API=rpc,rpc-v1,blockchain,rpc-v2
+
+# HTTP API caching config
+ENABLE_HTTP_CACHE_CONTROL=false
+HTTP_CACHE_CONTROL_DIRECTIVES=public,max-age=10

--- a/services/gateway/config.js
+++ b/services/gateway/config.js
@@ -66,6 +66,12 @@ config.api.versions = {
 	'/api/v2': 'http-version2',
 };
 
+/**
+ * HTTP API response caching support
+ */
+config.api.httpCacheControlDirectives = String(process.env.HTTP_CACHE_CONTROL_DIRECTIVES || 'public, max-age=10');
+config.api.enableHttpCacheControl = Boolean(String(process.env.ENABLE_HTTP_CACHE_CONTROL).toLowerCase() === 'true');
+
 // Unless STRICT_READINESS_CHECK env. variable is set false, includeCoreReadiness evaluates to true
 config.includeCoreReadiness = Boolean(String(process.env.STRICT_READINESS_CHECK).toLowerCase() !== 'false');
 

--- a/services/gateway/shared/registerHttpApi.js
+++ b/services/gateway/shared/registerHttpApi.js
@@ -188,7 +188,8 @@ const registerApi = (apiName, config) => {
 		},
 
 		async onAfterCall(ctx, route, req, res, data) {
-			// TODO: Add support for ETag
+			// Set 'Cache-Control' to assist response caching
+			ctx.meta.$responseHeaders = { 'Cache-Control': 'public, max-age=10' };
 
 			if (data.data && data.status) {
 				if (data.status === 'INVALID_PARAMS') data.status = 'BAD_REQUEST';

--- a/services/gateway/shared/registerHttpApi.js
+++ b/services/gateway/shared/registerHttpApi.js
@@ -21,6 +21,7 @@ const {
 } = require('lisk-service-framework');
 
 const path = require('path');
+const gatewayConfig = require('../config');
 const mapper = require('./customMapper');
 const { validate, dropEmptyProps } = require('./paramValidator');
 
@@ -188,8 +189,10 @@ const registerApi = (apiName, config) => {
 		},
 
 		async onAfterCall(ctx, route, req, res, data) {
-			// Set 'Cache-Control' to assist response caching
-			ctx.meta.$responseHeaders = { 'Cache-Control': 'public, max-age=10' };
+			if (gatewayConfig.api.enableHttpCacheControl) {
+				// Set 'Cache-Control' to assist response caching
+				ctx.meta.$responseHeaders = { 'Cache-Control': gatewayConfig.api.httpCacheControlDirectives };
+			}
 
 			if (data.data && data.status) {
 				if (data.status === 'INVALID_PARAMS') data.status = 'BAD_REQUEST';


### PR DESCRIPTION
### What was the problem?
This PR resolves #632 

### How was it solved?
- [x] Add `Cache-Control` header to the API response
- [x] Add switch to enable (disabled by default) the header in the response
- [x] Add environment variable to allow customization of the `Cache-Control` directives
- [x] Update docker environment file to include the above variables

### How was it tested?
Local
