### PR TITLE
Inconsistent aggregated values - Closes #1072

### DIFF
--- a/services/core/config.js
+++ b/services/core/config.js
@@ -119,15 +119,6 @@ config.queue = {
 		settings: {},
 		// limiter: {},
 	},
-	deleteIndexedBlocksQueue: {
-		defaultJobOptions: {
-			attempts: 10,
-			timeout: 5 * 60 * 1000, // millisecs
-			removeOnComplete: true,
-		},
-		settings: {},
-		// limiter: {},
-	},
 	transactionStatisticsQueue: {
 		defaultJobOptions: {
 			attempts: 5,

--- a/services/core/config.js
+++ b/services/core/config.js
@@ -119,6 +119,15 @@ config.queue = {
 		settings: {},
 		// limiter: {},
 	},
+	deleteIndexedBlocksQueue: {
+		defaultJobOptions: {
+			attempts: 10,
+			timeout: 5 * 60 * 1000, // millisecs
+			removeOnComplete: true,
+		},
+		settings: {},
+		// limiter: {},
+	},
 	transactionStatisticsQueue: {
 		defaultJobOptions: {
 			attempts: 5,

--- a/services/core/package-lock.json
+++ b/services/core/package-lock.json
@@ -26,7 +26,7 @@
         "lisk-service-framework": "https://github.com/LiskHQ/lisk-service/raw/fd16d55072965e76bb6ec10525a91bb3fdb9c7c7/framework/dist/lisk-service-framework-1.2.5.tgz",
         "method-override": "^3.0.0",
         "moment": "=2.24.0",
-        "mysql": "^2.18.1",
+        "mysql2": "^2.3.3",
         "semver": "^7.3.5",
         "signals": "^1.0.0",
         "split": "^1.0.1",
@@ -3198,14 +3198,6 @@
       "resolved": "https://registry.npmjs.org/big-number/-/big-number-2.0.0.tgz",
       "integrity": "sha512-C67Su0g+XsmXADX/UM9L/+xSbqqwq0D/qGJs2ky6Noy2FDuCZnC38ZSXODiaBvqWma2VYRZEXgm4H74PS6tCDg=="
     },
-    "node_modules/bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -4452,6 +4444,14 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4990,6 +4990,11 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -7306,6 +7311,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -7703,19 +7713,75 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "node_modules/mysql": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
-      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+    "node_modules/mysql2": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
+      "integrity": "sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==",
       "dependencies": {
-        "bignumber.js": "9.0.0",
-        "readable-stream": "2.3.7",
-        "safe-buffer": "5.1.2",
-        "sqlstring": "2.3.1"
+        "denque": "^2.0.1",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^4.0.0",
+        "lru-cache": "^6.0.0",
+        "named-placeholders": "^1.1.2",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
       },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/denque": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
+      "integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
+      "dependencies": {
+        "lru-cache": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "node_modules/nats": {
       "version": "1.4.12",
@@ -8333,6 +8399,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -8710,6 +8781,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
+    },
     "node_modules/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -8958,14 +9034,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "node_modules/sqlstring": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-      "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -12203,11 +12271,6 @@
       "resolved": "https://registry.npmjs.org/big-number/-/big-number-2.0.0.tgz",
       "integrity": "sha512-C67Su0g+XsmXADX/UM9L/+xSbqqwq0D/qGJs2ky6Noy2FDuCZnC38ZSXODiaBvqWma2VYRZEXgm4H74PS6tCDg=="
     },
-    "bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -13149,6 +13212,14 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -13518,6 +13589,11 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-regex": {
       "version": "1.1.4",
@@ -15246,6 +15322,11 @@
         }
       }
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -15475,15 +15556,63 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "mysql": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
-      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+    "mysql2": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
+      "integrity": "sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==",
       "requires": {
-        "bignumber.js": "9.0.0",
-        "readable-stream": "2.3.7",
-        "safe-buffer": "5.1.2",
-        "sqlstring": "2.3.1"
+        "denque": "^2.0.1",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^4.0.0",
+        "lru-cache": "^6.0.0",
+        "named-placeholders": "^1.1.2",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "dependencies": {
+        "denque": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+          "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "sqlstring": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+          "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="
+        }
+      }
+    },
+    "named-placeholders": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
+      "integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
+      "requires": {
+        "lru-cache": "^4.1.3"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
       }
     },
     "nats": {
@@ -15923,6 +16052,11 @@
         }
       }
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -16219,6 +16353,11 @@
         }
       }
     },
