### PR TITLE
Retrieve genesis height from the node - Closes #912

### DIFF
--- a/docs/api/version2.md
+++ b/docs/api/version2.md
@@ -1012,6 +1012,7 @@ No params required.
 ```jsonc
 {
   "data": {
+    "genesisHeight": 16270293,
     "height": 16550779,
     "finalizedHeight": 16550609,
     "networkVersion": "3.0",

--- a/services/core/config.js
+++ b/services/core/config.js
@@ -39,20 +39,17 @@ config.endpoints.mysql = process.env.SERVICE_CORE_MYSQL || 'mysql://lisk:passwor
 /**
  * Network-related settings
  */
-config.genesisHeight = Number(process.env.GENESIS_HEIGHT || 0);
 config.genesisBlockUrl = process.env.GENESIS_BLOCK_URL || '';
 
 config.networks = [
 	{
 		name: 'mainnet',
 		identifier: '4c09e6a781fc4c7bdb936ee815de8f94190f8a7519becd9de2081832be309a99',
-		genesisHeight: 16270293,
 		genesisBlockUrl: 'https://downloads.lisk.com/lisk/mainnet/genesis_block.json.tar.gz',
 	},
 	{
 		name: 'testnet',
 		identifier: '15f0dacc1060e91818224a94286b13aa04279c640bd5d6f193182031d133df7c',
-		genesisHeight: 14075260,
 		genesisBlockUrl: 'https://downloads.lisk.com/lisk/testnet/genesis_block.json.tar.gz',
 	},
 ];

--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -31,7 +31,6 @@ const {
 } = require('../common/wsRequest');
 
 const delay = require('../../../delay');
-const config = require('../../../../config');
 
 const blockchainStore = require('./blockchainStore');
 
@@ -57,20 +56,13 @@ const getNetworkStatus = async () => {
 };
 
 const updateGenesisHeight = async () => {
-	let genesisHeight = 0;
 	try {
-		// Determine genesis height
-		if (process.env.GENESIS_HEIGHT) {
-			genesisHeight = config.genesisHeight;
-		} else {
-			const { data: { networkIdentifier } } = await getNetworkStatus();
-			const [networkConfig] = config.networks.filter(c => networkIdentifier === c.identifier);
-			genesisHeight = networkConfig ? networkConfig.genesisHeight : 0;
-		}
+		// Get genesis height
+		const { data: { genesisHeight } } = await getNetworkStatus();
 		await setGenesisHeight(genesisHeight);
 	} catch (err) {
 		if (err.message.includes(timeoutMessage)) {
-			throw new TimeoutException('Request timed out when calling \'getGenesisHeight\'');
+			throw new TimeoutException('Request timed out when calling \'updateGenesisHeight\'');
 		}
 		throw err;
 	}

--- a/services/gateway/sources/version2/networkStatus.js
+++ b/services/gateway/sources/version2/networkStatus.js
@@ -19,6 +19,7 @@ module.exports = {
 	method: 'core.network.status',
 	definition: {
 		data: {
+			genesisHeight: '=,number',
 			height: '=,number',
 			finalizedHeight: '=,number',
 			networkVersion: '=,string',

--- a/tests/schemas/api_v2/networkStatus.schema.js
+++ b/tests/schemas/api_v2/networkStatus.schema.js
@@ -16,8 +16,9 @@
 import Joi from 'joi';
 
 const networkStatusSchema = {
-	height: Joi.number().integer().required(),
-	finalizedHeight: Joi.number().integer().required(),
+	genesisHeight: Joi.number().integer().min(0).required(),
+	height: Joi.number().integer().min(0).required(),
+	finalizedHeight: Joi.number().min(0).integer().required(),
 	networkVersion: Joi.string().required(),
 	networkIdentifier: Joi.string().required(),
 	milestone: Joi.string().required(),


### PR DESCRIPTION
### What was the problem?
This PR resolves #912 

### How was it solved?
- [x] Remove config support for `GENESIS_HEIGHT`
- [x] Fetch `genesisHeight` from `node.info`
- [x] Extend `/network/status` endpoint to return `genesisHeight`
- [x] Extend the integration test schema for `networkStatus` to include `genesisHeight`
- [x] Update documentation

### How was it tested?
Local
