### PR TITLE
Update Signal listener - Closes # 648

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
 				nvm(getNodejsVersion()) {
 					sh 'pm2 start --silent ecosystem.jenkins.config.js'
 				}
-				sleep(180)
+				sleep(90)
 				waitForHttp('http://localhost:9901/api/ready')
 				// waitForHttp('http://localhost:9901/api/v2/blocks?timestamp=1615917187')
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
 				nvm(getNodejsVersion()) {
 					sh 'pm2 start --silent ecosystem.jenkins.config.js'
 				}
-				sleep(90)
+				sleep(180)
 				waitForHttp('http://localhost:9901/api/ready')
 				// waitForHttp('http://localhost:9901/api/v2/blocks?timestamp=1615917187')
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
 				nvm(getNodejsVersion()) {
 					sh 'pm2 start --silent ecosystem.jenkins.config.js'
 				}
-				sleep(120)
+				sleep(90)
 				waitForHttp('http://localhost:9901/api/ready')
 				// waitForHttp('http://localhost:9901/api/v2/blocks?timestamp=1615917187')
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,7 @@ pipeline {
 				nvm(getNodejsVersion()) {
 					sh 'pm2 start --silent ecosystem.jenkins.config.js'
 				}
-				sleep(90)
+				sleep(120)
 				waitForHttp('http://localhost:9901/api/ready')
 				// waitForHttp('http://localhost:9901/api/v2/blocks?timestamp=1615917187')
 			}

--- a/services/core/events/blockchain.js
+++ b/services/core/events/blockchain.js
@@ -50,7 +50,11 @@ module.exports = [
 					].join('\n'));
 				}
 			};
-			if (!Signals.get('newBlock').has(newBlockListener)) Signals.get('newBlock').add(newBlockListener);
+			if (!Signals.get('newBlock').has(newBlockListener)) {
+				logger.debug('newBlock has newBlockListener: ', Signals.get('newBlock').has(newBlockListener));
+				Signals.get('newBlock').add(newBlockListener);
+				logger.debug('newBlock has now registered newBlockListener: ', Signals.get('newBlock').has(newBlockListener));
+			}
 		},
 	},
 	{
@@ -67,7 +71,11 @@ module.exports = [
 					}
 				}
 			};
-			if (!Signals.get('newBlock').has(newTransactionsListener)) Signals.get('newBlock').add(newTransactionsListener);
+			if (!Signals.get('newBlock').has(newTransactionsListener)) {
+				logger.debug('newBlock has newTransactionsListener: ', Signals.get('newBlock').has(newTransactionsListener));
+				Signals.get('newBlock').add(newTransactionsListener);
+				logger.debug('newBlock has now registered newTransactionsListener: ', Signals.get('newBlock').has(newTransactionsListener));
+			}
 		},
 	},
 	{
@@ -79,7 +87,11 @@ module.exports = [
 				const forgers = await core.getNextForgers({ limit: 25, offset: 0 });
 				callback(forgers);
 			};
-			if (!Signals.get('newBlock').has(forgersChangeListener)) Signals.get('newBlock').add(forgersChangeListener);
+			if (!Signals.get('newBlock').has(forgersChangeListener)) {
+				logger.debug('newBlock has forgersChangeListener: ', Signals.get('newBlock').has(forgersChangeListener));
+				Signals.get('newBlock').add(forgersChangeListener);
+				logger.debug('newBlock has now registered forgersChangeListener: ', Signals.get('newBlock').has(forgersChangeListener));
+			}
 		},
 	},
 	{
@@ -91,7 +103,11 @@ module.exports = [
 				if (data.timestamp) data.unixtime = await core.getUnixTime(data.timestamp);
 				callback(data);
 			};
-			if (!Signals.get('newRound').has(newRoundListener)) Signals.get('newRound').add(newRoundListener);
+			if (!Signals.get('newRound').has(newRoundListener)) {
+				logger.debug('newRound has newRoundListener: ', Signals.get('newRound').has(newRoundListener));
+				Signals.get('newRound').add(newRoundListener);
+				logger.debug('newRound has now registered newRoundListener: ', Signals.get('newRound').has(newRoundListener));
+			}
 		},
 	},
 	{
@@ -103,7 +119,11 @@ module.exports = [
 				const restData = await core.getEstimateFeeByte();
 				callback(restData);
 			};
-			if (!Signals.get('newFeeEstimate').has(newFeeEstimateListener)) Signals.get('newFeeEstimate').add(newFeeEstimateListener);
+			if (!Signals.get('newFeeEstimate').has(newFeeEstimateListener)) {
+				logger.debug('newFeeEstimate has newFeeEstimateListener: ', Signals.get('newFeeEstimate').has(newFeeEstimateListener));
+				Signals.get('newFeeEstimate').add(newFeeEstimateListener);
+				logger.debug('newFeeEstimate has now registered newFeeEstimateListener: ', Signals.get('newFeeEstimate').has(newFeeEstimateListener));
+			}
 		},
 	},
 	{
@@ -115,7 +135,11 @@ module.exports = [
 				const restData = await core.updateFinalizedHeight();
 				callback(restData ? restData.data : null);
 			};
-			if (!Signals.get('newBlock').has(updateFinalizedHeightListener)) Signals.get('newBlock').add(updateFinalizedHeightListener);
+			if (!Signals.get('newBlock').has(updateFinalizedHeightListener)) {
+				logger.debug('newBlock has updateFinalizedHeightListener: ', Signals.get('newBlock').has(updateFinalizedHeightListener));
+				Signals.get('newBlock').add(updateFinalizedHeightListener);
+				logger.debug('newBlock has now registered updateFinalizedHeightListener: ', Signals.get('newBlock').has(updateFinalizedHeightListener));
+			}
 		},
 	},
 ];

--- a/services/core/events/blockchain.js
+++ b/services/core/events/blockchain.js
@@ -14,11 +14,9 @@
  *
  */
 const util = require('util');
-const {
-	Logger,
-	Signals,
-} = require('lisk-service-framework');
+const { Logger } = require('lisk-service-framework');
 
+const Signals = require('../shared/signals');
 const core = require('../shared/core');
 
 const logger = Logger();

--- a/services/core/events/blockchain.js
+++ b/services/core/events/blockchain.js
@@ -30,7 +30,7 @@ module.exports = [
 		name: 'block.change',
 		description: 'Keep the block list up-to-date',
 		controller: callback => {
-			Signals.get('newBlock').add(async data => {
+			const newBlockListener = async data => {
 				if (data && Array.isArray(data.data)) {
 					const [block] = data.data;
 					logger.debug(`New block arrived (${block.id})...`);
@@ -49,14 +49,15 @@ module.exports = [
 						util.inspect(data),
 					].join('\n'));
 				}
-			});
+			};
+			if (!Signals.get('newBlock').has(newBlockListener)) Signals.get('newBlock').add(newBlockListener);
 		},
 	},
 	{
 		name: 'transactions.new',
 		description: 'Keep newly added transactions list up-to-date',
 		controller: callback => {
-			Signals.get('newBlock').add(async (data) => {
+			const newTransactionsListener = async (data) => {
 				if (data && Array.isArray(data.data)) {
 					const [block] = data.data;
 					if (block.numberOfTransactions > 0) {
@@ -65,51 +66,56 @@ module.exports = [
 						callback(transactionData);
 					}
 				}
-			});
+			};
+			if (!Signals.get('newBlock').has(newTransactionsListener)) Signals.get('newBlock').add(newTransactionsListener);
 		},
 	},
 	{
 		name: 'forgers.change',
 		description: 'Track round change updates',
 		controller: callback => {
-			Signals.get('newBlock').add(async () => {
+			const forgersChangeListener = async () => {
 				await core.reloadNextForgersCache();
 				const forgers = await core.getNextForgers({ limit: 25, offset: 0 });
 				callback(forgers);
-			});
+			};
+			if (!Signals.get('newBlock').has(forgersChangeListener)) Signals.get('newBlock').add(forgersChangeListener);
 		},
 	},
 	{
 		name: 'round.change',
 		description: 'Track round change updates',
 		controller: callback => {
-			Signals.get('newRound').add(async data => {
+			const newRoundListener = async data => {
 				logger.debug('Returning all forgers for the new round...');
 				if (data.timestamp) data.unixtime = await core.getUnixTime(data.timestamp);
 				callback(data);
-			});
+			};
+			if (!Signals.get('newRound').has(newRoundListener)) Signals.get('newRound').add(newRoundListener);
 		},
 	},
 	{
 		name: 'update.fee_estimates',
 		description: 'Keep the fee estimates up-to-date',
 		controller: callback => {
-			Signals.get('newFeeEstimate').add(async () => {
+			const newFeeEstimateListener = async () => {
 				logger.debug('Returning latest fee_estimates to the socket.io client...');
 				const restData = await core.getEstimateFeeByte();
 				callback(restData);
-			});
+			};
+			if (!Signals.get('newFeeEstimate').has(newFeeEstimateListener)) Signals.get('newFeeEstimate').add(newFeeEstimateListener);
 		},
 	},
 	{
 		name: 'update.height_finalized',
 		description: 'Keep the block finality height up-to-date',
 		controller: callback => {
-			Signals.get('newBlock').add(async () => {
+			const updateFinalizedHeightListener = async () => {
 				logger.debug('Returning latest heightFinalized to the socket.io client...');
 				const restData = await core.updateFinalizedHeight();
 				callback(restData ? restData.data : null);
-			});
+			};
+			if (!Signals.get('newBlock').has(updateFinalizedHeightListener)) Signals.get('newBlock').add(updateFinalizedHeightListener);
 		},
 	},
 ];

