### PR TITLE
Mitigate rank calculation issues (standby -> active) -Closes #731

### DIFF
--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -296,7 +296,7 @@ const updateDelegateListEveryBlock = () => {
 						if (delegateIndex === -1) delegateList.push(delegate);
 						else {
 							// Re-assign the current delegate status before updating the delegateList
-							// Avoid re-calculation of the delegate status
+							// Delegate status can change only at the beginning of a new round
 							const { status } = delegateList[delegateIndex];
 							delegateList[delegateIndex] = { ...delegate, status };
 						}

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -294,7 +294,12 @@ const updateDelegateListEveryBlock = () => {
 					// Update delegate list on newBlock event
 					if (delegate.isDelegate) {
 						if (delegateIndex === -1) delegateList.push(delegate);
-						else delegateList[delegateIndex] = delegate;
+						else {
+							// Re-assign the current delegate status before updating the delegateList
+							// Avoid re-calculation of the delegate status
+							const { status } = delegateList[delegateIndex];
+							delegateList[delegateIndex] = { ...delegate, status };
+						}
 						// Remove delegate from list when deleteBlock event contains delegate registration tx
 					} else if (delegateIndex !== -1) {
 						delegateList.splice(delegateIndex, 1);
@@ -329,6 +334,7 @@ const updateDelegateListEveryBlock = () => {
 	Signals.get('deleteBlock').add(updateDelegateCacheOnDeleteBlockListener);
 };
 
+// Updates the account details of the delegates
 const updateDelegateListOnAccountsUpdate = () => {
 	const updateDelegateListOnAccountsUpdateListener = (hexAddresses) => {
 		hexAddresses.forEach(async hexAddress => {

--- a/services/gateway/apis/http-version2/swagger/parameters/common.json
+++ b/services/gateway/apis/http-version2/swagger/parameters/common.json
@@ -22,8 +22,7 @@
         "name": "height",
         "in": "query",
         "description": "Query for block(s) by height or a height range (fromHeight:toHeight, both inclusive)",
-        "type": "integer",
-        "format": "int32",
+        "type": "string",
         "minimum": 1
     },
     "timestamp": {
@@ -31,7 +30,7 @@
         "in": "query",
         "description": "Range fromTimestamp:toTimestamp",
         "type": "string",
-        "minimum": 0
+        "minimum": 1
     },
     "address": {
         "name": "address",

--- a/services/gateway/apis/http-version2/swagger/parameters/transactions.json
+++ b/services/gateway/apis/http-version2/swagger/parameters/transactions.json
@@ -69,7 +69,7 @@
         "name": "amount",
         "in": "query",
         "description": "Amount range of from:to amount",
-        "type": "integer",
+        "type": "string",
         "minimum": 0
     },
     "transaction": {


### PR DESCRIPTION
### What was the problem?
This PR resolves #731 

### How was it solved?
- [x] Was unable to reproduce the issue with missing `rank` but `status` was missing
- [x] Ensure delegate `status` is updated when updating the delegates list
- [x] Update swagger specs to allow range search for the following request params:
   - [x] `amount`
   - [x] `height`

### How was it tested?
Local
