### PR TITLE
Fix transactions query with includePending param - Closes #883

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/pendingTransactions.js
+++ b/services/core/shared/core/compat/sdk_v5/pendingTransactions.js
@@ -104,7 +104,7 @@ const validateParams = async params => {
 const getPendingTransactions = async params => {
 	const pendingTransactions = {
 		data: [],
-		meta: {},
+		meta: { total: 0 },
 	};
 
 	const offset = Number(params.offset) || 0;

--- a/services/core/shared/core/compat/sdk_v5/pendingTransactions.js
+++ b/services/core/shared/core/compat/sdk_v5/pendingTransactions.js
@@ -62,6 +62,7 @@ const loadAllPendingTransactions = async () => {
 };
 
 const validateParams = async params => {
+	const validatedParams = {};
 	if (params.nonce && !(params.senderAddress || params.senderPublicKey)) {
 		throw new ValidationException('Nonce based retrieval is only possible along with senderAddress or senderPublicKey');
 	}
@@ -69,36 +70,36 @@ const validateParams = async params => {
 	if (params.senderUsername) {
 		const accountInfo = await getIndexedAccountInfo({ username: params.senderUsername, limit: 1 }, ['address', 'publicKey']);
 		if (!accountInfo || accountInfo.address === undefined) return new NotFoundException(`Account with username: ${params.senderUsername} does not exist`);
-		params.senderPublicKey = accountInfo.publicKey;
+		validatedParams.senderPublicKey = accountInfo.publicKey;
 	}
 
 	if (params.senderIdOrRecipientId) {
-		params.senderAddress = params.senderIdOrRecipientId;
-		params.recipientAddress = params.senderIdOrRecipientId;
+		validatedParams.senderAddress = params.senderIdOrRecipientId;
+		validatedParams.recipientAddress = params.senderIdOrRecipientId;
 	}
 
 	if (params.senderAddress) {
 		const account = await getIndexedAccountInfo({ address: params.senderAddress, limit: 1 }, ['address', 'publicKey']);
-		params.senderPublicKey = account.publicKey;
+		validatedParams.senderPublicKey = account.publicKey;
 	}
 
 	if (params.recipientPublicKey) {
-		params.recipientAddress = getHexAddressFromPublicKey(params.recipientPublicKey);
+		validatedParams.recipientAddress = getHexAddressFromPublicKey(params.recipientPublicKey);
 	}
 
 	if (params.recipientUsername) {
 		const accountInfo = await getIndexedAccountInfo({ username: params.recipientUsername, limit: 1 }, ['address']);
 		if (!accountInfo || accountInfo.address === undefined) return new NotFoundException(`Account with username: ${params.recipientUsername} does not exist`);
-		params.recipientAddress = accountInfo.address;
+		validatedParams.recipientAddress = accountInfo.address;
 	}
 
 	if (params.amount && params.amount.includes(':')) {
 		const minAmount = params.amount.split(':')[0];
 		const maxAmount = params.amount.split(':')[1];
-		params.minAmount = Number(minAmount);
-		params.maxAmount = Number(maxAmount);
+		validatedParams.minAmount = Number(minAmount);
+		validatedParams.maxAmount = Number(maxAmount);
 	}
-	return params;
+	return validatedParams;
 };
 
 const getPendingTransactions = async params => {

--- a/services/gateway/shared/paramValidator.js
+++ b/services/gateway/shared/paramValidator.js
@@ -86,7 +86,7 @@ const validateInputParams = (rawInputParams = {}, specs) => {
 			if (routeParams[cur].default !== undefined) acc[cur] = routeParams[cur].default;
 			if (requestParams[cur] !== undefined) {
 				if (paramDatatype === 'number') {
-					acc[cur] = requestParams[cur] === '' ? acc[cur] : requestParams[cur];
+					acc[cur] = requestParams[cur] === '' ? acc[cur] : Number(requestParams[cur]);
 				} else {
 					acc[cur] = requestParams[cur];
 				}


### PR DESCRIPTION
### What was the problem?
This PR resolves #883 

### How was it solved?
- [x] Avoid in-place edits of the `params` object when validating in `services/core/shared/core/compat/sdk_v5/pendingTransactions.js`
- [x] Ensure request params of type `number` are properly parsed on the gateway
- [x] Always request transactions from the Core with `offset` and `limit`
- [x] Adjust `offset` and `limit` as per the state of the pending transactions when requesting the on-chain transactions

### How was it tested?
Local
