### PR TITLE
Update genesis block retrieval configuration - Closes #640

### DIFF
--- a/services/core/.dockerignore
+++ b/services/core/.dockerignore
@@ -64,3 +64,6 @@ db_data
 
 # Benchmark directory
 benchmark
+
+# Data download directory
+data

--- a/services/core/.gitignore
+++ b/services/core/.gitignore
@@ -61,5 +61,5 @@ xunit-report.xml
 # Embedded DB directory
 db_data
 
-# Genesis block download
-shared/core/compat/sdk_v5/static
+# Data download directory
+data

--- a/services/core/config.js
+++ b/services/core/config.js
@@ -36,6 +36,21 @@ config.endpoints.geoip = process.env.GEOIP_JSON || 'https://geoip.lisk.io/json';
 config.endpoints.mysql = process.env.SERVICE_CORE_MYSQL || 'mysql://lisk:password@localhost:3306/lisk';
 config.endpoints.genesisBlock = process.env.GENESIS_BLOCK_URL || 'https://downloads.lisk.io/lisk/mainnet/genesis_block.json.tar.gz';
 
+config.network = [
+	{
+		name: 'mainnet',
+		identifier: 'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511',
+		genesisHeight: Number(process.env.GENESIS_HEIGHT || 0),
+		genesisBlockUrl: 'https://downloads.lisk.io/lisk/mainnet/genesis_block.json.tar.gz',
+	},
+	{
+		name: 'testnet',
+		identifier: '15f0dacc1060e91818224a94286b13aa04279c640bd5d6f193182031d133df7c',
+		genesisHeight: 14075260,
+		genesisBlockUrl: 'https://downloads.lisk.io/lisk/testnet/genesis_block.json.tar.gz',
+	},
+];
+
 /**
  * Indexing
  *
@@ -48,7 +63,6 @@ config.endpoints.genesisBlock = process.env.GENESIS_BLOCK_URL || 'https://downlo
  * such as transactions, accounts, votes etc.
  */
 config.indexNumOfBlocks = Number(process.env.INDEX_N_BLOCKS || 202);
-config.genesisHeight = Number(process.env.GENESIS_HEIGHT || 0);
 
 config.transactionStatistics = {
 	enabled: Boolean(String(process.env.ENABLE_TRANSACTION_STATS).toLowerCase() === 'true'),

--- a/services/core/config.js
+++ b/services/core/config.js
@@ -34,20 +34,19 @@ config.endpoints.redis = process.env.SERVICE_CORE_REDIS || 'redis://localhost:63
 config.endpoints.liskStatic = process.env.LISK_STATIC || 'https://static-data.lisk.io';
 config.endpoints.geoip = process.env.GEOIP_JSON || 'https://geoip.lisk.io/json';
 config.endpoints.mysql = process.env.SERVICE_CORE_MYSQL || 'mysql://lisk:password@localhost:3306/lisk';
-config.endpoints.genesisBlock = process.env.GENESIS_BLOCK_URL || 'https://downloads.lisk.io/lisk/mainnet/genesis_block.json.tar.gz';
 
 config.network = [
 	{
 		name: 'mainnet',
 		identifier: '022097430f51c10da3146920f4c82005900ce5da83bd5d92c04dec2645e54325',
 		genesisHeight: Number(process.env.GENESIS_HEIGHT || 0),
-		genesisBlockUrl: 'https://downloads.lisk.io/lisk/mainnet/genesis_block.json.tar.gz',
+		genesisBlockUrl: process.env.GENESIS_BLOCK_URL || 'https://downloads.lisk.io/lisk/mainnet/genesis_block.json.tar.gz',
 	},
 	{
 		name: 'testnet',
 		identifier: '15f0dacc1060e91818224a94286b13aa04279c640bd5d6f193182031d133df7c',
-		genesisHeight: 14075260,
-		genesisBlockUrl: 'https://downloads.lisk.io/lisk/testnet/genesis_block.json.tar.gz',
+		genesisHeight: Number(process.env.GENESIS_HEIGHT || 14075260),
+		genesisBlockUrl: process.env.GENESIS_BLOCK_URL || 'https://downloads.lisk.io/lisk/testnet/genesis_block.json.tar.gz',
 	},
 ];
 

--- a/services/core/config.js
+++ b/services/core/config.js
@@ -39,7 +39,7 @@ config.endpoints.genesisBlock = process.env.GENESIS_BLOCK_URL || 'https://downlo
 config.network = [
 	{
 		name: 'mainnet',
-		identifier: 'ed14889723f24ecc54871d058d98ce91ff2f973192075c0155ba2b7b70ad2511',
+		identifier: '022097430f51c10da3146920f4c82005900ce5da83bd5d92c04dec2645e54325',
 		genesisHeight: Number(process.env.GENESIS_HEIGHT || 0),
 		genesisBlockUrl: 'https://downloads.lisk.io/lisk/mainnet/genesis_block.json.tar.gz',
 	},

--- a/services/core/package-lock.json
+++ b/services/core/package-lock.json
@@ -2830,6 +2830,15 @@
       "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://npm.lisk.io/abab/-/abab-2.0.5.tgz",
@@ -3329,6 +3338,19 @@
         }
       }
     },