--- a/services/core/events/blockchain.js
+++ b/services/core/events/blockchain.js
@@ -50,11 +50,7 @@ module.exports = [
 					].join('\n'));
 				}
 			};
-			if (!Signals.get('newBlock').has(newBlockListener)) {
-				logger.debug('newBlock has newBlockListener: ', Signals.get('newBlock').has(newBlockListener));
-				Signals.get('newBlock').add(newBlockListener);
-				logger.debug('newBlock has now registered newBlockListener: ', Signals.get('newBlock').has(newBlockListener));
-			}
+			if (!Signals.get('newBlock').has(newBlockListener)) Signals.get('newBlock').add(newBlockListener);
 		},
 	},
 	{
@@ -71,11 +67,7 @@ module.exports = [
 					}
 				}
 			};
-			if (!Signals.get('newBlock').has(newTransactionsListener)) {
-				logger.debug('newBlock has newTransactionsListener: ', Signals.get('newBlock').has(newTransactionsListener));
-				Signals.get('newBlock').add(newTransactionsListener);
-				logger.debug('newBlock has now registered newTransactionsListener: ', Signals.get('newBlock').has(newTransactionsListener));
-			}
+			if (!Signals.get('newBlock').has(newTransactionsListener)) Signals.get('newBlock').add(newTransactionsListener);
 		},
 	},
 	{
@@ -87,11 +79,7 @@ module.exports = [
 				const forgers = await core.getNextForgers({ limit: 25, offset: 0 });
 				callback(forgers);
 			};
-			if (!Signals.get('newBlock').has(forgersChangeListener)) {
-				logger.debug('newBlock has forgersChangeListener: ', Signals.get('newBlock').has(forgersChangeListener));
-				Signals.get('newBlock').add(forgersChangeListener);
-				logger.debug('newBlock has now registered forgersChangeListener: ', Signals.get('newBlock').has(forgersChangeListener));
-			}
+			if (!Signals.get('newBlock').has(forgersChangeListener)) Signals.get('newBlock').add(forgersChangeListener);
 		},
 	},
 	{
@@ -103,11 +91,7 @@ module.exports = [
 				if (data.timestamp) data.unixtime = await core.getUnixTime(data.timestamp);
 				callback(data);
 			};
-			if (!Signals.get('newRound').has(newRoundListener)) {
-				logger.debug('newRound has newRoundListener: ', Signals.get('newRound').has(newRoundListener));
-				Signals.get('newRound').add(newRoundListener);
-				logger.debug('newRound has now registered newRoundListener: ', Signals.get('newRound').has(newRoundListener));
-			}
+			if (!Signals.get('newRound').has(newRoundListener)) Signals.get('newRound').add(newRoundListener);
 		},
 	},
 	{
@@ -119,11 +103,7 @@ module.exports = [
 				const restData = await core.getEstimateFeeByte();
 				callback(restData);
 			};
-			if (!Signals.get('newFeeEstimate').has(newFeeEstimateListener)) {
-				logger.debug('newFeeEstimate has newFeeEstimateListener: ', Signals.get('newFeeEstimate').has(newFeeEstimateListener));
-				Signals.get('newFeeEstimate').add(newFeeEstimateListener);
-				logger.debug('newFeeEstimate has now registered newFeeEstimateListener: ', Signals.get('newFeeEstimate').has(newFeeEstimateListener));
-			}
+			if (!Signals.get('newFeeEstimate').has(newFeeEstimateListener)) Signals.get('newFeeEstimate').add(newFeeEstimateListener);
 		},
 	},
 	{
@@ -135,11 +115,7 @@ module.exports = [
 				const restData = await core.updateFinalizedHeight();
 				callback(restData ? restData.data : null);
 			};
-			if (!Signals.get('newBlock').has(updateFinalizedHeightListener)) {
-				logger.debug('newBlock has updateFinalizedHeightListener: ', Signals.get('newBlock').has(updateFinalizedHeightListener));
-				Signals.get('newBlock').add(updateFinalizedHeightListener);
-				logger.debug('newBlock has now registered updateFinalizedHeightListener: ', Signals.get('newBlock').has(updateFinalizedHeightListener));
-			}
+			if (!Signals.get('newBlock').has(updateFinalizedHeightListener)) Signals.get('newBlock').add(updateFinalizedHeightListener);
 		},
 	},
 ];

--- a/services/core/events/blockchain.js
+++ b/services/core/events/blockchain.js
@@ -30,7 +30,7 @@ module.exports = [
 		name: 'block.change',
 		description: 'Keep the block list up-to-date',
 		controller: callback => {
-			const newBlockListener = async data => {
+			Signals.get('newBlock').add(async data => {
 				if (data && Array.isArray(data.data)) {
 					const [block] = data.data;
 					logger.debug(`New block arrived (${block.id})...`);
@@ -49,15 +49,14 @@ module.exports = [
 						util.inspect(data),
 					].join('\n'));
 				}
-			};
-			if (!Signals.get('newBlock').has(newBlockListener)) Signals.get('newBlock').add(newBlockListener);
+			});
 		},
 	},
 	{
 		name: 'transactions.new',
 		description: 'Keep newly added transactions list up-to-date',
 		controller: callback => {
-			const newTransactionsListener = async (data) => {
+			Signals.get('newBlock').add(async (data) => {
 				if (data && Array.isArray(data.data)) {
 					const [block] = data.data;
 					if (block.numberOfTransactions > 0) {
@@ -66,56 +65,51 @@ module.exports = [
 						callback(transactionData);
 					}
 				}
-			};
-			if (!Signals.get('newBlock').has(newTransactionsListener)) Signals.get('newBlock').add(newTransactionsListener);
+			});
 		},
 	},
 	{
 		name: 'forgers.change',
 		description: 'Track round change updates',
 		controller: callback => {
-			const forgersChangeListener = async () => {
+			Signals.get('newBlock').add(async () => {
 				await core.reloadNextForgersCache();
 				const forgers = await core.getNextForgers({ limit: 25, offset: 0 });
 				callback(forgers);
-			};
-			if (!Signals.get('newBlock').has(forgersChangeListener)) Signals.get('newBlock').add(forgersChangeListener);
+			});
 		},
 	},
 	{
 		name: 'round.change',
 		description: 'Track round change updates',
 		controller: callback => {
-			const newRoundListener = async data => {
+			Signals.get('newRound').add(async data => {
 				logger.debug('Returning all forgers for the new round...');
 				if (data.timestamp) data.unixtime = await core.getUnixTime(data.timestamp);
 				callback(data);
-			};
-			if (!Signals.get('newRound').has(newRoundListener)) Signals.get('newRound').add(newRoundListener);
+			});
 		},
 	},
 	{
 		name: 'update.fee_estimates',
 		description: 'Keep the fee estimates up-to-date',
 		controller: callback => {
-			const newFeeEstimateListener = async () => {
+			Signals.get('newFeeEstimate').add(async () => {
 				logger.debug('Returning latest fee_estimates to the socket.io client...');
 				const restData = await core.getEstimateFeeByte();
 				callback(restData);
-			};
-			if (!Signals.get('newFeeEstimate').has(newFeeEstimateListener)) Signals.get('newFeeEstimate').add(newFeeEstimateListener);
+			});
 		},
 	},
 	{
 		name: 'update.height_finalized',
 		description: 'Keep the block finality height up-to-date',
 		controller: callback => {
-			const updateFinalizedHeightListener = async () => {
+			Signals.get('newBlock').add(async () => {
 				logger.debug('Returning latest heightFinalized to the socket.io client...');
 				const restData = await core.updateFinalizedHeight();
 				callback(restData ? restData.data : null);
-			};
-			if (!Signals.get('newBlock').has(updateFinalizedHeightListener)) Signals.get('newBlock').add(updateFinalizedHeightListener);
+			});
 		},
 	},
 ];

