### PR TITLE
Make genesis block indexing able to resume - Closes #719

### DIFF
--- a/ecosystem.core3.config.js
+++ b/ecosystem.core3.config.js
@@ -27,7 +27,6 @@ module.exports = {
 			watch: false,
 			kill_timeout: 10000,
 			max_memory_restart: '512M',
-			instances: 1,
 			autorestart: true,
 			env: {
 				PORT: '9901',
@@ -50,7 +49,6 @@ module.exports = {
 			watch: false,
 			kill_timeout: 10000,
 			max_memory_restart: '1G',
-			instances: 1,
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -80,7 +78,6 @@ module.exports = {
 			watch: false,
 			kill_timeout: 10000,
 			max_memory_restart: '512M',
-			instances: 1,
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below

--- a/ecosystem.jenkins.config.js
+++ b/ecosystem.jenkins.config.js
@@ -27,7 +27,6 @@ module.exports = {
 			watch: false,
 			kill_timeout: 10000,
 			max_memory_restart: '512M',
-			instances: 1,
 			autorestart: true,
 			env: {
 				PORT: '9901',
@@ -46,7 +45,6 @@ module.exports = {
 			watch: false,
 			kill_timeout: 10000,
 			max_memory_restart: '512M',
-			instances: 1,
 			autorestart: true,
 			env: {
 				SERVICE_BROKER: 'redis://localhost:6379/0',
@@ -74,7 +72,6 @@ module.exports = {
 			watch: false,
 			kill_timeout: 10000,
 			max_memory_restart: '512M',
-			instances: 1,
 			autorestart: true,
 			env: {
 				SERVICE_BROKER: 'redis://localhost:6379/0',

--- a/services/core/config.js
+++ b/services/core/config.js
@@ -45,7 +45,7 @@ config.genesisBlockUrl = process.env.GENESIS_BLOCK_URL || '';
 config.networks = [
 	{
 		name: 'mainnet',
-		identifier: 'update_after_migration',
+		identifier: '4c09e6a781fc4c7bdb936ee815de8f94190f8a7519becd9de2081832be309a99',
 		genesisHeight: 16270293,
 		genesisBlockUrl: 'https://downloads.lisk.io/lisk/mainnet/genesis_block.json.tar.gz',
 	},

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -430,7 +430,10 @@ const indexGenesisAccounts = async () => {
 
 			// If the cache doesn't contain information, it'll be updated later on successful completion
 			const indexedTillBatch = await genesisAccountsCache.get('indexedTillBatch');
-			if (indexedTillBatch !== undefined && numAccountsIndexed < ((indexedTillBatch + 1) * BATCH_SIZE)) {
+			if (
+				indexedTillBatch !== undefined
+				&& numAccountsIndexed < ((indexedTillBatch + 1) * BATCH_SIZE)
+			) {
 				// Resume indexing starting from the batch that was last indexed
 				genesisAccountIndexingBatchNum = indexedTillBatch;
 				logger.info(`Genesis accounts already indexed until batch: ${genesisAccountIndexingBatchNum - 1}, will continue from batch ${genesisAccountIndexingBatchNum}`);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -615,7 +615,7 @@ const indexPastBlocks = async () => {
 
 	// Highest finalized block available within the index
 	// If index empty, default lastIndexedHeight (alias for height) to blockIndexLowerRange
-	const [{ height: lastIndexedHeight = blockIndexLowerRange } = {}] = await blocksDB.find({ sort: 'height:desc', limit: 1, isFinal: true });
+	const [{ height: lastIndexedHeight = blockIndexLowerRange } = {}] = await blocksDB.find({ sort: 'height:desc', limit: 1 });
 	const highestIndexedHeight = lastIndexedHeight > blockIndexLowerRange
 		? lastIndexedHeight : blockIndexLowerRange;
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #719 

### How was it solved?
- [x] Slower and controlled genesis account indexing
- [x] On init, resume genesis account indexing from where it was last stopped
- [x] Update PM2 config to display logs
- [x] Update `mainnet` identifier within `services/core/config.js`

### How was it tested?
Local
