### PR TITLE
Fix unlocking objects for accounts - Closes #894

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -179,8 +179,7 @@ const resolveAccountInfo = async accounts => BluebirdPromise.map(
 	async account => {
 		account.dpos.unlocking = await BluebirdPromise.map(
 			account.dpos.unlocking
-				.sort((a, b) => b - a)
-				.slice(0, 5),
+				.sort((a, b) => b - a),
 			async unlock => {
 				const delegateHexAddress = unlock.delegateAddress;
 				unlock.delegateAddress = getBase32AddressFromHex(unlock.delegateAddress);


### PR DESCRIPTION
### What was the problem?
This PR resolves #894 

### How was it solved?
- [x] Remove code `.slice(0.5)` from `resolveAccountInfo` method

### How was it tested?
Local