--- a/services/core/events/ready.js
+++ b/services/core/events/ready.js
@@ -13,12 +13,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const {
-	Logger,
-	Signals,
-} = require('lisk-service-framework');
+const { Logger } = require('lisk-service-framework');
 
 const { getCurrentStatus } = require('../ready');
+
+const Signals = require('../shared/signals');
 
 const logger = Logger();
 

--- a/services/core/events/ready.js
+++ b/services/core/events/ready.js
@@ -32,7 +32,11 @@ module.exports = [
 				const coreStatus = await getCurrentStatus();
 				callback(coreStatus);
 			};
-			if (!Signals.get('coreServiceReady').has(coreServiceReadyListener)) Signals.get('coreServiceReady').add(coreServiceReadyListener);
+			if (!Signals.get('coreServiceReady').has(coreServiceReadyListener)) {
+				logger.debug('coreServiceReady has coreServiceReadyListener: ', Signals.get('coreServiceReady').has(coreServiceReadyListener));
+				Signals.get('coreServiceReady').add(coreServiceReadyListener);
+				logger.debug('coreServiceReady has now registered coreServiceReadyListener: ', Signals.get('coreServiceReady').has(coreServiceReadyListener));
+			}
 		},
 	},
 ];

--- a/services/core/events/ready.js
+++ b/services/core/events/ready.js
@@ -32,11 +32,7 @@ module.exports = [
 				const coreStatus = await getCurrentStatus();
 				callback(coreStatus);
 			};
-			if (!Signals.get('coreServiceReady').has(coreServiceReadyListener)) {
-				logger.debug('coreServiceReady has coreServiceReadyListener: ', Signals.get('coreServiceReady').has(coreServiceReadyListener));
-				Signals.get('coreServiceReady').add(coreServiceReadyListener);
-				logger.debug('coreServiceReady has now registered coreServiceReadyListener: ', Signals.get('coreServiceReady').has(coreServiceReadyListener));
-			}
+			if (!Signals.get('coreServiceReady').has(coreServiceReadyListener)) Signals.get('coreServiceReady').add(coreServiceReadyListener);
 		},
 	},
 ];

--- a/services/core/events/ready.js
+++ b/services/core/events/ready.js
@@ -27,12 +27,11 @@ module.exports = [
 		name: 'coreService.Ready',
 		description: 'Returns current readiness status of Lisk Core service',
 		controller: async callback => {
-			const coreServiceReadyListener = async () => {
+			Signals.get('coreServiceReady').add(async () => {
 				logger.debug('Returns current readiness status of the Lisk Core service');
 				const coreStatus = await getCurrentStatus();
 				callback(coreStatus);
-			};
-			if (!Signals.get('coreServiceReady').has(coreServiceReadyListener)) Signals.get('coreServiceReady').add(coreServiceReadyListener);
+			});
 		},
 	},
 ];

--- a/services/core/events/ready.js
+++ b/services/core/events/ready.js
@@ -26,11 +26,12 @@ module.exports = [
 		name: 'coreService.Ready',
 		description: 'Returns current readiness status of Lisk Core service',
 		controller: async callback => {
-			Signals.get('coreServiceReady').add(async () => {
+			const coreServiceReadyListener = async () => {
 				logger.debug('Returns current readiness status of the Lisk Core service');
 				const coreStatus = await getCurrentStatus();
 				callback(coreStatus);
-			});
+			};
+			Signals.get('coreServiceReady').add(coreServiceReadyListener);
 		},
 	},
 ];

--- a/services/core/events/ready.js
+++ b/services/core/events/ready.js
@@ -27,11 +27,12 @@ module.exports = [
 		name: 'coreService.Ready',
 		description: 'Returns current readiness status of Lisk Core service',
 		controller: async callback => {
-			Signals.get('coreServiceReady').add(async () => {
+			const coreServiceReadyListener = async () => {
 				logger.debug('Returns current readiness status of the Lisk Core service');
 				const coreStatus = await getCurrentStatus();
 				callback(coreStatus);
-			});
+			};
+			if (!Signals.get('coreServiceReady').has(coreServiceReadyListener)) Signals.get('coreServiceReady').add(coreServiceReadyListener);
 		},
 	},
 ];

