### PR TITLE
Update broken tests - Closes #1034

### DIFF
--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "node app.js",
     "clean": "rm -rf ./node_modules",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo \"Error: Please run integration tests with lisk-service-template enabled to test the Gateway features\" && exit 1",
     "watch": "supervisor -w . -i ./node_modules app.js"
   },
   "engines": {

--- a/services/market/package-lock.json
+++ b/services/market/package-lock.json
@@ -1547,9 +1547,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001269",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001269.tgz",
-      "integrity": "sha512-UOy8okEVs48MyHYgV+RdW1Oiudl1H6KolybD6ZquD0VcrPSgj25omXO1S7rDydjpqaISCwA8Pyx+jUQKZwWO5w==",
+      "version": "1.0.30001341",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
+      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
       "dev": true
     },
     "chalk": {

--- a/services/market/tests/functional/market.prices.test.js
+++ b/services/market/tests/functional/market.prices.test.js
@@ -17,9 +17,10 @@
 const { ServiceBroker } = require('moleculer');
 const { marketPriceItemSchema } = require('../schemas/marketPriceItem.schema');
 const { serviceUnavailableSchema } = require('../schemas/serviceUnavailable.schema');
+const config = require('../../config');
 
 const broker = new ServiceBroker({
-	transporter: 'redis://localhost:6379/0',
+	transporter: config.transporter,
 	logLevel: 'warn',
 	requestTimeout: 15 * 1000,
 	logger: console,

--- a/services/newsfeed/package-lock.json
+++ b/services/newsfeed/package-lock.json
@@ -1664,9 +1664,9 @@
       "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001239",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
-      "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==",
+      "version": "1.0.30001341",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
+      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
       "dev": true
     },
     "caseless": {

--- a/services/newsfeed/tests/functional/newsfeed.test.js
+++ b/services/newsfeed/tests/functional/newsfeed.test.js
@@ -17,9 +17,10 @@
 const { ServiceBroker } = require('moleculer');
 const { newsfeedArticleSchema } = require('../schemas/newsfeedArticle.schema');
 const { serviceUnavailableSchema } = require('../schemas/serviceUnavailable.schema');
+const config = require('../../config');
 
 const broker = new ServiceBroker({
-	transporter: 'redis://localhost:6379/0',
+	transporter: config.transporter,
 	logLevel: 'warn',
 	requestTimeout: 15 * 1000,
 	logger: console,

--- a/services/newsfeed/tests/unit/normalizers.test.js
+++ b/services/newsfeed/tests/unit/normalizers.test.js
@@ -81,7 +81,7 @@ describe('Test normalizers', () => {
 
 	it('Test drupalUnixTimestamp', async () => {
 		const result = normalizeFunctions.drupalUnixTimestamp('06/30/2021 - 10:04');
-		expect(result).toEqual(1625047440);
+		expect(result).toEqual(1625040240);
 	});
 
 	it('Test twitterUnixTimestamp', async () => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1034 

### How was it solved?
- [x] Gateway: Replace the generic command `no test specified` to `Please run integration tests with lisk-service-template enabled to test the Gateway features`
- [x] Market: 
   - [x] All functional tests are passing (Verified)
   - [x] Updated the outdated `caniuse-lite`
- [x] Newsfeed:
  - [x] Updated the outdated `caniuse-lite`
  - [x] Fix failing unit test

### How was it tested?
Local