+    "big-json": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/big-json/-/big-json-3.1.0.tgz",
+      "integrity": "sha512-Xfzbp/LWMgOg41eO72u+TJnUflNsZf1U/Yhw9kNHP4J418xKzAxdVT5aHbZBQcAtjBj6KZasPefeAWclHyKrpQ==",
+      "requires": {
+        "JSONStream": "^1.3.1",
+        "assert-plus": "^1.0.0",
+        "into-stream": "^5.1.0",
+        "json-stream-stringify": "^2.0.1",
+        "once": "^1.4.0",
+        "through2": "^3.0.1"
+      }
+    },
     "big-number": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/big-number/-/big-number-2.0.0.tgz",
@@ -3341,7 +3363,7 @@
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "https://npm.lisk.io/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "optional": true,
       "requires": {
@@ -4793,6 +4815,15 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -5235,6 +5266,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
+    },
+    "into-stream": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
+      "integrity": "sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==",
+      "requires": {
+        "from2": "^2.3.0",
+        "p-is-promise": "^3.0.0"
+      }
     },
     "ioredis": {
       "version": "4.27.1",
@@ -8329,6 +8369,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-stream-stringify": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-2.0.3.tgz",
+      "integrity": "sha512-Ry+1rZE1YVKlCMG1emCiReP/OfZrFrEGZn6TC7NPpIGO9NXf0KEqqBL0flgt2J59EiRPv+CKi7S7v31RAHrdXw=="
+    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -8350,6 +8395,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -9501,6 +9551,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+      "integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ=="
     },
     "p-limit": {
       "version": "2.3.0",
@@ -11259,6 +11314,22 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "2 || 3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
+      }
     },
     "tildify": {
       "version": "2.0.0",

--- a/services/core/package.json
+++ b/services/core/package.json
@@ -34,6 +34,7 @@
     "@liskhq/lisk-transactions-v4": "npm:@liskhq/lisk-transactions@^4.0.0",
     "@liskhq/lisk-transactions-v5": "npm:@liskhq/lisk-transactions@^5.0.3",
     "async": "^3.2.0",
+    "big-json": "^3.1.0",
     "big-number": "=2.0.0",
     "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",

--- a/services/core/shared/arrayUtils.js
+++ b/services/core/shared/arrayUtils.js
@@ -1,0 +1,20 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2021 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const dropDuplicates = arr => arr.filter((v, i, a) => a.findIndex(t => (t === v)) === i);
+
+module.exports = {
+	dropDuplicates,
+};

--- a/services/core/shared/core/compat/common/constants.js
+++ b/services/core/shared/core/compat/common/constants.js
@@ -13,13 +13,17 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { Utils } = require('lisk-service-framework');
+const { CacheRedis, Utils } = require('lisk-service-framework');
 
 const http = require('./httpRequest');
 const { getApiClient } = require('./wsRequest');
 
 const ObjectUtilService = Utils.Data;
 const { isProperObject } = ObjectUtilService;
+
+const config = require('../../../../config');
+
+const constantsCache = CacheRedis('networkConstants', config.endpoints.redis);
 
 let coreVersion = '1.0.0-alpha.0';
 let constants;
@@ -82,6 +86,7 @@ const getNetworkConstants = async () => {
 			}
 			if (!isProperObject(result)) return {};
 			constants = result;
+			await constantsCache.set('networkConstants', JSON.stringify(constants));
 		}
 		return constants;
 	} catch (_) {

--- a/services/core/shared/core/compat/common/wsRequest.js
+++ b/services/core/shared/core/compat/common/wsRequest.js
@@ -33,11 +33,11 @@ const instantiateClient = async () => {
 				isInstantiating = true;
 				if (clientCache) await clientCache.disconnect();
 				clientCache = await createWSClient(`${liskAddress}/ws`);
+				isInstantiating = false;
 
 				// Inform listeners about the newly created ApiClient
 				logger.debug(`============== 'newApiClient' signal: ${Signals.get('newApiClient')} ==============`);
 				Signals.get('newApiClient').dispatch();
-				isInstantiating = false;
 			}
 			return clientCache;
 		}

