### PR TITLE
Lisk Service failing to reconnect to Lisk Core (intermittent) - Closes #1000

### DIFF
--- a/services/core/shared/core/compat/common/wsRequest.js
+++ b/services/core/shared/core/compat/common/wsRequest.js
@@ -24,6 +24,7 @@ const logger = Logger();
 
 const liskAddress = config.endpoints.liskWs;
 let clientCache;
+let instantiationBeginTime;
 let isInstantiating = false;
 
 // eslint-disable-next-line consistent-return
@@ -32,6 +33,7 @@ const instantiateClient = async () => {
 		if (!isInstantiating) {
 			if (!clientCache || !clientCache._channel.isAlive) {
 				isInstantiating = true;
+				instantiationBeginTime = Date.now();
 				if (clientCache) await clientCache.disconnect();
 				clientCache = await createWSClient(`${liskAddress}/ws`);
 				isInstantiating = false;
@@ -42,6 +44,7 @@ const instantiateClient = async () => {
 			}
 			return clientCache;
 		}
+		if (isInstantiating && (Date.now() - instantiationBeginTime) > 500) isInstantiating = false;
 	} catch (err) {
 		logger.error(`Error instantiating WS client to ${liskAddress}`);
 		logger.error(err.message);

--- a/services/core/shared/core/compat/common/wsRequest.js
+++ b/services/core/shared/core/compat/common/wsRequest.js
@@ -43,8 +43,10 @@ const instantiateClient = async () => {
 				Signals.get('newApiClient').dispatch();
 			}
 			return clientCache;
+		} else if ((Date.now() - instantiationBeginTime) > 500) {
+			// Waited too long, reset the flag to re-attempt client instantiation
+			isInstantiating = false;
 		}
-		if (isInstantiating && (Date.now() - instantiationBeginTime) > 500) isInstantiating = false;
 	} catch (err) {
 		logger.error(`Error instantiating WS client to ${liskAddress}`);
 		logger.error(err.message);

--- a/services/core/shared/core/compat/common/wsRequest.js
+++ b/services/core/shared/core/compat/common/wsRequest.js
@@ -23,6 +23,8 @@ const config = require('../../../../config');
 const logger = Logger();
 
 const liskAddress = config.endpoints.liskWs;
+const MAX_INSTANTIATION_WAIT_TIME = 50;
+
 let clientCache;
 let instantiationBeginTime;
 let isInstantiating = false;
@@ -45,7 +47,7 @@ const instantiateClient = async () => {
 			return clientCache;
 		}
 
-		if ((Date.now() - instantiationBeginTime) > 500) {
+		if ((Date.now() - instantiationBeginTime) > MAX_INSTANTIATION_WAIT_TIME) {
 			// Waited too long, reset the flag to re-attempt client instantiation
 			isInstantiating = false;
 		}

--- a/services/core/shared/core/compat/common/wsRequest.js
+++ b/services/core/shared/core/compat/common/wsRequest.js
@@ -43,7 +43,9 @@ const instantiateClient = async () => {
 				Signals.get('newApiClient').dispatch();
 			}
 			return clientCache;
-		} else if ((Date.now() - instantiationBeginTime) > 500) {
+		}
+
+		if ((Date.now() - instantiationBeginTime) > 500) {
 			// Waited too long, reset the flag to re-attempt client instantiation
 			isInstantiating = false;
 		}


### PR DESCRIPTION
### What was the problem?
This PR resolves #1000 

### How was it solved?
- [x] Reset the `isInstantiating` flag if the waiting is too long

### How was it tested?
Local (Restart Lisk Core node multiple times while Lisk Service keeps running)