+    "seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
+    },
     "serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -16415,11 +16554,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "sqlstring": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-      "integrity": "sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A="
     },
     "stack-trace": {
       "version": "0.0.10",

--- a/services/core/package-lock.json
+++ b/services/core/package-lock.json
@@ -22,7 +22,7 @@
         "compression": "^1.7.4",
         "debug": "=4.1.1",
         "ioredis": "^4.28.5",
-        "knex": "^0.95.4",
+        "knex": "^2.0.0",
         "lisk-service-framework": "https://github.com/LiskHQ/lisk-service/raw/fd16d55072965e76bb6ec10525a91bb3fdb9c7c7/framework/dist/lisk-service-framework-1.2.5.tgz",
         "method-override": "^3.0.0",
         "moment": "=2.24.0",
@@ -4487,7 +4487,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4531,9 +4530,9 @@
       }
     },
     "node_modules/getopts": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.5.tgz",
-      "integrity": "sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -7055,31 +7054,35 @@
       }
     },
     "node_modules/knex": {
-      "version": "0.95.15",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.15.tgz",
-      "integrity": "sha512-Loq6WgHaWlmL2bfZGWPsy4l8xw4pOE+tmLGkPG0auBppxpI0UcK+GYCycJcqz9W54f2LiGewkCVLBm3Wq4ur/w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.0.0.tgz",
+      "integrity": "sha512-LchC8/GLfreMz8d4kCwh/ymXttsoJG8zO1O0AJBjnxdyr2oT/k2ik77hP1PpZkZH9mDQrq6WsQcIu18Pnqppzg==",
       "dependencies": {
         "colorette": "2.0.16",
-        "commander": "^7.1.0",
-        "debug": "4.3.2",
+        "commander": "^9.1.0",
+        "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
-        "getopts": "2.2.5",
+        "get-package-type": "^0.1.0",
+        "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
         "pg-connection-string": "2.5.0",
-        "rechoir": "0.7.0",
+        "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
-        "tarn": "^3.0.1",
+        "tarn": "^3.0.2",
         "tildify": "2.0.0"
       },
       "bin": {
         "knex": "bin/cli.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
         "mysql": {
           "optional": true
         },
@@ -7101,17 +7104,17 @@
       }
     },
     "node_modules/knex/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
       "engines": {
-        "node": ">= 10"
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/knex/node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -8414,14 +8417,14 @@
       }
     },
     "node_modules/rechoir": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
-      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "dependencies": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/recursive-watch": {
@@ -13171,8 +13174,7 @@
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
     },
     "get-port": {
       "version": "5.1.1",
@@ -13195,9 +13197,9 @@
       }
     },
     "getopts": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.2.5.tgz",
-      "integrity": "sha512-9jb7AW5p3in+IiJWhQiZmmwkpLaR/ccTWdWQCtZM66HJcHHLegowh4q4tSD7gouUyeNvFWRavfK9GXosQHDpFA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
     },
     "glob": {
       "version": "7.2.0",
@@ -15062,34 +15064,35 @@
       "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
     },
     "knex": {
-      "version": "0.95.15",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.15.tgz",
-      "integrity": "sha512-Loq6WgHaWlmL2bfZGWPsy4l8xw4pOE+tmLGkPG0auBppxpI0UcK+GYCycJcqz9W54f2LiGewkCVLBm3Wq4ur/w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.0.0.tgz",
+      "integrity": "sha512-LchC8/GLfreMz8d4kCwh/ymXttsoJG8zO1O0AJBjnxdyr2oT/k2ik77hP1PpZkZH9mDQrq6WsQcIu18Pnqppzg==",
       "requires": {
         "colorette": "2.0.16",
-        "commander": "^7.1.0",
-        "debug": "4.3.2",
+        "commander": "^9.1.0",
+        "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
-        "getopts": "2.2.5",
+        "get-package-type": "^0.1.0",
+        "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
         "pg-connection-string": "2.5.0",
-        "rechoir": "0.7.0",
+        "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
-        "tarn": "^3.0.1",
+        "tarn": "^3.0.2",
         "tildify": "2.0.0"
       },
       "dependencies": {
         "commander": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+          "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
         },
         "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -15986,11 +15989,11 @@
       }
     },
     "rechoir": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
