### PR TITLE
Fix fee estimator genesis height - Closes #653

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/dynamicFees.js
+++ b/services/core/shared/core/compat/sdk_v5/dynamicFees.js
@@ -16,7 +16,7 @@
 const BluebirdPromise = require('bluebird');
 const { CacheRedis, Logger } = require('lisk-service-framework');
 
-const { getBlocks } = require('./blocks');
+const { getBlocks, getGenesisHeight } = require('./blocks');
 const { getApiClient } = require('../common');
 const { calcAvgFeeByteModes, EMAcalc } = require('../common/dynamicFees');
 
@@ -144,7 +144,7 @@ const getEstimateFeeByteForBlock = async (blockBatch, innerPrevFeeEstPerByte) =>
 
 const getEstimateFeeByteForBatch = async (fromHeight, toHeight, cacheKey) => {
 	const transactionsDB = await getTransactionsIndex();
-	const { genesisHeight } = config;
+	const genesisHeight = getGenesisHeight();
 	const { defaultStartBlockHeight } = config.feeEstimates;
 
 	// Check if the starting height is permitted by config or adjust acc.


### PR DESCRIPTION
### What was the problem?
This PR resolves #653 

### How was it solved?
- [x] Set `genesisHeight` properly within `getEstimateFeeByteForBatch` for SDKv5

### How was it tested?
Local + Jenkins
