### PR TITLE
Mitigate MySQL layer deadlock issue - Closes #820

### DIFF
--- a/services/core/shared/core/transactionStatistics.js
+++ b/services/core/shared/core/transactionStatistics.js
@@ -281,10 +281,12 @@ const validateTransactionStatistics = async historyLengthDays => {
 	const verifyStatistics = await BluebirdPromise.map(
 		Object.keys(distributionByType),
 		async type => {
+			const fromTimestamp = Math.floor((moment.unix(dateFrom).unix()) / 1000);
+			const toTimestamp = Math.floor((moment.unix(dateTo).unix()) / 1000);
+
 			const { meta: { total } } = await getTransactions({
 				moduleAssetId: type,
-				fromTimestamp: (moment.unix(dateFrom).unix()) / 1000,
-				toTimestamp: (moment.unix(dateTo).unix()) / 1000,
+				timestamp: `${fromTimestamp}:${toTimestamp}`,
 			});
 			return total === distributionByType[type];
 		},


### PR DESCRIPTION
### What was the problem?
This PR resolves #820 

### How was it solved?
- [x] Deadlocks are expected, so added user-friendly error logging when DB deadlocks are encountered
```
2022-02-03T14:55:46.873 WARN [queue] indexAccountsQueue Job failed,Deadlock encountered when indexing block at height 17651205. Will retry later.
2022-02-03T14:55:46.873 WARN [queue] indexAccountsQueue Job failed,Error: Deadlock encountered when indexing block at height 17651205. Will retry later.
    at Queue.indexBlocks ([/Users/sameer/Documents/Lisk/github/lisk-service/services/core/shared/core/compat/sdk_v5/blockchainIndex.js:245:10]())
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal[/process/task_queues.js:97:5]())
```
- [x] Fix `getTransactions` invocation in `validateTransactionStatistics`

### How was it tested?
Local
