### PR TITLE
Fix produced blocks and rewards calculation - Closes #676

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -228,8 +228,8 @@ const resolveDelegateInfo = async accounts => {
 const indexAccountsbyPublicKey = async (accountInfoArray) => {
 	const accountsDB = await getAccountsIndex();
 	const finalAccountsToIndex = await BluebirdPromise.map(
-		dropDuplicates(accountInfoArray
-			.map(accountInfo => getHexAddressFromPublicKey(accountInfo.publicKey))),
+		accountInfoArray
+			.map(accountInfo => getHexAddressFromPublicKey(accountInfo.publicKey)),
 		async address => {
 			const { data: [account] } = await getAccountsFromCore({ address });
 			const [accountInfo] = accountInfoArray

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -245,7 +245,14 @@ const indexAccountsbyPublicKey = async (accountInfoArray) => {
 						property: 'address',
 						value: account.address,
 					},
-				}, account);
+				}, {
+					...account,
+					balance: account.token.balance,
+					username: account.dpos.delegate.username,
+					rewards: accountInfo.reward,
+					producedBlocks: 1,
+					totalVotesReceived: account.dpos.delegate.totalVotesReceived,
+				});
 			}
 			return account;
 		},

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -589,7 +589,6 @@ const checkIndexReadiness = async () => {
 				Signals.get('blockIndexReady').dispatch(true);
 			} else {
 				logger.debug('Blocks index is not yet ready');
-				await indexMissingBlocks(getIndexStartHeight(), currentChainHeight);
 			}
 		} catch (err) {
 			logger.warn(`Error while checking index readiness: ${err.message}`);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -589,6 +589,7 @@ const checkIndexReadiness = async () => {
 				Signals.get('blockIndexReady').dispatch(true);
 			} else {
 				logger.debug('Blocks index is not yet ready');
+				await indexMissingBlocks(getIndexStartHeight(), currentChainHeight);
 			}
 		} catch (err) {
 			logger.warn(`Error while checking index readiness: ${err.message}`);

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -288,7 +288,7 @@ const updateDelegateListEveryBlock = () => {
 			// Rank is impacted only when a delegate gets (un-)voted
 			if (updatedDelegateAddresses.length) await computeDelegateRank();
 
-			// Update producedBlocks and rewards
+			// Update delegate cache with producedBlocks and rewards
 			const delegateIndex = delegateList.findIndex(acc => acc.address === block.generatorAddress);
 			if (delegateList[delegateIndex]
 				&& Object.getOwnPropertyNames(delegateList[delegateIndex]).length) {

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -290,7 +290,8 @@ const updateDelegateListEveryBlock = () => {
 
 			// Update producedBlocks and rewards
 			const delegateIndex = delegateList.findIndex(acc => acc.address === block.generatorAddress);
-			if (delegateList[delegateIndex] && Object.getOwnPropertyNames(delegateList[delegateIndex]).length) {
+			if (delegateList[delegateIndex]
+				&& Object.getOwnPropertyNames(delegateList[delegateIndex]).length) {
 				if (delegateList[delegateIndex].producedBlocks && delegateList[delegateIndex].rewards) {
 					delegateList[delegateIndex].producedBlocks = eventType === 'newBlock'
 						? delegateList[delegateIndex].producedBlocks + 1

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -290,19 +290,25 @@ const updateDelegateListEveryBlock = () => {
 
 			// Update producedBlocks and rewards
 			const delegateIndex = delegateList.findIndex(acc => acc.address === block.generatorAddress);
-			if (delegateList[delegateIndex]) {
-				delegateList[delegateIndex].producedBlocks = eventType === 'newBlock'
-					? delegateList[delegateIndex].producedBlocks + 1
-					: delegateList[delegateIndex].producedBlocks - 1;
-				delegateList[delegateIndex].rewards = eventType === 'newBlock'
-					? BigInt(delegateList[delegateIndex].rewards) + BigInt(block.reward)
-					: BigInt(delegateList[delegateIndex].rewards) - BigInt(block.reward);
+			if (delegateList[delegateIndex] && Object.getOwnPropertyNames(delegateList[delegateIndex]).length) {
+				if (delegateList[delegateIndex].producedBlocks && delegateList[delegateIndex].rewards) {
+					delegateList[delegateIndex].producedBlocks = eventType === 'newBlock'
+						? delegateList[delegateIndex].producedBlocks + 1
+						: delegateList[delegateIndex].producedBlocks - 1;
+
+					delegateList[delegateIndex].rewards = eventType === 'newBlock'
+						? (BigInt(delegateList[delegateIndex].rewards) + BigInt(block.reward)).toString()
+						: (BigInt(delegateList[delegateIndex].rewards) - BigInt(block.reward)).toString();
+				}
 			}
 		}
 	};
 
-	Signals.get('newBlock').add(newBlock => { updateDelegateCacheListener('newBlock', newBlock); });
-	Signals.get('deleteBlock').add(newBlock => { updateDelegateCacheListener('deleteBlock', newBlock); });
+	const updateDelegateCacheOnNewBlockListener = (block) => updateDelegateCacheListener('newBlock', block);
+	const updateDelegateCacheOnDeleteBlockListener = (block) => updateDelegateCacheListener('deleteBlock', block);
+
+	Signals.get('newBlock').add(updateDelegateCacheOnNewBlockListener);
+	Signals.get('deleteBlock').add(updateDelegateCacheOnDeleteBlockListener);
 };
 
 // Reload the delegate cache when all the indexes are up-to-date

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -263,7 +263,7 @@ const updateDelegateListEveryBlock = () => {
 
 		const updatedDelegateAddresses = [];
 		const [block] = data.data;
-		if (block && block.payload) {
+		if (block && block.payload && Array.isArray(block.payload)) {
 			block.payload.forEach(tx => {
 				if (tx.moduleID === dposModuleId) {
 					if (tx.assetID === registerDelegateAssetId) {
@@ -281,8 +281,14 @@ const updateDelegateListEveryBlock = () => {
 
 			updatedDelegateAccounts.forEach(delegate => {
 				const delegateIndex = delegateList.findIndex(acc => acc.address === delegate.address);
-				if (delegateIndex === -1) delegateList.push(delegate);
-				else delegateList[delegateIndex] = delegate;
+				// Update delegate list on newBlock event
+				if (delegate.isDelegate) {
+					if (delegateIndex === -1) delegateList.push(delegate);
+					else delegateList[delegateIndex] = delegate;
+				// Remove delegate from list when deleteBlock event contains delegate registration tx
+				} else if (delegateIndex !== -1) {
+					delegateList.splice(delegateIndex, 1);
+				}
 			});
 
 			// Rank is impacted only when a delegate gets (un-)voted

--- a/services/core/shared/core/events.js
+++ b/services/core/shared/core/events.js
@@ -51,7 +51,7 @@ const events = {
 	deleteBlock: async (block) => {
 		await deleteBlock(block);
 		logger.debug(`============== 'deleteBlock' signal: ${Signals.get('deleteBlock')} ==============`);
-		Signals.get('deleteBlock').dispatch(block);
+		Signals.get('deleteBlock').dispatch({ data: [block] });
 	},
 	newRound: async () => {
 		await reloadDelegateCache();

--- a/services/core/shared/core/transactions.js
+++ b/services/core/shared/core/transactions.js
@@ -43,7 +43,9 @@ const mergeTransactions = async (params) => {
 
 	allTransactions.meta.count = allTransactions.data.length;
 	allTransactions.meta.offset = offset;
-	allTransactions.meta.total = (transactions.meta.total + pendingTxs.meta.total);
+	allTransactions.meta.total = pendingTxs.data.length
+		? (transactions.meta.total + pendingTxs.meta.total)
+		: transactions.meta.total;
 
 	return allTransactions;
 };

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -334,8 +334,9 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 		return resultSet;
 	};
 
-	const increment = async (params, row) => {
+	const increment = async (params, rawRow) => {
 		let result;
+		const [row] = mapRows([rawRow]);
 		try {
 			[result] = await knex.transaction(
 				trx => trx(tableName)

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -334,9 +334,9 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 		return resultSet;
 	};
 
-	const increment = async (params, rawRow) => {
+	const increment = async (params, rawRow = {}) => {
 		let result;
-		const [row] = mapRows([rawRow || {}]);
+		const [row] = mapRows([rawRow]);
 		try {
 			[result] = await knex.transaction(
 				trx => trx(tableName)

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -336,7 +336,7 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 
 	const increment = async (params, rawRow) => {
 		let result;
-		const [row] = mapRows([rawRow]);
+		const [row] = mapRows([rawRow || {}]);
 		try {
 			[result] = await knex.transaction(
 				trx => trx(tableName)


### PR DESCRIPTION
### What was the problem?
This PR resolves #676 

### How was it solved?
- [x] Fix `indexAccountsbyPublicKey` method
- [x] Add logic to update delegate cache with `producedBlocks` and `rewards` on every newBlock/deleteBlock event
- [x] Fix transactions `meta.total` when includePending is true

### How was it tested?
- [x] Locally against `testnet`