### PR TITLE
Fix delegate vote weight calculation - Closes #669

### DIFF
--- a/docs/api/version2.md
+++ b/docs/api/version2.md
@@ -141,6 +141,7 @@ Make the version 2 API able to retrieve data by those criteria.
         "consecutiveMissedBlocks": 0,
         "lastForgedHeight": 68115,
         "isBanned": false,
+        "voteWeight": "201000000000",
         "totalVotesReceived": "201000000000",
       },
       "sentVotes": [

--- a/services/core/config.js
+++ b/services/core/config.js
@@ -45,7 +45,7 @@ config.networks = [
 	{
 		name: 'mainnet',
 		identifier: 'update_after_migration',
-		genesisHeight: 16301502,
+		genesisHeight: 16270293,
 		genesisBlockUrl: 'https://downloads.lisk.io/lisk/mainnet/genesis_block.json.tar.gz',
 	},
 	{

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -173,15 +173,15 @@ const resolveDelegateInfo = async accounts => {
 					publicKey: account.publicKey,
 				};
 
-				const adder = (acc, curr) => BigInt(acc) + BigInt(curr.amount);
-				const totalVotes = account.dpos.sentVotes.reduce(adder, BigInt(0));
 				const selfVote = account.dpos.sentVotes
 					.find(vote => vote.delegateAddress === account.address);
 				const selfVoteAmount = selfVote ? BigInt(selfVote.amount) : BigInt(0);
 				const cap = selfVoteAmount * BigInt(10);
 
 				account.totalVotesReceived = BigInt(account.dpos.delegate.totalVotesReceived);
-				const voteWeight = BigInt(totalVotes) > cap ? cap : account.totalVotesReceived;
+				const voteWeight = BigInt(account.totalVotesReceived) > cap
+					? cap
+					: account.totalVotesReceived;
 
 				account.delegateWeight = voteWeight;
 				account.username = account.dpos.delegate.username;

--- a/services/gateway/sources/version2/mappings/account.js
+++ b/services/gateway/sources/version2/mappings/account.js
@@ -60,6 +60,7 @@ module.exports = {
 			registrationHeight: '=,number',
 			lastForgedHeight: '=,number',
 			isBanned: '=,boolean',
+			voteWeight: 'delegateWeight,string',
 			totalVotesReceived: '=,string',
 			missedBlocks: '=,number',
 			producedBlocks: 'producedBlocks,number',


### PR DESCRIPTION
### What was the problem?
This PR resolves #669 

### How was it solved?
- [x] Use `totalVotesReceived` instead of aggregating `account.dpos.sentVotes` as `totalVotes`
- [x] Pass through the calculated `voteWeight` within the response
- [x] Update revised mainnet genesis block height

### How was it tested?
Local
