### PR TITLE
Delegates incorrectly identified as standby - Closes #984

### DIFF
--- a/services/core/shared/core/delegates.js
+++ b/services/core/shared/core/delegates.js
@@ -95,7 +95,7 @@ const computeDelegateStatus = async () => {
 				delegate.status = delegateStatus.PUNISHED;
 			} else if (activeNextForgersList.includes(delegate.account.address)) {
 				delegate.status = delegateStatus.ACTIVE;
-			} else if (delegate.delegateWeight >= MIN_ELIGIBLE_VOTE_WEIGHT) {
+			} else if (BigInt(delegate.delegateWeight) >= BigInt(MIN_ELIGIBLE_VOTE_WEIGHT)) {
 				delegate.status = delegateStatus.STANDBY;
 			}
 		}


### PR DESCRIPTION
### What was the problem?
This PR resolves #984 

### How was it solved?
- [x] Ensure datatype when comparing delegateWeight / voteWeight to determine delegate status

### How was it tested?
Local
