### PR TITLE
Use networkConstants cache for past blocks - Closes #643

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -16,6 +16,7 @@
 const BluebirdPromise = require('bluebird');
 const util = require('util');
 const {
+	CacheRedis,
 	Logger,
 	Signals,
 	Exceptions: { ValidationException, NotFoundException },
@@ -53,6 +54,8 @@ const mysqlIndex = require('../../../indexdb/mysql');
 const blocksIndexSchema = require('./schema/blocks');
 
 const getBlocksIndex = () => mysqlIndex('blocks', blocksIndexSchema);
+
+const constantsCache = CacheRedis('networkConstants', config.endpoints.redis);
 
 const logger = Logger();
 
@@ -492,7 +495,7 @@ const indexPastBlocks = async () => {
 	if (config.indexNumOfBlocks === 0) setIsSyncFullBlockchain(true);
 
 	// Lowest and highest block heights expected to be indexed
-	const blockIndexHigherRange = (await coreApi.getNetworkStatus()).data.height;
+	const blockIndexHigherRange = JSON.parse(await constantsCache.get('networkConstants')).data.height;
 	const blockIndexLowerRange = config.indexNumOfBlocks > 0
 		? blockIndexHigherRange - config.indexNumOfBlocks : genesisHeight;
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #643 

### How was it solved?
- [x] Use networkConstants cache to determine `blockIndexHigherRange` when indexing past blocks

### How was it tested?
Local + Jenkins