--- a/services/core/shared/core/compat/common/wsRequest.js
+++ b/services/core/shared/core/compat/common/wsRequest.js
@@ -33,11 +33,11 @@ const instantiateClient = async () => {
 				isInstantiating = true;
 				if (clientCache) await clientCache.disconnect();
 				clientCache = await createWSClient(`${liskAddress}/ws`);
-				isInstantiating = false;
 
 				// Inform listeners about the newly created ApiClient
 				logger.debug(`============== 'newApiClient' signal: ${Signals.get('newApiClient')} ==============`);
 				Signals.get('newApiClient').dispatch();
+				isInstantiating = false;
 			}
 			return clientCache;
 		}

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -41,6 +41,10 @@ const {
 } = require('../../queue');
 
 const {
+	dropDuplicates,
+} = require('../../../arrayUtils');
+
+const {
 	parseToJSONCompatObj,
 } = require('../../../jsonTools');
 
@@ -109,8 +113,7 @@ const getAccountsFromCore = async (params) => {
 
 const indexAccountsbyAddress = async (addressesToIndex, isGenesisBlockAccount = false) => {
 	const { data: accountsToIndex } = await getAccountsFromCore({
-		addresses: addressesToIndex
-			.filter((v, i, a) => a.findIndex(t => (t === v)) === i), // Remove duplicates
+		addresses: dropDuplicates(addressesToIndex),
 	});
 	const finalAccountsToIndex = await BluebirdPromise.map(
 		accountsToIndex,
@@ -226,9 +229,8 @@ const indexAccountsbyPublicKey = async (accountInfoArray) => {
 	const accountsDB = await getAccountsIndex();
 
 	const { data: accountsToIndex } = await getAccountsFromCore({
-		addresses: accountInfoArray
-			.map(accountInfo => getHexAddressFromPublicKey(accountInfo.publicKey))
-			.filter((v, i, a) => a.findIndex(t => (t === v)) === i), // Remove duplicates
+		addresses: dropDuplicates(accountInfoArray
+			.map(accountInfo => getHexAddressFromPublicKey(accountInfo.publicKey))),
 	});
 
 	const finalAccountsToIndex = await BluebirdPromise.map(

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -108,7 +108,10 @@ const getAccountsFromCore = async (params) => {
 };
 
 const indexAccountsbyAddress = async (addressesToIndex, isGenesisBlockAccount = false) => {
-	const { data: accountsToIndex } = await getAccountsFromCore({ addresses: addressesToIndex });
+	const { data: accountsToIndex } = await getAccountsFromCore({
+		addresses: addressesToIndex
+			.filter((v, i, a) => a.findIndex(t => (t === v)) === i), // Remove duplicates
+	});
 	const finalAccountsToIndex = await BluebirdPromise.map(
 		accountsToIndex,
 		async account => {
@@ -224,7 +227,8 @@ const indexAccountsbyPublicKey = async (accountInfoArray) => {
 
 	const { data: accountsToIndex } = await getAccountsFromCore({
 		addresses: accountInfoArray
-			.map(accountInfo => getHexAddressFromPublicKey(accountInfo.publicKey)),
+			.map(accountInfo => getHexAddressFromPublicKey(accountInfo.publicKey))
+			.filter((v, i, a) => a.findIndex(t => (t === v)) === i), // Remove duplicates
 	});
 
 	const finalAccountsToIndex = await BluebirdPromise.map(

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -534,7 +534,7 @@ const checkIndexReadiness = async () => {
 				logger.debug('Blocks index is not yet ready');
 			}
 		} catch (err) {
-			logger.warn(`Error at checkIndexReadiness: ${err.message}`);
+			logger.warn(`Error while checking index readiness: ${err.message}`);
 		}
 	}
 	return getIndexReadyStatus();

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -513,24 +513,28 @@ const indexPastBlocks = async () => {
 const checkIndexReadiness = async () => {
 	logger.debug('============== Checking blocks index ready status ==============');
 	if (!getIndexReadyStatus()) {
-		const blocksDB = await getBlocksIndex();
-		const currentChainHeight = (await coreApi.getNetworkStatus()).data.height;
-		const numBlocksIndexed = await blocksDB.count();
-		const [lastIndexedBlock] = await blocksDB.find({ sort: 'height:desc', limit: 1 });
+		try {
+			const blocksDB = await getBlocksIndex();
+			const currentChainHeight = (await coreApi.getNetworkStatus()).data.height;
+			const numBlocksIndexed = await blocksDB.count();
+			const [lastIndexedBlock] = await blocksDB.find({ sort: 'height:desc', limit: 1 });
 
-		logger.debug(
-			`\nnumBlocksIndexed: ${numBlocksIndexed}`,
-			`\nlastIndexedBlock: ${lastIndexedBlock.height}`,
-			`\ncurrentChainHeight: ${currentChainHeight}`,
-		);
-		if (numBlocksIndexed >= currentChainHeight - genesisHeight
-			&& lastIndexedBlock.height >= currentChainHeight - 1) {
-			setIndexReadyStatus(true);
-			logger.info('Blocks index is now ready');
-			logger.debug(`============== 'blockIndexReady' signal: ${Signals.get('blockIndexReady')} ==============`);
-			Signals.get('blockIndexReady').dispatch(true);
-		} else {
-			logger.debug('Blocks index is not yet ready');
+			logger.debug(
+				`\nnumBlocksIndexed: ${numBlocksIndexed}`,
+				`\nlastIndexedBlock: ${lastIndexedBlock.height}`,
+				`\ncurrentChainHeight: ${currentChainHeight}`,
+			);
+			if (numBlocksIndexed >= currentChainHeight - genesisHeight
+				&& lastIndexedBlock.height >= currentChainHeight - 1) {
+				setIndexReadyStatus(true);
+				logger.info('Blocks index is now ready');
+				logger.debug(`============== 'blockIndexReady' signal: ${Signals.get('blockIndexReady')} ==============`);
+				Signals.get('blockIndexReady').dispatch(true);
+			} else {
+				logger.debug('Blocks index is not yet ready');
+			}
+		} catch (err) {
+			logger.warn(`Error at checkIndexReadiness: ${err.message}`);
 		}
 	}
 	return getIndexReadyStatus();

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -378,9 +378,7 @@ const indexGenesisBlock = async () => {
 		.filter(account => account.address.length > 16) // Filter out reclaim accounts
 		.map(account => account.address);
 
-	const accountAddressesToIndex = initDelegateAddresses
-		.concat(nonDelegateAddressesToIndex)
-		.filter((v, i, a) => a.findIndex(t => (t === v)) === i); // Remove duplicates
+	const accountAddressesToIndex = initDelegateAddresses.concat(nonDelegateAddressesToIndex);
 
 	const PAGE_SIZE = 20;
 	const NUM_PAGES = Math.ceil(accountAddressesToIndex.length / PAGE_SIZE);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -41,7 +41,6 @@ const {
 
 const {
 	getApiClient,
-	getNetworkConstants,
 	getIndexReadyStatus,
 	setIndexReadyStatus,
 	setIsSyncFullBlockchain,
@@ -487,13 +486,13 @@ const indexMissingBlocks = async (startHeight, endHeight) => {
 };
 
 const indexPastBlocks = async () => {
-	logger.info('Building index of blocks');
+	logger.info('Building the blocks index');
 	const blocksDB = await getBlocksIndex();
 
 	if (config.indexNumOfBlocks === 0) setIsSyncFullBlockchain(true);
 
 	// Lowest and highest block heights expected to be indexed
-	const blockIndexHigherRange = (await getNetworkConstants()).data.height;
+	const blockIndexHigherRange = (await coreApi.getNetworkStatus()).data.height;
 	const blockIndexLowerRange = config.indexNumOfBlocks > 0
 		? blockIndexHigherRange - config.indexNumOfBlocks : genesisHeight;
 
@@ -509,6 +508,7 @@ const indexPastBlocks = async () => {
 	// Start building the block index
 	await buildIndex(highestIndexedHeight, blockIndexHigherRange);
 	await indexMissingBlocks(blockIndexLowerRange, blockIndexHigherRange);
+	logger.info('Finished building the blocks index');
 };
 
 const checkIndexReadiness = async () => {

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -16,7 +16,6 @@
 const BluebirdPromise = require('bluebird');
 const util = require('util');
 const {
-	CacheRedis,
 	Logger,
 	Signals,
 	Exceptions: { ValidationException, NotFoundException },
@@ -42,6 +41,7 @@ const {
 
 const {
 	getApiClient,
+	getNetworkConstants,
 	getIndexReadyStatus,
 	setIndexReadyStatus,
 	setIsSyncFullBlockchain,
@@ -54,8 +54,6 @@ const mysqlIndex = require('../../../indexdb/mysql');
 const blocksIndexSchema = require('./schema/blocks');
 
 const getBlocksIndex = () => mysqlIndex('blocks', blocksIndexSchema);
-
-const constantsCache = CacheRedis('networkConstants', config.endpoints.redis);
 
 const logger = Logger();
 
@@ -495,7 +493,7 @@ const indexPastBlocks = async () => {
 	if (config.indexNumOfBlocks === 0) setIsSyncFullBlockchain(true);
 
 	// Lowest and highest block heights expected to be indexed
-	const blockIndexHigherRange = JSON.parse(await constantsCache.get('networkConstants')).data.height;
+	const blockIndexHigherRange = (await getNetworkConstants()).data.height;
 	const blockIndexLowerRange = config.indexNumOfBlocks > 0
 		? blockIndexHigherRange - config.indexNumOfBlocks : genesisHeight;
 

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -56,9 +56,11 @@ const getBlocksIndex = () => mysqlIndex('blocks', blocksIndexSchema);
 
 const logger = Logger();
 
-const { genesisHeight } = config;
+let genesisHeight;
 let finalizedHeight;
 let indexStartHeight;
+
+const setGenesisHeight = (height) => genesisHeight = height;
 
 const getGenesisHeight = () => genesisHeight;
 
@@ -519,6 +521,11 @@ const init = async () => {
 
 	// Check state of index and perform update
 	try {
+		// Determine genesis height
+		const { data: { networkIdentifier } } = await coreApi.getNetworkStatus();
+		const [networkConfig] = config.network.filter(c => c.identifier === networkIdentifier);
+		setGenesisHeight(networkConfig.genesisHeight);
+
 		await indexGenesisBlock().catch(err => {
 			logger.error(err.message);
 			logger.warn('Unable to index the Genesis block. Continuing with the remaining...');

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -521,10 +521,8 @@ const init = async () => {
 
 	// Check state of index and perform update
 	try {
-		// Determine genesis height
-		const { data: { networkIdentifier } } = await coreApi.getNetworkStatus();
-		const [networkConfig] = config.network.filter(c => c.identifier === networkIdentifier);
-		setGenesisHeight(networkConfig.genesisHeight);
+		// Set the genesis height
+		setGenesisHeight(await coreApi.getGenesisHeight());
 
 		await indexGenesisBlock().catch(err => {
 			logger.error(err.message);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -160,7 +160,7 @@ const normalizeBlocks = async (blocks, isIgnoreGenesisAccounts = true) => {
 					accounts,
 					initRounds,
 					initDelegates,
-					...otherAssets,
+					...otherAssets
 				} = block.asset;
 
 				block.asset = { ...otherAssets };

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -369,7 +369,7 @@ const indexGenesisBlock = async () => {
 	const blocksDB = await getBlocksIndex();
 	const [indexedGenesisBlock] = await blocksDB.find({ height: genesisHeight });
 
-	if (indexedGenesisBlock !== undefined) {
+	if (indexedGenesisBlock) {
 		logger.info(`Genesis block already indexed at height ${genesisHeight}`);
 	} else {
 		logger.info(`Ìndexing genesis block at height ${genesisHeight}`);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -16,6 +16,7 @@
 const BluebirdPromise = require('bluebird');
 const util = require('util');
 const {
+	CacheRedis,
 	Logger,
 	Signals,
 	Exceptions: { ValidationException, NotFoundException },
@@ -53,6 +54,8 @@ const mysqlIndex = require('../../../indexdb/mysql');
 const blocksIndexSchema = require('./schema/blocks');
 
 const getBlocksIndex = () => mysqlIndex('blocks', blocksIndexSchema);
+
+const constantsCache = CacheRedis('networkConstants', config.endpoints.redis);
 
 const logger = Logger();
 
@@ -492,7 +495,7 @@ const indexPastBlocks = async () => {
 	if (config.indexNumOfBlocks === 0) setIsSyncFullBlockchain(true);
 
 	// Lowest and highest block heights expected to be indexed
-	const blockIndexHigherRange = (await coreApi.getNetworkStatus()).data.height;
+	const blockIndexHigherRange = JSON.parse(await constantsCache.get('networkConstants')).data.height;
 	const blockIndexLowerRange = config.indexNumOfBlocks > 0
 		? blockIndexHigherRange - config.indexNumOfBlocks : genesisHeight;
 

--- a/services/core/shared/core/compat/sdk_v5/blocksUtils.js
+++ b/services/core/shared/core/compat/sdk_v5/blocksUtils.js
@@ -54,8 +54,7 @@ const downloadGenesisBlock = async () => {
 			request(genesisBlockURL)
 				.then(async response => {
 					const genesisBlock = typeof response === 'string' ? JSON.parse(response).data : response.data;
-					fs.writeFileSync(genesisBlockFilePath, JSON.stringify(genesisBlock));
-					resolve();
+					fs.writeFile(genesisBlockFilePath, JSON.stringify(genesisBlock), () => resolve());
 				})
 				.catch(err => reject(err));
 		}

--- a/services/core/shared/core/compat/sdk_v5/blocksUtils.js
+++ b/services/core/shared/core/compat/sdk_v5/blocksUtils.js
@@ -25,7 +25,6 @@ const {
 	HTTP: { request },
 } = require('lisk-service-framework');
 
-const { getApiClient } = require('../common/wsRequest');
 const config = require('../../../../config');
 
 const logger = Logger();

--- a/services/core/shared/core/compat/sdk_v5/blocksUtils.js
+++ b/services/core/shared/core/compat/sdk_v5/blocksUtils.js
@@ -50,7 +50,7 @@ const loadConfig = async () => {
 	const [networkConfig] = config.network.filter(c => c.identifier === networkIdentifier);
 	genesisBlockURL = networkConfig.genesisBlockUrl;
 
-	genesisBlockFilePath = `./shared/core/compat/sdk_v5/static/${networkConfig.name}/genesis_block.json`;
+	genesisBlockFilePath = `./data/${networkConfig.name}/genesis_block.json`;
 
 	// If file exists, already create a read stream
 	if (fs.existsSync(genesisBlockFilePath)) readStream = fs.createReadStream(genesisBlockFilePath);

--- a/services/core/shared/core/compat/sdk_v5/blocksUtils.js
+++ b/services/core/shared/core/compat/sdk_v5/blocksUtils.js
@@ -72,8 +72,8 @@ const downloadGenesisBlock = async () => {
 		} else {
 			request(genesisBlockURL)
 				.then(async response => {
-					const genesisBlock = typeof response === 'string' ? JSON.parse(response).data : response.data;
-					fs.writeFile(genesisBlockFilePath, JSON.stringify(genesisBlock), () => resolve());
+					const block = typeof response === 'string' ? JSON.parse(response).data : response.data;
+					fs.writeFile(genesisBlockFilePath, JSON.stringify(block), () => resolve());
 				})
 				.catch(err => reject(err));
 		}

--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -77,6 +77,7 @@ const getBlockByID = async id => {
 const getBlocksByIDs = async ids => {
 	try {
 		// File based Genesis block handling
+		const genesisBlockId = getGenesisBlockId();
 		if (ids.includes(genesisBlockId)) {
 			const remainingIds = ids.filter(id => id !== genesisBlockId);
 			const genesisBlockResult = await getBlockByID(genesisBlockId);
@@ -95,7 +96,6 @@ const getBlocksByIDs = async ids => {
 	} catch (err) {
 		if (err.message.includes(timeoutMessage)) {
 			await getApiClient();
-			const genesisBlockId = getGenesisBlockId();
 			throw new TimeoutException(`Request timed out when calling 'getBlocksByIDs' for IDs: ${ids}`);
 		}
 		throw err;

--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -105,7 +105,7 @@ const getBlocksByIDs = async ids => {
 const getBlockByHeight = async height => {
 	try {
 		// File based Genesis block handling
-		if (getGenesisBlockId() && Number(height) === getGenesisHeight()) {
+		if (getGenesisBlockId() && Number(height) === await getGenesisHeight()) {
 			return { data: [await getGenesisBlockFromFS()] };
 		}
 
@@ -116,7 +116,7 @@ const getBlockByHeight = async height => {
 		if (err.message.includes(timeoutMessage)) {
 			await getApiClient();
 			// Download to the FS & return the genesis block
-			if (Number(height) === getGenesisHeight()) return { data: [await getGenesisBlockFromFS()] };
+			if (Number(height) === await getGenesisHeight()) return { data: [await getGenesisBlockFromFS()] };
 			throw new TimeoutException(`Request timed out when calling 'getBlockByHeight' for height: ${height}`);
 		}
 		throw err;
@@ -126,7 +126,7 @@ const getBlockByHeight = async height => {
 const getBlocksByHeightBetween = async (from, to) => {
 	try {
 		// File based Genesis block handling
-		if (getGenesisBlockId() && Number(from) === getGenesisHeight()) {
+		if (getGenesisBlockId() && Number(from) === await getGenesisHeight()) {
 			const genesisBlockResult = await getBlockByHeight(from);
 			if (from < to) {
 				const { data: [genesisBlock] } = genesisBlockResult;

--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -51,8 +51,8 @@ const getGenesisHeight = async () => {
 	if (!genesisHeight) {
 		// Determine genesis height
 		const { data: { networkIdentifier } } = await getNetworkStatus();
-		const [networkConfig] = config.network.filter(c => c.identifier === networkIdentifier);
-		genesisHeight = Number(networkConfig.genesisHeight);
+		const [networkConfig = {}] = config.network.filter(c => c.identifier === networkIdentifier);
+		genesisHeight = Number(networkConfig.genesisHeight || 0);
 	}
 	return genesisHeight;
 };

--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -115,6 +115,8 @@ const getBlockByHeight = async height => {
 	} catch (err) {
 		if (err.message.includes(timeoutMessage)) {
 			await getApiClient();
+			// Download to the FS & return the genesis block
+			if (Number(height) === getGenesisHeight()) return { data: [await getGenesisBlockFromFS()] };
 			throw new TimeoutException(`Request timed out when calling 'getBlockByHeight' for height: ${height}`);
 		}
 		throw err;

--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -116,6 +116,7 @@ const getBlockByHeight = async height => {
 		if (err.message.includes(timeoutMessage)) {
 			await getApiClient();
 			// Download to the FS & return the genesis block
+			// eslint-disable-next-line max-len
 			if (Number(height) === await getGenesisHeight()) return { data: [await getGenesisBlockFromFS()] };
 			throw new TimeoutException(`Request timed out when calling 'getBlockByHeight' for height: ${height}`);
 		}

--- a/services/core/shared/core/peerCache.js
+++ b/services/core/shared/core/peerCache.js
@@ -88,17 +88,21 @@ const getStatistics = () => peerStore.statistics;
 
 const reload = async () => {
 	logger.debug('Refreshing peer cache...');
-	if (sdkVersion <= 4) {
-		peerStore.peers = await requestAll(coreApi.getPeers, {});
-	} else {
-		peerStore.peers = (await coreApi.getPeers()).data;
+	try {
+		if (sdkVersion <= 4) {
+			peerStore.peers = await requestAll(coreApi.getPeers, {});
+		} else {
+			peerStore.peers = (await coreApi.getPeers()).data;
+		}
+		peerStore.connected = peerStore.peers.filter(o => o.state === peerStates.CONNECTED);
+		peerStore.disconnected = peerStore.peers.filter(o => o.state === peerStates.DISCONNECTED);
+		peerStore.statistics = await refreshStatistics();
+		logger.debug('Updated peer cache.');
+		logger.debug(`============== 'peerReload' signal: ${Signals.get('peerReload')} ==============`);
+		Signals.get('peerReload').dispatch(peerStore.peers);
+	} catch (err) {
+		logger.debug(`Unable to reload peer cache: ${err.message}`);
 	}
-	peerStore.connected = peerStore.peers.filter(o => o.state === peerStates.CONNECTED);
-	peerStore.disconnected = peerStore.peers.filter(o => o.state === peerStates.DISCONNECTED);
-	peerStore.statistics = await refreshStatistics();
-	logger.debug('Updated peer cache.');
-	logger.debug(`============== 'peerReload' signal: ${Signals.get('peerReload')} ==============`);
-	Signals.get('peerReload').dispatch(peerStore.peers);
 };
 
 module.exports = {

--- a/services/core/shared/knownAccounts.js
+++ b/services/core/shared/knownAccounts.js
@@ -36,11 +36,11 @@ const getAccountKnowledge = (address) => {
 const reloadKnowledge = async () => {
 	logger.debug('Reloading known accounts...');
 
-	await waitForLastBlock();
-	const netStatus = await getNetworkStatus();
-	const { nethash } = netStatus.data.constants;
-
 	try {
+		await waitForLastBlock();
+		const netStatus = await getNetworkStatus();
+		const { nethash } = netStatus.data.constants;
+
 		const knownNetworks = await HTTP.request(`${staticUrl}/networks.json`);
 		if (knownNetworks.data[nethash]) {
 			const knownAccounts = await HTTP.request(`${staticUrl}/known_${knownNetworks.data[nethash]}.json`);


### PR DESCRIPTION
### What was the problem?
This PR resolves #640 

### How was it solved?
- [x] Created config section specific to the networks (testnet/mainnet)
- [x] Preferential fetching of Genesis block from FS if exists
- [x] Access genesis block by `height` / `blockId`
- [x] Error handling for `peerCache.js` and `knownAccounts.js`
- [x] Avoid re-indexing already indexed Genesis block

### How was it tested?
Local
