### PR TITLE
CORS issue: the headers are skipped when origin is not set - Closes #910

### DIFF
--- a/services/gateway/shared/moleculer-web/methods.js
+++ b/services/gateway/shared/moleculer-web/methods.js
@@ -23,6 +23,12 @@ module.exports = {
 
 			let requestID = req.headers['x-request-id'];
 			if (req.headers['x-correlation-id']) requestID = req.headers['x-correlation-id'];
+
+			// Manually set request origin to `http + host` if not exists
+			// to ensure proper `Access-Control-*` response headers
+			// TODO: Check for security implications
+			if (!req.headers.origin) req.headers.origin = `http://${req.headers.host}`;
+
 			const options = { requestID };
 			if (this.settings.rootCallOptions) {
 				if (_.isPlainObject(this.settings.rootCallOptions)) {


### PR DESCRIPTION
### What was the problem?
This PR resolves #910 

### How was it solved?
- [x] Manually set request origin to `http + request_host` if not exists inside moleculer-web's `httpHandler`

### How was it tested?
Local

```
Sameers-MBP:lisk-service sameer$ curl --verbose http://localhost:9902/api/v2/network/status 2>&1 | grep -i access-control-
< Access-Control-Allow-Origin: *
< Access-Control-Expose-Headers: 
< Access-Control-Allow-Headers: Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Max-Age
< Access-Control-Allow-Methods: GET, OPTIONS, POST, PUT, DELETE
< Access-Control-Max-Age: 3600

Sameers-MBP:lisk-service sameer$ curl --verbose --header Origin:http://localhost:1234 http://localhost:9902/api/v2/network/status 2>&1 | grep -i access-control
< Access-Control-Allow-Origin: *
< Access-Control-Expose-Headers: 
< Access-Control-Allow-Headers: Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers, Access-Control-Max-Age
< Access-Control-Allow-Methods: GET, OPTIONS, POST, PUT, DELETE
< Access-Control-Max-Age: 3600
```