-      "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
       "requires": {
-        "resolve": "^1.9.0"
+        "resolve": "^1.20.0"
       }
     },
     "recursive-watch": {

--- a/services/core/package.json
+++ b/services/core/package.json
@@ -46,7 +46,7 @@
     "lisk-service-framework": "https://github.com/LiskHQ/lisk-service/raw/fd16d55072965e76bb6ec10525a91bb3fdb9c7c7/framework/dist/lisk-service-framework-1.2.5.tgz",
     "method-override": "^3.0.0",
     "moment": "=2.24.0",
-    "mysql": "^2.18.1",
+    "mysql2": "^2.3.3",
     "semver": "^7.3.5",
     "signals": "^1.0.0",
     "split": "^1.0.1",

--- a/services/core/package.json
+++ b/services/core/package.json
@@ -42,7 +42,7 @@
     "compression": "^1.7.4",
     "debug": "=4.1.1",
     "ioredis": "^4.28.5",
-    "knex": "^0.95.4",
+    "knex": "^2.0.0",
     "lisk-service-framework": "https://github.com/LiskHQ/lisk-service/raw/fd16d55072965e76bb6ec10525a91bb3fdb9c7c7/framework/dist/lisk-service-framework-1.2.5.tgz",
     "method-override": "^3.0.0",
     "moment": "=2.24.0",

--- a/services/core/shared/core/compat/common/constants.js
+++ b/services/core/shared/core/compat/common/constants.js
@@ -72,9 +72,9 @@ const resolveBaseFees = (networkConstants) => {
 	return networkFeeConstants;
 };
 
-const getNetworkConstants = async () => {
+const getNetworkConstants = async (forceUpdate = false) => {
 	try {
-		if (!constants) {
+		if (!constants || forceUpdate) {
 			let result = await http.get('/node/constants'); // Necessary to remove cyclic dependency
 			if (Object.getOwnPropertyNames(result).length === 0) {
 				const apiClient = await getApiClient();

--- a/services/core/shared/core/compat/sdk_v5/accountIndex.js
+++ b/services/core/shared/core/compat/sdk_v5/accountIndex.js
@@ -65,10 +65,6 @@ const accountPkUpdateQueue = Queue('accountQueueByPublicKey', updateAccountInfoP
 const accountAddrUpdateQueue = Queue('accountQueueByAddress', updateAccountInfoAddr, 1);
 const accountDirectUpdateQueue = Queue('accountQueueDirect', updateAccountWithData, 1);
 
-const indexAccountByPublicKey = async (publicKey) => redis.sadd('pendingAccountsByPublicKey', publicKey);
-
-const indexAccountByAddress = async (address) => redis.sadd('pendingAccountsByAddress', address);
-
 const triggerAccountUpdates = async () => {
 	const publicKeys = await redis.spop('pendingAccountsByPublicKey', 64);
 	publicKeys.forEach(publicKey => {
@@ -84,8 +80,6 @@ const triggerAccountUpdates = async () => {
 const indexAccountWithData = async (account) => accountDirectUpdateQueue.add(account);
 
 module.exports = {
-	indexAccountByPublicKey,
-	indexAccountByAddress,
 	indexAccountWithData,
 	triggerAccountUpdates,
 };

--- a/services/core/shared/core/compat/sdk_v5/accountIndex.js
+++ b/services/core/shared/core/compat/sdk_v5/accountIndex.js
@@ -81,7 +81,7 @@ const triggerAccountUpdates = async () => {
 	});
 };
 
-const indexAccountWithData = (account) => accountDirectUpdateQueue.add(account);
+const indexAccountWithData = async (account) => accountDirectUpdateQueue.add(account);
 
 module.exports = {
 	indexAccountByPublicKey,

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -192,8 +192,7 @@ const resolveAccountInfo = async accounts => BluebirdPromise.map(
 	accounts,
 	async account => {
 		account.dpos.unlocking = await BluebirdPromise.map(
-			account.dpos.unlocking
-				.sort((a, b) => b - a),
+			account.dpos.unlocking.sort((a, b) => b - a),
 			async unlock => {
 				const delegateHexAddress = unlock.delegateAddress;
 				unlock.delegateAddress = getBase32AddressFromHex(unlock.delegateAddress);
@@ -644,16 +643,9 @@ const removeReclaimedLegacyAccountInfoFromCache = () => {
 };
 
 const keepAccountsCacheUpdated = async () => {
-	// TODO: Cleanup, if the fix works
-	// const accountsDB = await getAccountsIndex();
-	// const updateAccountsCacheListener = async (address) => {
-	// 	const accounts = await getAccountsByAddress(address);
-	// 	await accountsDB.upsert(accounts);
-	// };
-
 	const updateAccountsCacheListener = async (addresses) => BluebirdPromise.map(
 		addresses,
-		address => indexAccountByAddress(address),
+		async (address) => indexAccountByAddress(address),
 		{ concurrency: addresses.length },
 	);
 

--- a/services/core/shared/core/compat/sdk_v5/accounts.js
+++ b/services/core/shared/core/compat/sdk_v5/accounts.js
@@ -14,6 +14,8 @@
  *
  */
 const BluebirdPromise = require('bluebird');
+const Redis = require('ioredis');
+
 const {
 	CacheRedis,
 	Exceptions: {
@@ -35,10 +37,6 @@ const {
 	getHexAddressFromBase32,
 	getBase32AddressFromPublicKey,
 } = require('./accountUtils');
-
-const {
-	indexAccountByAddress,
-} = require('./accountIndex');
 
 const { getGenesisConfig } = require('./network');
 
@@ -62,13 +60,13 @@ const {
 	standardizePomHeight,
 } = require('./dpos');
 
-const coreApi = require('./coreApi');
-const config = require('../../../../config');
-const Signals = require('../../../signals');
-
 const {
 	getTableInstance,
 } = require('../../../indexdb/mysql');
+
+const coreApi = require('./coreApi');
+const config = require('../../../../config');
+const Signals = require('../../../signals');
 
 const accountsIndexSchema = require('./schema/accounts');
 const blocksIndexSchema = require('./schema/blocks');
@@ -83,6 +81,11 @@ const getTransactionsIndex = () => getTableInstance('transactions', transactions
 const accountsCache = CacheRedis('accounts', config.endpoints.volatileRedis);
 const legacyAccountCache = CacheRedis('legacyAccount', config.endpoints.redis);
 const latestBlockCache = CacheRedis('latestBlock', config.endpoints.redis);
+
+const redis = new Redis(config.endpoints.redis);
+
+const indexAccountByPublicKey = async (publicKey) => redis.sadd('pendingAccountsByPublicKey', publicKey);
+const indexAccountByAddress = async (address) => redis.sadd('pendingAccountsByAddress', address);
 
 const requestApi = coreApi.requestRetry;
 
@@ -674,4 +677,6 @@ module.exports = {
 	getAccountsBySearch,
 	resolveMultisignatureMemberships,
 	getNumberOfForgers,
+	indexAccountByAddress,
+	indexAccountByPublicKey,
 };

--- a/services/core/shared/core/compat/sdk_v5/blockchainIndex.js
+++ b/services/core/shared/core/compat/sdk_v5/blockchainIndex.js
@@ -296,7 +296,7 @@ const deleteIndexedBlocks = async job => {
 // Initialize queues
 const indexBlocksQueue = Queue('indexBlocksQueue', indexBlock, 30);
 const updateBlockIndexQueue = Queue('updateBlockIndexQueue', updateBlockIndex, 1);
-const deleteIndexedBlocksQueue = Queue('deleteIndexedBlocksQueue', deleteIndexedBlocks, 1);
+const deleteIndexedBlocksQueue = Queue('deleteIndexedBlocksQueue', deleteIndexedBlocks, 1, config.queue.deleteIndexedBlocksQueue);
 
 const verifyAndIndexBlock = async data => {
 	const { block } = data.data;

--- a/services/core/shared/core/compat/sdk_v5/blockchainIndex.js
+++ b/services/core/shared/core/compat/sdk_v5/blockchainIndex.js
@@ -104,10 +104,6 @@ const getIndexVerifiedHeight = () => blockchainStore.get('indexVerifiedHeight');
 const setIndexDiff = (height) => blockchainStore.set('indexStatus', height);
 const getIndexDiff = () => blockchainStore.get('indexStatus');
 
-// Key-based account update
-// There is a bug that does not update public keys
-const KEY_BASED_ACCOUNT_UPDATE = false;
-
 // Key constants for the KV-store
 const genesisAccountPageCached = 'genesisAccountPageCached';
 const isGenesisAccountIndexingFinished = 'isGenesisAccountIndexingFinished';
@@ -694,10 +690,8 @@ const init = async () => {
 		await indexMissingBlocks();
 		await updateNonFinalBlocks();
 
-		if (KEY_BASED_ACCOUNT_UPDATE === true) {
-			// Ensure accounts are updated regularly
-			setInterval(triggerAccountUpdates, 15 * 1000); // ms
-		}
+		// Ensure the pendingAccounts updates are performed regularly
+		setInterval(triggerAccountUpdates, 15 * 1000); // ms
 
 		logger.info('Finished all blockchain index startup tasks');
 	} catch (err) {

--- a/services/core/shared/core/compat/sdk_v5/blockchainIndex.js
+++ b/services/core/shared/core/compat/sdk_v5/blockchainIndex.js
@@ -529,7 +529,9 @@ const indexMissingBlocks = async (params = {}) => {
 
 	// Retrieve the list of missing blocks
 	const missingBlockRanges = await findMissingBlocksInRange(
-		blockIndexLowerRange, blockIndexHigherRange);
+		blockIndexLowerRange,
+		blockIndexHigherRange,
+	);
 
 	// Start building the block index
 	try {
@@ -539,13 +541,12 @@ const indexMissingBlocks = async (params = {}) => {
 			await setIndexVerifiedHeight(Math.max(indexVerifiedHeight, blockIndexHigherRange));
 		} else {
 			for (let i = 0; i < missingBlockRanges.length; i++) {
+				/* eslint-disable no-await-in-loop */
 				const { from, to } = missingBlockRanges[i];
-
 				logger.info(`Attempting to cache missing blocks ${from}-${to} (${to - from + 1} blocks)`);
-				/* eslint-disable-next-line no-await-in-loop */
 				await buildIndex(from, to);
-				/* eslint-disable-next-line no-await-in-loop */
 				await setIndexVerifiedHeight(to + 1);
+				/* eslint-enable no-await-in-loop */
 			}
 		}
 	} catch (err) {
@@ -701,5 +702,4 @@ module.exports = {
 	getIndexStats,
 	deleteBlock,
 	initializeSearchIndex,
-	indexMissingBlocks,
 };

--- a/services/core/shared/core/compat/sdk_v5/blockchainIndex.js
+++ b/services/core/shared/core/compat/sdk_v5/blockchainIndex.js
@@ -252,6 +252,8 @@ const updateBlockIndex = async job => {
 };
 
 const deleteIndexedBlocks = async job => {
+	const { blocks } = job.data;
+
 	const blocksDB = await getBlocksIndex();
 	const connection = await getDbConnection();
 	const trx = await startDbTransaction(connection);
@@ -259,7 +261,7 @@ const deleteIndexedBlocks = async job => {
 		const accountsDB = await getAccountsIndex();
 		const transactionsDB = await getTransactionsIndex();
 		const votesDB = await getVotesIndex();
-		const { blocks } = job.data;
+
 		const generatorPkInfoArray = await getGeneratorPkInfoArray(blocks);
 		const accountsByPublicKey = await getAccountsByPublicKey(generatorPkInfoArray);
 		if (accountsByPublicKey.length) await accountsDB.upsert(accountsByPublicKey, trx);

--- a/services/core/shared/core/compat/sdk_v5/blocks.js
+++ b/services/core/shared/core/compat/sdk_v5/blocks.js
@@ -263,6 +263,7 @@ module.exports = {
 	getBlocks,
 	getGenesisHeight,
 	updateFinalizedHeight,
+	setFinalizedHeight,
 	getFinalizedHeight,
 	normalizeBlocks,
 	getCurrentHeight,

--- a/services/core/shared/core/compat/sdk_v5/coreApi.js
+++ b/services/core/shared/core/compat/sdk_v5/coreApi.js
@@ -118,7 +118,7 @@ const getBlockByHeight = async height => {
 			return { data: [await getGenesisBlockFromFS()] };
 		}
 	} catch (err) {
-		logger.warn('Retrieval of the genesis block snapshot was not possible, retrieveing genesis block directly from Lisk Core');
+		logger.trace('Retrieval of the genesis block snapshot was not possible, retrieveing genesis block directly from Lisk Core');
 	}
 
 	try {

--- a/services/core/shared/core/compat/sdk_v5/events.js
+++ b/services/core/shared/core/compat/sdk_v5/events.js
@@ -42,7 +42,7 @@ const register = async (events) => {
 
 			logger.debug(`New block forged: ${newBlock.id} at height ${newBlock.height}`);
 			events.newBlock(newBlock);
-			events.updateAccountsByAddress(affectedAccountAddresses);
+			events.updateAccountsByAddresses(affectedAccountAddresses);
 			events.calculateFeeEstimate();
 		} catch (err) {
 			logger.error(`Error while processing the 'app:block:new' event:\n${err.stack}`);
@@ -57,7 +57,7 @@ const register = async (events) => {
 
 			logger.debug(`Block deleted: ${deletedBlock.id} at height ${deletedBlock.height}`);
 			events.deleteBlock(deletedBlock);
-			events.updateAccountsByAddress(affectedAccountAddresses);
+			events.updateAccountsByAddresses(affectedAccountAddresses);
 			events.calculateFeeEstimate();
 		} catch (err) {
 			logger.error(`Error while processing the 'app:block:delete' event:\n${err.stack}`);

--- a/services/core/shared/core/compat/sdk_v5/index.js
+++ b/services/core/shared/core/compat/sdk_v5/index.js
@@ -27,7 +27,6 @@ const blockInit = require('./blocks').init;
 
 const {
 	deleteBlock,
-	indexMissingBlocks,
 } = require('./blockchainIndex');
 
 const blockchainIndexInit = require('./blockchainIndex').init;
@@ -113,7 +112,6 @@ module.exports = {
 	deleteBlock,
 	getGenesisHeight,
 	getIndexStartHeight,
-	indexMissingBlocks,
 	updateFinalizedHeight,
 	getFinalizedHeight,
 

--- a/services/core/shared/core/compat/sdk_v5/transactions.js
+++ b/services/core/shared/core/compat/sdk_v5/transactions.js
@@ -273,8 +273,8 @@ const getTransactions = async params => {
 
 	const total = await transactionsDB.count(params);
 	const resultSet = await transactionsDB.find(
-		Object.assign({}, params, { limit: params.limit || total }),
-		['id', 'timestamp', 'height', 'blockId']
+		{ ...params, limit: params.limit || total },
+		['id', 'timestamp', 'height', 'blockId'],
 	);
 	params.ids = resultSet.map(row => row.id);
 

--- a/services/core/shared/core/compat/sdk_v5/transactions.js
+++ b/services/core/shared/core/compat/sdk_v5/transactions.js
@@ -271,8 +271,11 @@ const getTransactions = async params => {
 
 	params = await validateParams(params);
 
-	const resultSet = await transactionsDB.find(params, ['id', 'timestamp', 'height', 'blockId']);
 	const total = await transactionsDB.count(params);
+	const resultSet = await transactionsDB.find(
+		Object.assign({}, params, { limit: params.limit || total }),
+		['id', 'timestamp', 'height', 'blockId']
+	);
 	params.ids = resultSet.map(row => row.id);
 
 	if (params.ids.length) {

--- a/services/core/shared/core/events.js
+++ b/services/core/shared/core/events.js
@@ -64,10 +64,10 @@ const events = {
 			logger.error(`Error occured when processing 'newBlock' event:\n${err.stack}`);
 		}
 	},
-	updateAccountsByAddress: async (addresses) => {
+	updateAccountsByAddresses: async (addresses) => {
 		try {
-			logger.debug(`============== 'updateAccountsByAddress' signal: ${Signals.get('updateAccountsByAddress')} ==============`);
-			Signals.get('updateAccountsByAddress').dispatch(addresses);
+			logger.debug(`============== 'updateAccountsByAddresses' signal: ${Signals.get('updateAccountsByAddresses')} ==============`);
+			Signals.get('updateAccountsByAddresses').dispatch(addresses);
 		} catch (err) {
 			logger.error(`Error occured when processing 'newBlock' event:\n${err.stack}`);
 		}

--- a/services/core/shared/core/index.js
+++ b/services/core/shared/core/index.js
@@ -99,7 +99,6 @@ const {
 	updateFinalizedHeight,
 	getSDKVersion,
 	init,
-	indexMissingBlocks,
 	getGenesisHeight,
 	getIndexStartHeight,
 } = require('./compat');
@@ -166,7 +165,6 @@ module.exports = {
 	getSDKVersion,
 	waitForLastBlock,
 	init,
-	indexMissingBlocks,
 	getGenesisHeight,
 	getIndexStartHeight,
 };

--- a/services/core/shared/core/queue.js
+++ b/services/core/shared/core/queue.js
@@ -48,12 +48,12 @@ const queueInstance = (jobName = 'defaultJob', jobFn, concurrency = 1, options =
 		});
 
 		queue.on('error', (err) => {
-			logger.error(`${jobName} Job error`, err);
+			logger.error(`${jobName} Job error: ${err}`);
 		});
 
 		queue.on('failed', (job, err) => {
-			logger.warn(`${jobName} Job failed`, err.message);
-			logger.warn(`${jobName} Job failed`, err.stack);
+			logger.warn(`${jobName} Job failed: ${err.message}`);
+			logger.warn(`${jobName} Job failed: ${err.stack}`);
 		});
 
 		setInterval(async () => {

--- a/services/core/shared/indexdb/mysql.js
+++ b/services/core/shared/indexdb/mysql.js
@@ -48,8 +48,8 @@ const loadSchema = async (knex, tableName, tableConfig) => {
 
 const createDbConnection = async (connEndpoint) => {
 	const knex = require('knex')({
-		client: 'mysql',
-		version: '5.7',
+		client: 'mysql2',
+		version: '8',
 		connection: connEndpoint,
 		useNullAsDefault: true,
 		pool: {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1072 

### How was it solved?
- [x] Update `updateAccountsCacheListener` to use queues instead of directly updating the index
- [x] Ensure `getGeneratorPkInfoArray` always receives `generatorPublickey` within input params
- [x] Update `knex` version and switch MySQL client from `mysql` to `mysql2`
- [x] Wait to start indexing if the Lisk Core node is still syncing with the network

### How was it tested?
Index mainnet on multiple instances
 - Compare `producedBlocks` from `/accounts` endpoint against `meta.total` from `/blocks` endpoint for any given account
 - Compare `/accounts` response on the two deployments
 - Compare `/votes_received` response on the two deployments
