### PR TITLE
Fix delegate sort comparator - Closes #935

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/index.js
+++ b/services/core/shared/core/compat/sdk_v5/index.js
@@ -43,6 +43,7 @@ const {
 const {
 	getBase32AddressFromHex,
 	getBase32AddressFromPublicKey,
+	getHexAddressFromBase32,
 } = require('./accountUtils');
 
 const {
@@ -118,6 +119,7 @@ module.exports = {
 	getAccounts,
 	getBase32AddressFromHex,
 	getBase32AddressFromPublicKey,
+	getHexAddressFromBase32,
 	getMultisignatureGroups,
 	getMultisignatureMemberships,
 	validateAddress,

--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -44,7 +44,8 @@ let delegateList = [];
 const delegateComparator = (a, b) => {
 	const diff = BigInt(b.delegateWeight) - BigInt(a.delegateWeight);
 	if (diff !== 0) return Number(diff);
-	return Buffer.from(a.account.address).compare(Buffer.from(b.account.address));
+	return Buffer.from(coreApi.getHexAddressFromBase32(a.account.address))
+		.compare(Buffer.from(coreApi.getHexAddressFromBase32(b.account.address)));
 };
 
 const computeDelegateRank = async () => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #935 

### How was it solved?
- [x] Update delegate comparator to use `hex` address instead of their `base32` addresses to resolve the ties when sorting the delegates

### How was it tested?
Local
