### PR TITLE
Fix normalizeRangeParam method - Closes #1056

### DIFF
--- a/services/core/shared/core/compat/sdk_v5/paramUtils.js
+++ b/services/core/shared/core/compat/sdk_v5/paramUtils.js
@@ -17,6 +17,8 @@ const {
 	Exceptions: { ValidationException },
 } = require('lisk-service-framework');
 
+const EMPTY_STRING = '';
+
 const normalizeRangeParam = (params, property) => {
 	if (typeof params[property] === 'string' && params[property].includes(':')) {
 		const [fromStr, toStr] = params[property].split(':');
@@ -28,7 +30,13 @@ const normalizeRangeParam = (params, property) => {
 		if (from && to && from > to) throw new ValidationException(`From ${property} cannot be greater than to ${property}.`);
 
 		if (!params.propBetweens) params.propBetweens = [];
-		params.propBetweens.push({ property, from, to });
+		if (fromStr === EMPTY_STRING) {
+			params.propBetweens.push({ property, to });
+		} else if (toStr === EMPTY_STRING) {
+			params.propBetweens.push({ property, from });
+		} else {
+			params.propBetweens.push({ property, from, to });
+		}
 
 		const normalizedParams = Object.keys(params).reduce(
 			(acc, key) => {

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -211,10 +211,10 @@ const getTableInstance = async (tableName, tableConfig, connEndpoint = config.en
 			const { propBetweens } = params;
 			propBetweens.forEach(
 				propBetween => {
-					if (propBetween.from) query.where(propBetween.property, '>=', propBetween.from);
-					if (propBetween.to) query.where(propBetween.property, '<=', propBetween.to);
-					if (propBetween.greaterThan) query.where(propBetween.property, '>', propBetween.greaterThan);
-					if (propBetween.lowerThan) query.where(propBetween.property, '<', propBetween.lowerThan);
+					if ('from' in propBetween) query.where(propBetween.property, '>=', propBetween.from);
+					if ('to' in propBetween) query.where(propBetween.property, '<=', propBetween.to);
+					if ('greaterThan' in propBetween) query.where(propBetween.property, '>', propBetween.greaterThan);
+					if ('lowerThan' in propBetween) query.where(propBetween.property, '<', propBetween.lowerThan);
 				});
 		}
 

--- a/services/core/tests/unit/paramUtils.test.js
+++ b/services/core/tests/unit/paramUtils.test.js
@@ -38,6 +38,34 @@ describe('paramUtils tests', () => {
 		);
 	});
 
+	it('Return normalized params only with \'from\' value', async () => {
+		const params = { amount: '1000:' };
+		const normalizedParams = normalizeRangeParam(params, property);
+		expect(typeof normalizedParams).toBe('object');
+		expect(normalizedParams.propBetweens).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property,
+					from: 1000,
+				}),
+			]),
+		);
+	});
+
+	it('Return normalized params only with \'to\' value', async () => {
+		const params = { amount: ':9999' };
+		const normalizedParams = normalizeRangeParam(params, property);
+		expect(typeof normalizedParams).toBe('object');
+		expect(normalizedParams.propBetweens).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property,
+					to: 9999,
+				}),
+			]),
+		);
+	});
+
 	it('Throw error in case of invalid (numeric) range', async () => {
 		try {
 			const params = { amount: '1000:100' };

--- a/services/newsfeed/shared/indexdb/mysql.js
+++ b/services/newsfeed/shared/indexdb/mysql.js
@@ -220,10 +220,10 @@ const getDbInstance = async (tableName, tableConfig, connEndpoint = config.endpo
 			const { propBetweens } = params;
 			propBetweens.forEach(
 				propBetween => {
-					if (propBetween.from) query.where(propBetween.property, '>=', propBetween.from);
-					if (propBetween.to) query.where(propBetween.property, '<=', propBetween.to);
-					if (propBetween.greaterThan) query.where(propBetween.property, '>', propBetween.greaterThan);
-					if (propBetween.lowerThan) query.where(propBetween.property, '<', propBetween.lowerThan);
+					if ('from' in propBetween) query.where(propBetween.property, '>=', propBetween.from);
+					if ('to' in propBetween) query.where(propBetween.property, '<=', propBetween.to);
+					if ('greaterThan' in propBetween) query.where(propBetween.property, '>', propBetween.greaterThan);
+					if ('lowerThan' in propBetween) query.where(propBetween.property, '<', propBetween.lowerThan);
 				});
 		}
 


### PR DESCRIPTION
### What was the problem?
This PR resolves #1056 

### How was it solved?

- [x] Update `normalizeRangeParam` method to include `from` and `to` values in `propBetween` only when defined
- [x] Update `mysql.js` to support the above change in `core` and `newsfeed` microservices
- [x] Add unit tests for the introduced changes

### How was it tested?
Local