--- a/services/core/package-lock.json
+++ b/services/core/package-lock.json
@@ -10644,7 +10644,7 @@
     },
     "signals": {
       "version": "1.0.0",
-      "resolved": "https://npm.lisk.io/signals/-/signals-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/signals/-/signals-1.0.0.tgz",
       "integrity": "sha1-ZfDBWZNSs1Ny7KrlolDmEHN27Wk="
     },
     "sisteransi": {

--- a/services/core/package.json
+++ b/services/core/package.json
@@ -49,6 +49,7 @@
     "moment": "=2.24.0",
     "mysql": "^2.18.1",
     "semver": "^7.3.5",
+    "signals": "^1.0.0",
     "split": "^1.0.1",
     "sqlite3": "^5.0.2",
     "stack-trace": "0.0.10",

--- a/services/core/ready.js
+++ b/services/core/ready.js
@@ -13,13 +13,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const {
-	Logger,
-	Signals,
-} = require('lisk-service-framework');
+const { Logger } = require('lisk-service-framework');
 
 const core = require('./shared/core');
 const config = require('./config');
+const Signals = require('./shared/signals');
 
 const logger = Logger();
 

--- a/services/core/ready.js
+++ b/services/core/ready.js
@@ -50,7 +50,7 @@ const newBlockListener = async () => {
 		// Check for fee estimates
 		logger.debug('Check if fee estmates are ready');
 		const fees = await core.getEstimateFeeByte();
-		if (Object.getOwnPropertyNames(fees).length) features.isFeeEstimatesReady = true;
+		if (Object.getOwnPropertyNames(fees).length && fees.status !== 'SERVICE_UNAVAILABLE') features.isFeeEstimatesReady = true;
 
 		// Check if delegates list is ready
 		const delegatesList = await core.getDelegates({});

--- a/services/core/ready.js
+++ b/services/core/ready.js
@@ -37,22 +37,14 @@ const blockIndexReadyListener = () => {
 	logger.debug('Indexing finished');
 	features.isIndexReady = true;
 };
-if (!Signals.get('blockIndexReady').has(blockIndexReadyListener)) {
-	logger.debug('blockIndexReady has blockIndexReadyListener: ', Signals.get('blockIndexReady').has(blockIndexReadyListener));
-	Signals.get('blockIndexReady').add(blockIndexReadyListener);
-	logger.debug('blockIndexReady has now registered blockIndexReadyListener: ', Signals.get('blockIndexReady').has(blockIndexReadyListener));
-}
+if (!Signals.get('blockIndexReady').has(blockIndexReadyListener)) Signals.get('blockIndexReady').add(blockIndexReadyListener);
 
 // Check if transaction stats are built
 const transactionStatsReadyListener = (days) => {
 	logger.debug('Transaction stats calculated for:', `${days}days`);
 	features.isTransactionStatsReady = true;
 };
-if (!Signals.get('transactionStatsReady').has(transactionStatsReadyListener)) {
-	logger.debug('transactionStatsReady has transactionStatsReadyListener: ', Signals.get('transactionStatsReady').has(transactionStatsReadyListener));
-	Signals.get('transactionStatsReady').add(transactionStatsReadyListener);
-	logger.debug('transactionStatsReady has now registered transactionStatsReadyListener: ', Signals.get('transactionStatsReady').has(transactionStatsReadyListener));
-}
+if (!Signals.get('transactionStatsReady').has(transactionStatsReadyListener)) Signals.get('transactionStatsReady').add(transactionStatsReadyListener);
 
 const newBlockListener = async () => {
 	if (!isCoreReady()) {
@@ -73,11 +65,7 @@ const newBlockListener = async () => {
 	logger.debug(`============== 'coreServiceReady' signal: ${Signals.get('coreServiceReady')} ==============`);
 	if (isCoreReady()) Signals.get('coreServiceReady').dispatch(true);
 };
-if (!Signals.get('newBlock').has(newBlockListener)) {
-	logger.debug('newBlock has newBlockListener: ', Signals.get('newBlock').has(newBlockListener));
-	Signals.get('newBlock').add(newBlockListener);
-	logger.debug('newBlock has now registered newBlockListener: ', Signals.get('newBlock').has(newBlockListener));
-}
+if (!Signals.get('newBlock').has(newBlockListener)) Signals.get('newBlock').add(newBlockListener);
 
 const getCurrentStatus = async () => features;
 

--- a/services/core/ready.js
+++ b/services/core/ready.js
@@ -37,14 +37,22 @@ const blockIndexReadyListener = () => {
 	logger.debug('Indexing finished');
 	features.isIndexReady = true;
 };
-if (!Signals.get('blockIndexReady').has(blockIndexReadyListener)) Signals.get('blockIndexReady').add(blockIndexReadyListener);
+if (!Signals.get('blockIndexReady').has(blockIndexReadyListener)) {
+	logger.debug('blockIndexReady has blockIndexReadyListener: ', Signals.get('blockIndexReady').has(blockIndexReadyListener));
+	Signals.get('blockIndexReady').add(blockIndexReadyListener);
+	logger.debug('blockIndexReady has now registered blockIndexReadyListener: ', Signals.get('blockIndexReady').has(blockIndexReadyListener));
+}
 
 // Check if transaction stats are built
 const transactionStatsReadyListener = (days) => {
 	logger.debug('Transaction stats calculated for:', `${days}days`);
 	features.isTransactionStatsReady = true;
 };
-if (!Signals.get('transactionStatsReady').has(transactionStatsReadyListener)) Signals.get('transactionStatsReady').add(transactionStatsReadyListener);
+if (!Signals.get('transactionStatsReady').has(transactionStatsReadyListener)) {
+	logger.debug('transactionStatsReady has transactionStatsReadyListener: ', Signals.get('transactionStatsReady').has(transactionStatsReadyListener));
+	Signals.get('transactionStatsReady').add(transactionStatsReadyListener);
+	logger.debug('transactionStatsReady has now registered transactionStatsReadyListener: ', Signals.get('transactionStatsReady').has(transactionStatsReadyListener));
+}
 
 const newBlockListener = async () => {
 	if (!isCoreReady()) {
@@ -65,7 +73,11 @@ const newBlockListener = async () => {
 	logger.debug(`============== 'coreServiceReady' signal: ${Signals.get('coreServiceReady')} ==============`);
 	if (isCoreReady()) Signals.get('coreServiceReady').dispatch(true);
 };
-if (!Signals.get('newBlock').has(newBlockListener)) Signals.get('newBlock').add(newBlockListener);
+if (!Signals.get('newBlock').has(newBlockListener)) {
+	logger.debug('newBlock has newBlockListener: ', Signals.get('newBlock').has(newBlockListener));
+	Signals.get('newBlock').add(newBlockListener);
+	logger.debug('newBlock has now registered newBlockListener: ', Signals.get('newBlock').has(newBlockListener));
+}
 
 const getCurrentStatus = async () => features;
 

--- a/services/core/ready.js
+++ b/services/core/ready.js
@@ -33,20 +33,18 @@ const features = {
 const isCoreReady = () => !Object.keys(features).some(value => !features[value]);
 
 // Check if all blocks are indexed
-const blockIndexReadyListener = () => {
+Signals.get('blockIndexReady').add(() => {
 	logger.debug('Indexing finished');
 	features.isIndexReady = true;
-};
-if (!Signals.get('blockIndexReady').has(blockIndexReadyListener)) Signals.get('blockIndexReady').add(blockIndexReadyListener);
+});
 
 // Check if transaction stats are built
-const transactionStatsReadyListener = (days) => {
+Signals.get('transactionStatsReady').add((days) => {
 	logger.debug('Transaction stats calculated for:', `${days}days`);
 	features.isTransactionStatsReady = true;
-};
-if (!Signals.get('transactionStatsReady').has(transactionStatsReadyListener)) Signals.get('transactionStatsReady').add(transactionStatsReadyListener);
+});
 
-const newBlockListener = async () => {
+Signals.get('newBlock').add(async () => {
 	if (!isCoreReady()) {
 		// Check for fee estimates
 		logger.debug('Check if fee estmates are ready');
@@ -64,8 +62,7 @@ const newBlockListener = async () => {
 	// Core reports readiness only if all services available
 	logger.debug(`============== 'coreServiceReady' signal: ${Signals.get('coreServiceReady')} ==============`);
 	if (isCoreReady()) Signals.get('coreServiceReady').dispatch(true);
-};
-if (!Signals.get('newBlock').has(newBlockListener)) Signals.get('newBlock').add(newBlockListener);
+});
 
 const getCurrentStatus = async () => features;
 

--- a/services/core/ready.js
+++ b/services/core/ready.js
@@ -33,18 +33,20 @@ const features = {
 const isCoreReady = () => !Object.keys(features).some(value => !features[value]);
 
 // Check if all blocks are indexed
-Signals.get('blockIndexReady').add(() => {
+const blockIndexReadyListener = () => {
 	logger.debug('Indexing finished');
 	features.isIndexReady = true;
-});
+};
+if (!Signals.get('blockIndexReady').has(blockIndexReadyListener)) Signals.get('blockIndexReady').add(blockIndexReadyListener);
 
 // Check if transaction stats are built
-Signals.get('transactionStatsReady').add((days) => {
+const transactionStatsReadyListener = (days) => {
 	logger.debug('Transaction stats calculated for:', `${days}days`);
 	features.isTransactionStatsReady = true;
-});
+};
+if (!Signals.get('transactionStatsReady').has(transactionStatsReadyListener)) Signals.get('transactionStatsReady').add(transactionStatsReadyListener);
 
-Signals.get('newBlock').add(async () => {
+const newBlockListener = async () => {
 	if (!isCoreReady()) {
 		// Check for fee estimates
 		logger.debug('Check if fee estmates are ready');
@@ -62,7 +64,8 @@ Signals.get('newBlock').add(async () => {
 	// Core reports readiness only if all services available
 	logger.debug(`============== 'coreServiceReady' signal: ${Signals.get('coreServiceReady')} ==============`);
 	if (isCoreReady()) Signals.get('coreServiceReady').dispatch(true);
-});
+};
+if (!Signals.get('newBlock').has(newBlockListener)) Signals.get('newBlock').add(newBlockListener);
 
 const getCurrentStatus = async () => features;
 

--- a/services/core/ready.js
+++ b/services/core/ready.js
@@ -31,18 +31,21 @@ const features = {
 const isCoreReady = () => !Object.keys(features).some(value => !features[value]);
 
 // Check if all blocks are indexed
-Signals.get('blockIndexReady').add(() => {
+const blockIndexReadyListener = () => {
 	logger.debug('Indexing finished');
 	features.isIndexReady = true;
-});
+};
+
+Signals.get('blockIndexReady').add(blockIndexReadyListener);
 
 // Check if transaction stats are built
-Signals.get('transactionStatsReady').add((days) => {
+const transactionStatsReadyListener = (days) => {
 	logger.debug('Transaction stats calculated for:', `${days}days`);
 	features.isTransactionStatsReady = true;
-});
+};
+Signals.get('transactionStatsReady').add(transactionStatsReadyListener);
 
-Signals.get('newBlock').add(async () => {
+const newBlockListener = async () => {
 	if (!isCoreReady()) {
 		// Check for fee estimates
 		logger.debug('Check if fee estmates are ready');
@@ -60,7 +63,8 @@ Signals.get('newBlock').add(async () => {
 	// Core reports readiness only if all services available
 	logger.debug(`============== 'coreServiceReady' signal: ${Signals.get('coreServiceReady')} ==============`);
 	if (isCoreReady()) Signals.get('coreServiceReady').dispatch(true);
-});
+};
+Signals.get('newBlock').add(newBlockListener);
 
 const getCurrentStatus = async () => features;
 

--- a/services/core/shared/core/compat/common/wsRequest.js
+++ b/services/core/shared/core/compat/common/wsRequest.js
@@ -13,8 +13,10 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { Logger, Signals } = require('lisk-service-framework');
+const { Logger } = require('lisk-service-framework');
 const { createWSClient } = require('@liskhq/lisk-api-client');
+
+const Signals = require('../../../signals');
 
 const config = require('../../../../config');
 

--- a/services/core/shared/core/compat/sdk_v2/index.js
+++ b/services/core/shared/core/compat/sdk_v2/index.js
@@ -13,7 +13,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { Logger, Signals } = require('lisk-service-framework');
+const { Logger } = require('lisk-service-framework');
+
+const Signals = require('../../../signals');
 
 const coreApi = require('./coreApi');
 

--- a/services/core/shared/core/compat/sdk_v3/index.js
+++ b/services/core/shared/core/compat/sdk_v3/index.js
@@ -13,7 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { Logger, Signals } = require('lisk-service-framework');
+const { Logger } = require('lisk-service-framework');
 
 const {
 	getBlocks,
@@ -29,6 +29,8 @@ const { getVotes } = require('./votes');
 const { getVoters } = require('./voters');
 const events = require('./events');
 const { getNetworkStatus } = require('./network');
+
+const Signals = require('../../../signals');
 
 const logger = Logger();
 

--- a/services/core/shared/core/compat/sdk_v4/blocks.js
+++ b/services/core/shared/core/compat/sdk_v4/blocks.js
@@ -13,9 +13,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { CacheRedis, Logger, Signals } = require('lisk-service-framework');
+const { CacheRedis, Logger } = require('lisk-service-framework');
 
 const coreApi = require('./coreApi');
+
+const Signals = require('../../../signals');
 
 const config = require('../../../../config');
 const { initializeQueue } = require('../../queue');

--- a/services/core/shared/core/compat/sdk_v4/transactions.js
+++ b/services/core/shared/core/compat/sdk_v4/transactions.js
@@ -154,11 +154,7 @@ const indexTransactionsListener = async (blockId) => {
 	});
 	transactionIdx.upsert(transactions.data);
 };
-if (!Signals.get('indexTransactions').has(indexTransactionsListener)) {
-	logger.debug('indexTransactions has indexTransactionsListener: ', Signals.get('indexTransactions').has(indexTransactionsListener));
-	Signals.get('indexTransactions').add(indexTransactionsListener);
-	logger.debug('indexTransactions has now registered indexTransactionsListener: ', Signals.get('indexTransactions').has(indexTransactionsListener));
-}
+if (!Signals.get('indexTransactions').has(indexTransactionsListener)) Signals.get('indexTransactions').add(indexTransactionsListener);
 
 const getPendingTransactionsFromCore = async params => {
 	const pendingTx = await coreApi.getPendingTransactions(params);

--- a/services/core/shared/core/compat/sdk_v4/transactions.js
+++ b/services/core/shared/core/compat/sdk_v4/transactions.js
@@ -137,7 +137,7 @@ const getTransactions = async params => {
 	return transactions;
 };
 
-Signals.get('indexTransactions').add(async blockId => {
+const indexTransactionsListener = async (blockId) => {
 	const transactionIdx = await getTransactionIdx();
 	const blockResult = await transactionIdx.find({ blockId }, 'id');
 	if (blockResult.length > 0) return;
@@ -153,7 +153,8 @@ Signals.get('indexTransactions').add(async blockId => {
 		tx.unixTimestamp = unixTimestamp;
 	});
 	transactionIdx.upsert(transactions.data);
-});
+};
+if (!Signals.get('indexTransactions').has(indexTransactionsListener)) Signals.get('indexTransactions').add(indexTransactionsListener);
 
 const getPendingTransactionsFromCore = async params => {
 	const pendingTx = await coreApi.getPendingTransactions(params);

--- a/services/core/shared/core/compat/sdk_v4/transactions.js
+++ b/services/core/shared/core/compat/sdk_v4/transactions.js
@@ -137,7 +137,7 @@ const getTransactions = async params => {
 	return transactions;
 };
 
-const indexTransactionsListener = async (blockId) => {
+Signals.get('indexTransactions').add(async blockId => {
 	const transactionIdx = await getTransactionIdx();
 	const blockResult = await transactionIdx.find({ blockId }, 'id');
 	if (blockResult.length > 0) return;
@@ -153,8 +153,7 @@ const indexTransactionsListener = async (blockId) => {
 		tx.unixTimestamp = unixTimestamp;
 	});
 	transactionIdx.upsert(transactions.data);
-};
-if (!Signals.get('indexTransactions').has(indexTransactionsListener)) Signals.get('indexTransactions').add(indexTransactionsListener);
+});
 
 const getPendingTransactionsFromCore = async params => {
 	const pendingTx = await coreApi.getPendingTransactions(params);

--- a/services/core/shared/core/compat/sdk_v4/transactions.js
+++ b/services/core/shared/core/compat/sdk_v4/transactions.js
@@ -154,7 +154,11 @@ const indexTransactionsListener = async (blockId) => {
 	});
 	transactionIdx.upsert(transactions.data);
 };
-if (!Signals.get('indexTransactions').has(indexTransactionsListener)) Signals.get('indexTransactions').add(indexTransactionsListener);
+if (!Signals.get('indexTransactions').has(indexTransactionsListener)) {
+	logger.debug('indexTransactions has indexTransactionsListener: ', Signals.get('indexTransactions').has(indexTransactionsListener));
+	Signals.get('indexTransactions').add(indexTransactionsListener);
+	logger.debug('indexTransactions has now registered indexTransactionsListener: ', Signals.get('indexTransactions').has(indexTransactionsListener));
+}
 
 const getPendingTransactionsFromCore = async params => {
 	const pendingTx = await coreApi.getPendingTransactions(params);

--- a/services/core/shared/core/compat/sdk_v4/transactions.js
+++ b/services/core/shared/core/compat/sdk_v4/transactions.js
@@ -13,10 +13,12 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { Logger, Signals } = require('lisk-service-framework');
+const { Logger } = require('lisk-service-framework');
 const BluebirdPromise = require('bluebird');
 const coreApi = require('./coreApi');
 const requestAll = require('../../../requestAll');
+
+const Signals = require('../../../signals');
 
 const logger = Logger();
 

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -544,11 +544,7 @@ const checkIndexReadiness = async () => {
 const init = async () => {
 	// Index every new incoming block
 	const indexNewBlocksListener = async (data) => { await indexNewBlocks(data); };
-	if (!Signals.get('newBlock').has(indexNewBlocksListener)) {
-		logger.debug('newBlock has indexNewBlocksListener: ', Signals.get('newBlock').has(indexNewBlocksListener));
-		Signals.get('newBlock').add(indexNewBlocksListener);
-		logger.debug('newBlock has now registered indexNewBlocksListener: ', Signals.get('newBlock').has(indexNewBlocksListener));
-	}
+	if (!Signals.get('newBlock').has(indexNewBlocksListener)) Signals.get('newBlock').add(indexNewBlocksListener);
 
 	// Check state of index and perform update
 	try {
@@ -566,11 +562,7 @@ const init = async () => {
 	}
 
 	// Check and update index readiness status
-	if (!Signals.get('newBlock').has(checkIndexReadiness)) {
-		logger.debug('newBlock has checkIndexReadiness: ', Signals.get('newBlock').has(checkIndexReadiness));
-		Signals.get('newBlock').add(checkIndexReadiness);
-		logger.debug('newBlock has now registered checkIndexReadiness: ', Signals.get('newBlock').has(checkIndexReadiness));
-	}
+	if (!Signals.get('newBlock').has(checkIndexReadiness)) Signals.get('newBlock').add(checkIndexReadiness);
 };
 
 module.exports = {

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -543,7 +543,8 @@ const checkIndexReadiness = async () => {
 
 const init = async () => {
 	// Index every new incoming block
-	Signals.get('newBlock').add(async data => { await indexNewBlocks(data); });
+	const indexNewBlocksListener = async (data) => { await indexNewBlocks(data); };
+	if (!Signals.get('newBlock').has(indexNewBlocksListener)) Signals.get('newBlock').add(indexNewBlocksListener);
 
 	// Check state of index and perform update
 	try {
@@ -561,7 +562,7 @@ const init = async () => {
 	}
 
 	// Check and update index readiness status
-	Signals.get('newBlock').add(checkIndexReadiness);
+	if (!Signals.get('newBlock').has(checkIndexReadiness)) Signals.get('newBlock').add(checkIndexReadiness);
 };
 
 module.exports = {

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -543,8 +543,7 @@ const checkIndexReadiness = async () => {
 
 const init = async () => {
 	// Index every new incoming block
-	const indexNewBlocksListener = async (data) => { await indexNewBlocks(data); };
-	if (!Signals.get('newBlock').has(indexNewBlocksListener)) Signals.get('newBlock').add(indexNewBlocksListener);
+	Signals.get('newBlock').add(async data => { await indexNewBlocks(data); });
 
 	// Check state of index and perform update
 	try {
@@ -562,7 +561,7 @@ const init = async () => {
 	}
 
 	// Check and update index readiness status
-	if (!Signals.get('newBlock').has(checkIndexReadiness)) Signals.get('newBlock').add(checkIndexReadiness);
+	Signals.get('newBlock').add(checkIndexReadiness);
 };
 
 module.exports = {

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -544,7 +544,11 @@ const checkIndexReadiness = async () => {
 const init = async () => {
 	// Index every new incoming block
 	const indexNewBlocksListener = async (data) => { await indexNewBlocks(data); };
-	if (!Signals.get('newBlock').has(indexNewBlocksListener)) Signals.get('newBlock').add(indexNewBlocksListener);
+	if (!Signals.get('newBlock').has(indexNewBlocksListener)) {
+		logger.debug('newBlock has indexNewBlocksListener: ', Signals.get('newBlock').has(indexNewBlocksListener));
+		Signals.get('newBlock').add(indexNewBlocksListener);
+		logger.debug('newBlock has now registered indexNewBlocksListener: ', Signals.get('newBlock').has(indexNewBlocksListener));
+	}
 
 	// Check state of index and perform update
 	try {
@@ -562,7 +566,11 @@ const init = async () => {
 	}
 
 	// Check and update index readiness status
-	if (!Signals.get('newBlock').has(checkIndexReadiness)) Signals.get('newBlock').add(checkIndexReadiness);
+	if (!Signals.get('newBlock').has(checkIndexReadiness)) {
+		logger.debug('newBlock has checkIndexReadiness: ', Signals.get('newBlock').has(checkIndexReadiness));
+		Signals.get('newBlock').add(checkIndexReadiness);
+		logger.debug('newBlock has now registered checkIndexReadiness: ', Signals.get('newBlock').has(checkIndexReadiness));
+	}
 };
 
 module.exports = {

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -17,9 +17,10 @@ const BluebirdPromise = require('bluebird');
 const util = require('util');
 const {
 	Logger,
-	Signals,
 	Exceptions: { ValidationException, NotFoundException },
 } = require('lisk-service-framework');
+
+const Signals = require('../../../signals');
 
 const coreApi = require('./coreApi');
 const config = require('../../../../config');

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -544,7 +544,8 @@ const checkIndexReadiness = async () => {
 
 const init = async () => {
 	// Index every new incoming block
-	Signals.get('newBlock').add(async data => { await indexNewBlocks(data); });
+	const indexNewBlocksListener = async (data) => { await indexNewBlocks(data); };
+	Signals.get('newBlock').add(indexNewBlocksListener);
 
 	// Check state of index and perform update
 	try {

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -505,7 +505,7 @@ const indexPastBlocks = async () => {
 
 	// Highest block available within the index
 	// If index empty, default lastIndexedHeight (alias for height) to blockIndexLowerRange
-	const [{ height: lastIndexedHeight = blockIndexLowerRange } = {}] = await blocksDB.find({ sort: 'height:desc', limit: 1 });
+	const [{ height: lastIndexedHeight = blockIndexLowerRange } = {}] = await blocksDB.find({ sort: 'height:desc', limit: 1, isFinal: true });
 	const highestIndexedHeight = lastIndexedHeight > blockIndexLowerRange
 		? lastIndexedHeight : blockIndexLowerRange;
 

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -284,21 +284,13 @@ const updateDelegateListEveryBlock = () => {
 			if (updatedDelegateAddresses.length) await computeDelegateRank();
 		}
 	};
-	if (!Signals.get('newBlock').has(updateDelegateCacheListener)) {
-		logger.debug('newBlock has updateDelegateCacheListener: ', Signals.get('newBlock').has(updateDelegateCacheListener));
-		Signals.get('newBlock').add(updateDelegateCacheListener);
-		logger.debug('newBlock has now registered updateDelegateCacheListener: ', Signals.get('newBlock').has(updateDelegateCacheListener));
-	}
+	if (!Signals.get('newBlock').has(updateDelegateCacheListener)) Signals.get('newBlock').add(updateDelegateCacheListener);
 };
 
 // Reload the delegate cache when all the indexes are up-to-date
 const refreshDelegateListOnIndexReady = () => {
 	const reloadDelegateCacheListener = () => reload();
-	if (!Signals.get('blockIndexReady').has(reloadDelegateCacheListener)) {
-		logger.debug('blockIndexReady has reloadDelegateCacheListener: ', Signals.get('blockIndexReady').has(reloadDelegateCacheListener));
-		Signals.get('blockIndexReady').add(reloadDelegateCacheListener);
-		logger.debug('blockIndexReady has now registered reloadDelegateCacheListener: ', Signals.get('blockIndexReady').has(reloadDelegateCacheListener));
-	}
+	if (!Signals.get('blockIndexReady').has(reloadDelegateCacheListener)) Signals.get('blockIndexReady').add(reloadDelegateCacheListener);
 };
 
 updateDelegateListEveryBlock();

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -250,48 +250,42 @@ const reload = async () => {
 };
 
 // Keep the delegate cache up-to-date
-const updateDelegateListEveryBlock = () => {
-	const updateDelegateCacheListener = async (data) => {
-		const dposModuleId = 5;
-		const registerDelegateAssetId = 0;
-		const voteDelegateAssetId = 1;
+const updateDelegateListEveryBlock = () => Signals.get('newBlock').add(async data => {
+	const dposModuleId = 5;
+	const registerDelegateAssetId = 0;
+	const voteDelegateAssetId = 1;
 
-		const updatedDelegateAddresses = [];
-		const [block] = data.data;
-		if (block && block.payload) {
-			block.payload.forEach(tx => {
-				if (tx.moduleID === dposModuleId) {
-					if (tx.assetID === registerDelegateAssetId) {
-						updatedDelegateAddresses
-							.push(coreApi.getBase32AddressFromPublicKey(tx.senderPublicKey));
-					} else if (tx.assetID === voteDelegateAssetId) {
-						tx.asset.votes.forEach(vote => updatedDelegateAddresses
-							.push(coreApi.getBase32AddressFromHex(vote.delegateAddress)));
-					}
+	const updatedDelegateAddresses = [];
+	const [block] = data.data;
+	if (block && block.payload) {
+		block.payload.forEach(tx => {
+			if (tx.moduleID === dposModuleId) {
+				if (tx.assetID === registerDelegateAssetId) {
+					updatedDelegateAddresses
+						.push(coreApi.getBase32AddressFromPublicKey(tx.senderPublicKey));
+				} else if (tx.assetID === voteDelegateAssetId) {
+					tx.asset.votes.forEach(vote => updatedDelegateAddresses
+						.push(coreApi.getBase32AddressFromHex(vote.delegateAddress)));
 				}
-			});
+			}
+		});
 
-			const { data: updatedDelegateAccounts } = await coreApi
-				.getAccounts({ addresses: updatedDelegateAddresses });
+		const { data: updatedDelegateAccounts } = await coreApi
+			.getAccounts({ addresses: updatedDelegateAddresses });
 
-			updatedDelegateAccounts.forEach(delegate => {
-				const delegateIndex = delegateList.findIndex(acc => acc.address === delegate.address);
-				if (delegateIndex === -1) delegateList.push(delegate);
-				else delegateList[delegateIndex] = delegate;
-			});
+		updatedDelegateAccounts.forEach(delegate => {
+			const delegateIndex = delegateList.findIndex(acc => acc.address === delegate.address);
+			if (delegateIndex === -1) delegateList.push(delegate);
+			else delegateList[delegateIndex] = delegate;
+		});
 
-			// Rank is impacted only when a delegate gets (un-)voted
-			if (updatedDelegateAddresses.length) await computeDelegateRank();
-		}
-	};
-	if (!Signals.get('newBlock').has(updateDelegateCacheListener)) Signals.get('newBlock').add(updateDelegateCacheListener);
-};
+		// Rank is impacted only when a delegate gets (un-)voted
+		if (updatedDelegateAddresses.length) await computeDelegateRank();
+	}
+});
 
 // Reload the delegate cache when all the indexes are up-to-date
-const refreshDelegateListOnIndexReady = () => {
-	const reloadDelegateCacheListener = () => reload();
-	if (!Signals.get('blockIndexReady').has(reloadDelegateCacheListener)) Signals.get('blockIndexReady').add(reloadDelegateCacheListener);
-};
+const refreshDelegateListOnIndexReady = () => Signals.get('blockIndexReady').add(() => reload());
 
 updateDelegateListEveryBlock();
 refreshDelegateListOnIndexReady();

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -250,42 +250,48 @@ const reload = async () => {
 };
 
 // Keep the delegate cache up-to-date
-const updateDelegateListEveryBlock = () => Signals.get('newBlock').add(async data => {
-	const dposModuleId = 5;
-	const registerDelegateAssetId = 0;
-	const voteDelegateAssetId = 1;
+const updateDelegateListEveryBlock = () => {
+	const updateDelegateCacheListener = async (data) => {
+		const dposModuleId = 5;
+		const registerDelegateAssetId = 0;
+		const voteDelegateAssetId = 1;
 
-	const updatedDelegateAddresses = [];
-	const [block] = data.data;
-	if (block && block.payload) {
-		block.payload.forEach(tx => {
-			if (tx.moduleID === dposModuleId) {
-				if (tx.assetID === registerDelegateAssetId) {
-					updatedDelegateAddresses
-						.push(coreApi.getBase32AddressFromPublicKey(tx.senderPublicKey));
-				} else if (tx.assetID === voteDelegateAssetId) {
-					tx.asset.votes.forEach(vote => updatedDelegateAddresses
-						.push(coreApi.getBase32AddressFromHex(vote.delegateAddress)));
+		const updatedDelegateAddresses = [];
+		const [block] = data.data;
+		if (block && block.payload) {
+			block.payload.forEach(tx => {
+				if (tx.moduleID === dposModuleId) {
+					if (tx.assetID === registerDelegateAssetId) {
+						updatedDelegateAddresses
+							.push(coreApi.getBase32AddressFromPublicKey(tx.senderPublicKey));
+					} else if (tx.assetID === voteDelegateAssetId) {
+						tx.asset.votes.forEach(vote => updatedDelegateAddresses
+							.push(coreApi.getBase32AddressFromHex(vote.delegateAddress)));
+					}
 				}
-			}
-		});
+			});
 
-		const { data: updatedDelegateAccounts } = await coreApi
-			.getAccounts({ addresses: updatedDelegateAddresses });
+			const { data: updatedDelegateAccounts } = await coreApi
+				.getAccounts({ addresses: updatedDelegateAddresses });
 
-		updatedDelegateAccounts.forEach(delegate => {
-			const delegateIndex = delegateList.findIndex(acc => acc.address === delegate.address);
-			if (delegateIndex === -1) delegateList.push(delegate);
-			else delegateList[delegateIndex] = delegate;
-		});
+			updatedDelegateAccounts.forEach(delegate => {
+				const delegateIndex = delegateList.findIndex(acc => acc.address === delegate.address);
+				if (delegateIndex === -1) delegateList.push(delegate);
+				else delegateList[delegateIndex] = delegate;
+			});
 
-		// Rank is impacted only when a delegate gets (un-)voted
-		if (updatedDelegateAddresses.length) await computeDelegateRank();
-	}
-});
+			// Rank is impacted only when a delegate gets (un-)voted
+			if (updatedDelegateAddresses.length) await computeDelegateRank();
+		}
+	};
+	if (!Signals.get('newBlock').has(updateDelegateCacheListener)) Signals.get('newBlock').add(updateDelegateCacheListener);
+};
 
 // Reload the delegate cache when all the indexes are up-to-date
-const refreshDelegateListOnIndexReady = () => Signals.get('blockIndexReady').add(() => reload());
+const refreshDelegateListOnIndexReady = () => {
+	const reloadDelegateCacheListener = () => reload();
+	if (!Signals.get('blockIndexReady').has(reloadDelegateCacheListener)) Signals.get('blockIndexReady').add(reloadDelegateCacheListener);
+};
 
 updateDelegateListEveryBlock();
 refreshDelegateListOnIndexReady();

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -284,13 +284,21 @@ const updateDelegateListEveryBlock = () => {
 			if (updatedDelegateAddresses.length) await computeDelegateRank();
 		}
 	};
-	if (!Signals.get('newBlock').has(updateDelegateCacheListener)) Signals.get('newBlock').add(updateDelegateCacheListener);
+	if (!Signals.get('newBlock').has(updateDelegateCacheListener)) {
+		logger.debug('newBlock has updateDelegateCacheListener: ', Signals.get('newBlock').has(updateDelegateCacheListener));
+		Signals.get('newBlock').add(updateDelegateCacheListener);
+		logger.debug('newBlock has now registered updateDelegateCacheListener: ', Signals.get('newBlock').has(updateDelegateCacheListener));
+	}
 };
 
 // Reload the delegate cache when all the indexes are up-to-date
 const refreshDelegateListOnIndexReady = () => {
 	const reloadDelegateCacheListener = () => reload();
-	if (!Signals.get('blockIndexReady').has(reloadDelegateCacheListener)) Signals.get('blockIndexReady').add(reloadDelegateCacheListener);
+	if (!Signals.get('blockIndexReady').has(reloadDelegateCacheListener)) {
+		logger.debug('blockIndexReady has reloadDelegateCacheListener: ', Signals.get('blockIndexReady').has(reloadDelegateCacheListener));
+		Signals.get('blockIndexReady').add(reloadDelegateCacheListener);
+		logger.debug('blockIndexReady has now registered reloadDelegateCacheListener: ', Signals.get('blockIndexReady').has(reloadDelegateCacheListener));
+	}
 };
 
 updateDelegateListEveryBlock();

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -13,9 +13,10 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { Logger, CacheRedis, Signals } = require('lisk-service-framework');
+const { Logger, CacheRedis } = require('lisk-service-framework');
 const BluebirdPromise = require('bluebird');
 
+const Signals = require('../signals');
 const config = require('../../config');
 
 const cacheRedisDelegates = CacheRedis('delegates', config.endpoints.redis);

--- a/services/core/shared/core/events.js
+++ b/services/core/shared/core/events.js
@@ -88,6 +88,6 @@ const init = () => {
 init();
 
 // Re-subscribe to the events whenever a new client is instantiated
-Signals.get('newApiClient').add(() => { init(); });
+Signals.get('newApiClient').add(init);
 
 module.exports = { init };

--- a/services/core/shared/core/events.js
+++ b/services/core/shared/core/events.js
@@ -88,6 +88,10 @@ init();
 
 // Re-subscribe to the events whenever a new client is instantiated
 const newApiClientListener = () => { init(); };
-if (!Signals.get('newApiClient').has(newApiClientListener)) Signals.get('newApiClient').add(newApiClientListener);
+if (!Signals.get('newApiClient').has(newApiClientListener)) {
+	logger.debug('newApiClient has newApiClientListener: ', Signals.get('newApiClient').has(newApiClientListener));
+	Signals.get('newApiClient').add(newApiClientListener);
+	logger.debug('newApiClient has now registered newApiClientListener: ', Signals.get('newApiClient').has(newApiClientListener));
+}
 
 module.exports = { init };

--- a/services/core/shared/core/events.js
+++ b/services/core/shared/core/events.js
@@ -88,10 +88,6 @@ init();
 
 // Re-subscribe to the events whenever a new client is instantiated
 const newApiClientListener = () => { init(); };
-if (!Signals.get('newApiClient').has(newApiClientListener)) {
-	logger.debug('newApiClient has newApiClientListener: ', Signals.get('newApiClient').has(newApiClientListener));
-	Signals.get('newApiClient').add(newApiClientListener);
-	logger.debug('newApiClient has now registered newApiClientListener: ', Signals.get('newApiClient').has(newApiClientListener));
-}
+if (!Signals.get('newApiClient').has(newApiClientListener)) Signals.get('newApiClient').add(newApiClientListener);
 
 module.exports = { init };

--- a/services/core/shared/core/events.js
+++ b/services/core/shared/core/events.js
@@ -87,7 +87,6 @@ const init = () => {
 init();
 
 // Re-subscribe to the events whenever a new client is instantiated
-const newApiClientListener = () => { init(); };
-if (!Signals.get('newApiClient').has(newApiClientListener)) Signals.get('newApiClient').add(newApiClientListener);
+Signals.get('newApiClient').add(() => { init(); });
 
 module.exports = { init };

--- a/services/core/shared/core/events.js
+++ b/services/core/shared/core/events.js
@@ -13,8 +13,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { Logger, Signals } = require('lisk-service-framework');
+const { Logger } = require('lisk-service-framework');
 const core = require('./compat');
+const Signals = require('../signals');
 
 const {
 	performLastBlockUpdate,

--- a/services/core/shared/core/events.js
+++ b/services/core/shared/core/events.js
@@ -87,6 +87,7 @@ const init = () => {
 init();
 
 // Re-subscribe to the events whenever a new client is instantiated
-Signals.get('newApiClient').add(() => { init(); });
+const newApiClientListener = () => { init(); };
+if (!Signals.get('newApiClient').has(newApiClientListener)) Signals.get('newApiClient').add(newApiClientListener);
 
 module.exports = { init };

--- a/services/core/shared/core/peerCache.js
+++ b/services/core/shared/core/peerCache.js
@@ -13,7 +13,9 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { Logger, Signals } = require('lisk-service-framework');
+const { Logger } = require('lisk-service-framework');
+
+const Signals = require('../signals');
 
 const coreApi = require('./compat');
 const requestAll = require('../requestAll');

--- a/services/core/shared/core/transactionStatistics.js
+++ b/services/core/shared/core/transactionStatistics.js
@@ -248,12 +248,11 @@ const fetchTransactionsForPastNDays = async (n, forceReload = false) => {
 };
 
 const init = async historyLengthDays => {
-	const transactionStatsListener = async () => {
+	Signals.get('blockIndexReady').add(async () => {
 		await fetchTransactionsForPastNDays(historyLengthDays, true);
 		logger.debug(`============== 'transactionStatsReady' signal: ${Signals.get('transactionStatsReady')} ==============`);
 		Signals.get('transactionStatsReady').dispatch(historyLengthDays);
-	};
-	if (!Signals.get('blockIndexReady').has(transactionStatsListener)) Signals.get('blockIndexReady').add(transactionStatsListener);
+	});
 };
 
 const updateTodayStats = async () => fetchTransactionsForPastNDays(1, true);

--- a/services/core/shared/core/transactionStatistics.js
+++ b/services/core/shared/core/transactionStatistics.js
@@ -253,11 +253,7 @@ const init = async historyLengthDays => {
 		logger.debug(`============== 'transactionStatsReady' signal: ${Signals.get('transactionStatsReady')} ==============`);
 		Signals.get('transactionStatsReady').dispatch(historyLengthDays);
 	};
-	if (!Signals.get('blockIndexReady').has(transactionStatsListener)) {
-		logger.debug('blockIndexReady has transactionStatsListener: ', Signals.get('blockIndexReady').has(transactionStatsListener));
-		Signals.get('blockIndexReady').add(transactionStatsListener);
-		logger.debug('blockIndexReady has now registered transactionStatsListener: ', Signals.get('blockIndexReady').has(transactionStatsListener));
-	}
+	if (!Signals.get('blockIndexReady').has(transactionStatsListener)) Signals.get('blockIndexReady').add(transactionStatsListener);
 };
 
 const updateTodayStats = async () => fetchTransactionsForPastNDays(1, true);

--- a/services/core/shared/core/transactionStatistics.js
+++ b/services/core/shared/core/transactionStatistics.js
@@ -253,7 +253,11 @@ const init = async historyLengthDays => {
 		logger.debug(`============== 'transactionStatsReady' signal: ${Signals.get('transactionStatsReady')} ==============`);
 		Signals.get('transactionStatsReady').dispatch(historyLengthDays);
 	};
-	if (!Signals.get('blockIndexReady').has(transactionStatsListener)) Signals.get('blockIndexReady').add(transactionStatsListener);
+	if (!Signals.get('blockIndexReady').has(transactionStatsListener)) {
+		logger.debug('blockIndexReady has transactionStatsListener: ', Signals.get('blockIndexReady').has(transactionStatsListener));
+		Signals.get('blockIndexReady').add(transactionStatsListener);
+		logger.debug('blockIndexReady has now registered transactionStatsListener: ', Signals.get('blockIndexReady').has(transactionStatsListener));
+	}
 };
 
 const updateTodayStats = async () => fetchTransactionsForPastNDays(1, true);

--- a/services/core/shared/core/transactionStatistics.js
+++ b/services/core/shared/core/transactionStatistics.js
@@ -250,11 +250,12 @@ const fetchTransactionsForPastNDays = async (n, forceReload = false) => {
 };
 
 const init = async historyLengthDays => {
-	Signals.get('blockIndexReady').add(async () => {
+	const transactionStatsListener = async () => {
 		await fetchTransactionsForPastNDays(historyLengthDays, true);
 		logger.debug(`============== 'transactionStatsReady' signal: ${Signals.get('transactionStatsReady')} ==============`);
 		Signals.get('transactionStatsReady').dispatch(historyLengthDays);
-	});
+	};
+	Signals.get('blockIndexReady').add(transactionStatsListener);
 };
 
 const updateTodayStats = async () => fetchTransactionsForPastNDays(1, true);

--- a/services/core/shared/core/transactionStatistics.js
+++ b/services/core/shared/core/transactionStatistics.js
@@ -248,11 +248,12 @@ const fetchTransactionsForPastNDays = async (n, forceReload = false) => {
 };
 
 const init = async historyLengthDays => {
-	Signals.get('blockIndexReady').add(async () => {
+	const transactionStatsListener = async () => {
 		await fetchTransactionsForPastNDays(historyLengthDays, true);
 		logger.debug(`============== 'transactionStatsReady' signal: ${Signals.get('transactionStatsReady')} ==============`);
 		Signals.get('transactionStatsReady').dispatch(historyLengthDays);
-	});
+	};
+	if (!Signals.get('blockIndexReady').has(transactionStatsListener)) Signals.get('blockIndexReady').add(transactionStatsListener);
 };
 
 const updateTodayStats = async () => fetchTransactionsForPastNDays(1, true);

--- a/services/core/shared/core/transactionStatistics.js
+++ b/services/core/shared/core/transactionStatistics.js
@@ -13,9 +13,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { Logger, Signals } = require('lisk-service-framework');
+const { Logger } = require('lisk-service-framework');
 const moment = require('moment');
 const BigNumber = require('big-number');
+
+const Signals = require('../signals');
 
 const config = require('../../config');
 const { getTransactions } = require('./transactions');

--- a/services/core/shared/signals.js
+++ b/services/core/shared/signals.js
@@ -1,0 +1,38 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2020 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const Signal = require('signals');
+
+const { Logger } = require('lisk-service-framework');
+
+const logger = Logger();
+
+const signals = {};
+
+const register = name => {
+	signals[name] = new Signal();
+	logger.debug(`Registered internal signal ${name}`);
+	return signals[name];
+};
+
+const get = name => {
+	const signal = signals[name] ? signals[name] : register(name);
+	return {
+		dispatch: signal.dispatch,
+		add: (listener) => { if (!signal.has(listener)) signal.add(listener) },
+	};
+};
+
+module.exports = { register, get };

--- a/services/core/shared/signals.js
+++ b/services/core/shared/signals.js
@@ -31,7 +31,7 @@ const get = name => {
 	const signal = signals[name] ? signals[name] : register(name);
 	return {
 		dispatch: signal.dispatch,
-		add: (listener) => { if (!signal.has(listener)) signal.add(listener) },
+		add: (listener) => { if (!signal.has(listener)) signal.add(listener); },
 	};
 };
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #648 

### How was it solved?
- [x] Prevent adding a listener to the Signal if it already is registered
- [x] Simplify implementation for `getApiClient`
- [x] Ensure `isFeeEstimatesReady` is not ready when the response status is `SERVICE_UNAVAILABLE`
- [x] Consider the highest finalized indexed block height to continue indexing the past blocks (cherry-picked from #663)

### How was it tested?
Local
