### PR TITLE
Cache accounts - Closes #688

### DIFF
--- a/docker/lisk-service/docker-compose.core.yml
+++ b/docker/lisk-service/docker-compose.core.yml
@@ -35,6 +35,17 @@ services:
     healthcheck:
       test: redis-cli ping
 
+  redis_core_volatile:
+    image: redis:5-alpine
+    volumes:
+      - ./redis/redis.volatile.conf:/etc/redis/redis.conf:ro
+    networks:
+      - core_network
+    restart: always
+    command: redis-server /etc/redis/redis.conf
+    healthcheck:
+      test: redis-cli ping
+
   mysql_core:
     image: mysql:5.7
     volumes:

--- a/docker/lisk-service/docker-compose.core.yml
+++ b/docker/lisk-service/docker-compose.core.yml
@@ -6,6 +6,7 @@ services:
     depends_on:
       - redis_common
       - redis_core
+      - redis_core_volatile
       - mysql_core
     networks:
       - services_network

--- a/docker/lisk-service/env/core.env
+++ b/docker/lisk-service/env/core.env
@@ -1,5 +1,6 @@
 # Lisk Service Core
 SERVICE_CORE_REDIS=redis://redis_core:6379/0
+SERVICE_CORE_REDIS_VOLATILE=redis://redis_core_volatile:6379/0
 SERVICE_CORE_MYSQL=mysql://lisk:password@mysql_core:3306/lisk
 
 # Lisk static assets, ie. known account lists

--- a/docker/redis/redis.volatile.conf
+++ b/docker/redis/redis.volatile.conf
@@ -11,5 +11,5 @@ tcp-keepalive 300
 appendonly no
 
 # Memory management
-maxmemory 1024mb
+maxmemory 512mb
 maxmemory-policy allkeys-lru

--- a/services/core/config.js
+++ b/services/core/config.js
@@ -31,6 +31,7 @@ config.httpTimeout = Number(process.env.LISK_CORE_CLIENT_TIMEOUT) || 30; // in s
 config.endpoints.liskHttp = `${(process.env.LISK_CORE_HTTP || 'http://127.0.0.1:8080')}/api`;
 config.endpoints.liskWs = process.env.LISK_CORE_WS || config.endpoints.liskHttp.replace('http', 'ws').replace('/api', '');
 config.endpoints.redis = process.env.SERVICE_CORE_REDIS || 'redis://localhost:6379/1';
+config.endpoints.volatileRedis = process.env.SERVICE_CORE_REDIS_VOLATILE || 'redis://localhost:6379/2';
 config.endpoints.liskStatic = process.env.LISK_STATIC || 'https://static-data.lisk.com';
 config.endpoints.geoip = process.env.GEOIP_JSON || 'https://geoip.lisk.io/json';
 config.endpoints.mysql = process.env.SERVICE_CORE_MYSQL || 'mysql://lisk:password@localhost:3306/lisk';

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -121,6 +121,8 @@ const getAccountsFromCore = async (params) => {
 
 	if (response.data) {
 		accounts.data = response.data.map(account => normalizeAccount(account));
+
+		// Cache the latest account information for 'CACHE_TTL' duration
 		await BluebirdPromise.map(
 			accounts.data,
 			async account => accountsCache.set(account.address, JSON.stringify(account), CACHE_TTL),
@@ -144,6 +146,7 @@ const getAccountsFromCache = async (params) => {
 			const accountString = await accountsCache.get(getBase32AddressFromHex(address));
 			if (accountString) return JSON.parse(accountString);
 
+			// Fetch account information from Core, if not present in cache
 			const { data: [account] } = await getAccountsFromCore({ address });
 			return account;
 		},

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -65,7 +65,7 @@ const getBlocksIndex = () => mysqlIndex('blocks', blocksIndexSchema);
 const getTransactionsIndex = () => mysqlIndex('transactions', transactionsIndexSchema);
 
 const ACCOUNTS_CACHE_TTL = 15 * 1000; // in milliseconds
-const accountsCache = CacheRedis('accounts', config.endpoints.redis);
+const accountsCache = CacheRedis('accounts', config.endpoints.volatileRedis);
 const legacyAccountCache = CacheRedis('legacyAccount', config.endpoints.redis);
 
 // A boolean mapping against the genesis account addresses to indicate migration status

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -118,7 +118,7 @@ const getAccountsFromCore = async (params) => {
 	if (response.data) {
 		accounts.data = response.data.map(account => normalizeAccount(account));
 
-		// Cache the latest account information for 'CACHE_TTL' duration
+		// Cache the latest account information for 'ACCOUNTS_CACHE_TTL' duration
 		await BluebirdPromise.map(
 			accounts.data,
 			async account => accountsCache

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -67,8 +67,8 @@ const getAccountsIndex = () => mysqlIndex('accounts', accountsIndexSchema);
 const getBlocksIndex = () => mysqlIndex('blocks', blocksIndexSchema);
 const getTransactionsIndex = () => mysqlIndex('transactions', transactionsIndexSchema);
 
-const CACHE_MAX_ITEMS = 2048;
-const CACHE_TTL = 10000; // in milliseconds
+const CACHE_MAX_ITEMS = 4096;
+const CACHE_TTL = 15 * 1000; // in milliseconds
 const accountsCache = CacheLRU('accounts', { max: CACHE_MAX_ITEMS, ttl: CACHE_TTL });
 const legacyAccountCache = CacheRedis('legacyAccount', config.endpoints.redis);
 
@@ -123,7 +123,7 @@ const getAccountsFromCore = async (params) => {
 		accounts.data = response.data.map(account => normalizeAccount(account));
 		await BluebirdPromise.map(
 			accounts.data,
-			async account => accountsCache.set(account.address, JSON.stringify(account)),
+			async account => accountsCache.set(account.address, JSON.stringify(account), CACHE_TTL),
 			{ concurrency: accounts.data.length },
 		);
 	}

--- a/services/core/shared/core/compat/sdk_v5/events.js
+++ b/services/core/shared/core/compat/sdk_v5/events.js
@@ -28,8 +28,14 @@ const register = async (events) => {
 		try {
 			const incomingBlock = apiClient.block.decode(Buffer.from(data.block, 'hex'));
 			const [newBlock] = await normalizeBlocks([incomingBlock]);
+			const affectedAccountAddresses = data.accounts.map(acc => {
+				const account = apiClient.account.decode(Buffer.from(acc, 'hex'));
+				const accountAddressHex = account.address.toString('hex');
+				return accountAddressHex;
+			});
 			logger.debug(`New block forged: ${newBlock.id} at height ${newBlock.height}`);
 			events.newBlock(newBlock);
+			events.updateAccountsByAddress(affectedAccountAddresses);
 			events.calculateFeeEstimate();
 		} catch (err) {
 			logger.error(`Error while processing the 'app:block:new' event:\n${err.stack}`);

--- a/services/core/shared/core/events.js
+++ b/services/core/shared/core/events.js
@@ -62,6 +62,14 @@ const events = {
 			logger.error(`Error occured when processing 'newBlock' event:\n${err.stack}`);
 		}
 	},
+	updateAccountsByAddress: async (addresses) => {
+		try {
+			logger.debug(`============== 'updateAccountsByAddress' signal: ${Signals.get('updateAccountsByAddress')} ==============`);
+			Signals.get('updateAccountsByAddress').dispatch(addresses);
+		} catch (err) {
+			logger.error(`Error occured when processing 'newBlock' event:\n${err.stack}`);
+		}
+	},
 	deleteBlock: async (block) => {
 		try {
 			await deleteBlock(block);


### PR DESCRIPTION
### What was the problem?
This PR resolves #688 

### How was it solved?
- [x] Use Redis configuration to keep the most often used accounts (LRU-policy)
- [x] Account retrieval from Lisk Core always updates the Redis LRU cache
- [x] Created a different function to retrieve cached account data
- [x] Always fetch account from the cache, if unavailable fetch from Core

### How was it tested?
Local
