### PR TITLE
Add endpoint to fetch peers - Closes #1092

### DIFF
--- a/services/blockchain-connector/jobs/peers.js
+++ b/services/blockchain-connector/jobs/peers.js
@@ -21,7 +21,7 @@ module.exports = [
 	{
 		name: 'refresh.peers',
 		description: 'Keep the peer list up-to-date',
-		interval: 90, // seconds
+		interval: 60, // seconds
 		init: () => {
 			try {
 				logger.debug('Initializing peer list...');

--- a/services/gateway/apis/http-version3/methods/peers.js
+++ b/services/gateway/apis/http-version3/methods/peers.js
@@ -1,0 +1,35 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const peersSource = require('../../../sources/version3/peers');
+const envelope = require('../../../sources/version3/mappings/stdEnvelope');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/peers',
+	rpcMethod: 'get.peers',
+	tags: ['Peers'],
+	params: {
+		ip: { optional: true, type: 'string', pattern: /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/ },
+		networkVersion: { optional: true, type: 'string', pattern: /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$/ },
+		state: { optional: true, type: 'string', enum: ['connected', 'disconnected', 'any'], default: 'any', lowercase: true },
+		height: { optional: true, min: 0, type: 'number', integer: true },
+		limit: { optional: true, min: 1, max: 100, type: 'number', integer: true, default: 10 },
+		offset: { optional: true, min: 0, type: 'number', integer: true, default: 0 },
+		sort: { optional: true, type: 'string', enum: ['height:asc', 'height:desc', 'networkVersion:asc', 'networkVersion:desc'], default: 'height:desc' },
+	},
+	source: peersSource,
+	envelope,
+};

--- a/services/gateway/sources/version3/mappings/peer.js
+++ b/services/gateway/sources/version3/mappings/peer.js
@@ -1,0 +1,28 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+module.exports = {
+	ip: '=,string',
+	port: '=,number',
+	networkVersion: '=,string',
+	state: '=,string',
+	height: '=,number',
+	networkIdentifier: '=,string',
+	location: {
+		countryCode: 'location.country_code,string',
+		latitude: 'location.latitude,string',
+		longitude: 'location.longitude,string',
+	},
+};

--- a/services/gateway/sources/version3/peers.js
+++ b/services/gateway/sources/version3/peers.js
@@ -1,0 +1,39 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const peer = require('./mappings/peer');
+
+module.exports = {
+	type: 'moleculer',
+	method: 'indexer.peers',
+	params: {
+		ip: '=,string',
+		networkVersion: '=,string',
+		state: '=,string',
+		height: '=,number',
+		limit: '=,number',
+		offset: '=,number',
+		sort: '=,string',
+	},
+	definition: {
+		data: ['data', peer],
+		meta: {
+			count: '=,number',
+			offset: '=,number',
+			total: '=,number',
+		},
+		links: {},
+	},
+};

--- a/tests/integration/api_v3/http/peers.test.js
+++ b/tests/integration/api_v3/http/peers.test.js
@@ -1,0 +1,302 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const semver = require('semver');
+const config = require('../../../config');
+const { api } = require('../../../helpers/api');
+
+const {
+	goodRequestSchema,
+	metaSchema,
+	badRequestSchema,
+	urlNotFoundSchema,
+	notFoundSchema,
+} = require('../../../schemas/httpGenerics.schema');
+
+const {
+	peerSchema,
+} = require('../../../schemas/api_v3/peer.schema');
+
+const baseUrl = config.SERVICE_ENDPOINT;
+const baseUrlV2 = `${baseUrl}/api/v3`;
+const endpoint = `${baseUrlV2}/peers`;
+
+// TODO: Enable when peers endpoint is available from sdk
+xdescribe('Peers API', () => {
+	describe('GET /peers', () => {
+		xit('without request params -> ok', async () => {
+			const response = await api.get(`${endpoint}`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		xit('empty ip -> ok', async () => {
+			const response = await api.get(`${endpoint}?ip=`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('invalid ip -> bad request', async () => {
+			const response = await api.get(`${endpoint}?ip=0`, 400);
+			expect(response).toMap(badRequestSchema);
+		});
+
+		xit('valid networkVersion -> ok', async () => {
+			const response = await api.get(`${endpoint}?networkVersion=2.0`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		xit('empty networkVersion -> ok', async () => {
+			const response = await api.get(`${endpoint}?networkVersion=`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('non-existent networkVersion -> not found', async () => {
+			const response = await api.get(`${endpoint}?networkVersion=9.99.0`, 404);
+			expect(response).toMap(urlNotFoundSchema);
+		});
+
+		it('invalid networkVersion -> bad request', async () => {
+			const response = await api.get(`${endpoint}?networkVersion=v2.0`, 400);
+			expect(response).toMap(badRequestSchema);
+		});
+
+		xit('\'connected\' state -> ok', async () => {
+			const response = await api.get(`${endpoint}?state=connected`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		xit('\'disconnected\' state -> ok', async () => {
+			const response = await api.get(`${endpoint}?state=disconnected`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		xit('\'any\' state -> ok', async () => {
+			const response = await api.get(`${endpoint}?state=any`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		xit('empty state -> ok', async () => {
+			const response = await api.get(`${endpoint}?state=`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('invalid state 1 -> bad request', async () => {
+			const response = await api.get(`${endpoint}?state=invalid`, 400);
+			expect(response).toMap(badRequestSchema);
+		});
+
+		it('invalid state 2 -> bad request', async () => {
+			const response = await api.get(`${endpoint}?state=1`, 400);
+			expect(response).toMap(badRequestSchema);
+		});
+
+		xit('empty height -> ok', async () => {
+			const response = await api.get(`${endpoint}?height=`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('non-existent height -> not found error', async () => {
+			const response = await api.get(`${endpoint}?height=1000000000`, 404);
+			expect(response).toMap(notFoundSchema);
+		});
+
+		it('invalid height -> bad request', async () => {
+			const response = await api.get(`${endpoint}?height=-10`, 400);
+			expect(response).toMap(badRequestSchema);
+		});
+
+		xit('limit=100 -> ok', async () => {
+			const response = await api.get(`${endpoint}?limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		xit('empty limit -> ok', async () => {
+			const response = await api.get(`${endpoint}?limit=`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		xit('empty offset -> ok', async () => {
+			const response = await api.get(`${endpoint}?offset=`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('too big offset -> not found error', async () => {
+			const response = await api.get(`${endpoint}?offset=1000000`, 404);
+			expect(response).toMap(notFoundSchema);
+		});
+
+		xit('empty sort -> ok', async () => {
+			const response = await api.get(`${endpoint}?sort=`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('wrong sort -> bad request error', async () => {
+			const response = await api.get(`${endpoint}?sort=height:ascc`, 400);
+			expect(response).toMap(badRequestSchema);
+		});
+
+		it('invalid request param -> bad request', async () => {
+			const response = await api.get(`${endpoint}?invalidParam=invalid`, 400);
+			expect(response).toMap(badRequestSchema);
+		});
+
+		it('wrong url -> not found', async () => {
+			const response = await api.get(`${endpoint}/112`, 404);
+			expect(response).toMap(urlNotFoundSchema);
+		});
+	});
+
+	xdescribe('Peers sorted by height', () => {
+		it('returns 10 peers sorted by height descending', async () => {
+			const response = await api.get(`${endpoint}?sort=height:desc`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			if (response.data.length > 1) {
+				for (let i = 1; i < response.data.length; i++) {
+					const prevPeer = response.data[i - 1];
+					const currPeer = response.data[i];
+					expect(prevPeer.height).toBeGreaterThanOrEqual(currPeer.height);
+				}
+			}
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('returns 10 peers sorted by height ascending', async () => {
+			const response = await api.get(`${endpoint}?sort=height:asc`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			if (response.data.length > 1) {
+				for (let i = 1; i < response.data.length; i++) {
+					const prevPeer = response.data[i - 1];
+					const currPeer = response.data[i];
+					expect(prevPeer.height).toBeLessThanOrEqual(currPeer.height);
+				}
+			}
+			expect(response.meta).toMap(metaSchema);
+		});
+	});
+
+	xdescribe('Peers sorted by networkVersion', () => {
+		it('returns 10 peers sorted by networkVersion descending', async () => {
+			const response = await api.get(`${endpoint}?sort=networkVersion:desc`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			if (response.data.length > 1) {
+				for (let i = 1; i < response.data.length; i++) {
+					const prevPeer = response.data[i - 1];
+					const currPeer = response.data[i];
+					expect(semver.gte(
+						semver.coerce(prevPeer.networkVersion),
+						semver.coerce(currPeer.networkVersion),
+					)).toBeTruthy();
+				}
+			}
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('returns 10 peers sorted by networkVersion ascending', async () => {
+			const response = await api.get(`${endpoint}?sort=networkVersion:asc`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(peer => expect(peer).toMap(peerSchema));
+			if (response.data.length > 1) {
+				for (let i = 1; i < response.data.length; i++) {
+					const prevPeer = response.data[i - 1];
+					const currPeer = response.data[i];
+					expect(semver.lte(
+						semver.coerce(prevPeer.networkVersion),
+						semver.coerce(currPeer.networkVersion),
+					)).toBeTruthy();
+				}
+			}
+			expect(response.meta).toMap(metaSchema);
+		});
+	});
+});

--- a/tests/integration/api_v3/rpc/peers.test.js
+++ b/tests/integration/api_v3/rpc/peers.test.js
@@ -1,0 +1,318 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const semver = require('semver');
+const config = require('../../../config');
+const { request } = require('../../../helpers/socketIoRpcRequest');
+
+const {
+	wrongMethodSchema,
+	invalidParamsSchema,
+	jsonRpcEnvelopeSchema,
+	metaSchema,
+} = require('../../../schemas/rpcGenerics.schema');
+
+const {
+	emptyResponseSchema,
+	peerSchema,
+} = require('../../../schemas/api_v3/peer.schema');
+
+const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
+const requestPeers = async params => request(wsRpcUrl, 'get.peers', params);
+
+// TODO: Enable when peers endpoint is available from sdk
+xdescribe('Peers API', () => {
+	describe('get.peers', () => {
+		xit('without request params -> ok', async () => {
+			const response = await requestPeers({});
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		xit('empty ip -> ok', async () => {
+			const response = await requestPeers({ ip: '' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('invalid ip -> bad request', async () => {
+			const response = await requestPeers({ ip: '0' });
+			expect(response).toMap(invalidParamsSchema);
+		});
+
+		xit('valid networkVersion -> ok', async () => {
+			const response = await requestPeers({ networkVersion: '2.0' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		xit('empty networkVersion -> ok', async () => {
+			const response = await requestPeers({ networkVersion: '' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('non-existent networkVersion -> empty response', async () => {
+			const error = await requestPeers({ networkVersion: '9.99.0' });
+			expect(error).toMap(emptyResponseSchema);
+		});
+
+		it('invalid networkVersion -> invalid param', async () => {
+			const error = await requestPeers({ networkVersion: 'v2.0' });
+			expect(error).toMap(invalidParamsSchema);
+		});
+
+		xit('\'connected\' state -> ok', async () => {
+			const response = await requestPeers({ state: 'connected' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		xit('\'disconnected\' state -> ok', async () => {
+			const response = await requestPeers({ state: 'disconnected' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		xit('\'any\' state -> ok', async () => {
+			const response = await requestPeers({ state: 'any' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		xit('empty state -> ok', async () => {
+			const response = await requestPeers({ state: '' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('invalid state 1 -> invalid param', async () => {
+			const error = await requestPeers({ state: 'invalid' });
+			expect(error).toMap(invalidParamsSchema);
+		});
+
+		it('invalid state 2 -> invalid param', async () => {
+			const error = await requestPeers({ state: 1 });
+			expect(error).toMap(invalidParamsSchema);
+		});
+
+		xit('empty height -> ok', async () => {
+			const response = await requestPeers({ height: '' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('non-existent height -> empty response', async () => {
+			const error = await requestPeers({ height: 1000000000 });
+			expect(error).toMap(emptyResponseSchema);
+		});
+
+		it('invalid height -> bad request', async () => {
+			const error = await requestPeers({ height: -10 });
+			expect(error).toMap(invalidParamsSchema);
+		});
+
+		xit('limit=100 -> ok', async () => {
+			const response = await requestPeers({ limit: 100 });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(100);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		xit('empty limit -> ok', async () => {
+			const response = await requestPeers({ limit: '' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		xit('empty offset -> ok', async () => {
+			const response = await requestPeers({ offset: '' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('too big offset -> empty response', async () => {
+			const response = await requestPeers({ offset: 1000000 });
+			expect(response).toMap(emptyResponseSchema);
+		});
+
+		xit('empty sort -> ok', async () => {
+			const response = await requestPeers({ sort: '' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('wrong sort -> invalid param', async () => {
+			const response = await requestPeers({ sort: 'height:ascc' });
+			expect(response).toMap(invalidParamsSchema);
+		});
+
+		it('invalid request param -> invalid param', async () => {
+			const response = await requestPeers({ invalidParam: 'invalid' });
+			expect(response).toMap(invalidParamsSchema);
+		});
+
+		it('wrong url -> invalid request', async () => {
+			const response = await request(wsRpcUrl, 'get.peers.connected', {});
+			expect(response).toMap(wrongMethodSchema);
+		});
+	});
+
+	xdescribe('Peers sorted by height', () => {
+		it('returns 10 peers sorted by height descending', async () => {
+			const response = await requestPeers({ sort: 'height:desc' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			if (result.data.length > 1) {
+				for (let i = 1; i < result.data.length; i++) {
+					const prevPeer = result.data[i - 1];
+					const currPeer = result.data[i];
+					expect(prevPeer.height).toBeGreaterThanOrEqual(currPeer.height);
+				}
+			}
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('returns 10 peers sorted by height ascending', async () => {
+			const response = await requestPeers({ sort: 'height:asc' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			if (result.data.length > 1) {
+				for (let i = 1; i < result.data.length; i++) {
+					const prevPeer = result.data[i - 1];
+					const currPeer = result.data[i];
+					expect(prevPeer.height).toBeLessThanOrEqual(currPeer.height);
+				}
+			}
+			expect(result.meta).toMap(metaSchema);
+		});
+	});
+
+	xdescribe('Peers sorted by networkVersion', () => {
+		it('returns 10 peers sorted by networkVersion descending', async () => {
+			const response = await requestPeers({ sort: 'networkVersion:desc' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			if (result.data.length > 1) {
+				for (let i = 1; i < result.data.length; i++) {
+					const prevPeer = result.data[i - 1];
+					const currPeer = result.data[i];
+					expect(semver.gte(
+						semver.coerce(prevPeer.networkVersion),
+						semver.coerce(currPeer.networkVersion),
+					)).toBeTruthy();
+				}
+			}
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('returns 10 peers sorted by networkVersion ascending', async () => {
+			const response = await requestPeers({ sort: 'networkVersion:desc' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(peer => expect(peer).toMap(peerSchema));
+			if (result.data.length > 1) {
+				for (let i = 1; i < result.data.length; i++) {
+					const prevPeer = result.data[i - 1];
+					const currPeer = result.data[i];
+					expect(semver.lte(
+						semver.coerce(prevPeer.networkVersion),
+						semver.coerce(currPeer.networkVersion),
+					)).toBeTruthy();
+				}
+			}
+			expect(result.meta).toMap(metaSchema);
+		});
+	});
+});

--- a/tests/schemas/api_v3/peer.schema.js
+++ b/tests/schemas/api_v3/peer.schema.js
@@ -1,0 +1,54 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import Joi from 'joi';
+
+const { jsonRPCSchema } = require('../rpcGenerics.schema');
+
+const allowedPeerStateNames = ['connected', 'disconnected', 'any'];
+
+const locationSchema = {
+	countryCode: Joi.string().length(2).optional(),
+	latitude: Joi.string().pattern(/^[0-9.-]+$/).optional(),
+	longitude: Joi.string().pattern(/^[0-9.-]+$/).optional(),
+};
+
+const peerSchema = {
+	ip: Joi.string().ip({ version: 'ipv4', cidr: 'forbidden' }).required(),
+	port: Joi.number().port().optional(),
+	networkVersion: Joi.string().required(),
+	state: Joi.string().valid(...allowedPeerStateNames).required(),
+	height: Joi.number().optional(),
+	networkIdentifier: Joi.string().required(),
+	location: Joi.object(locationSchema).optional(),
+};
+
+const emptyResultEnvelopeSchema = {
+	data: Joi.array().length(0).required(),
+	meta: Joi.object().required(),
+	links: Joi.object().optional(),
+};
+
+const emptyResponseSchema = {
+	jsonrpc: jsonRPCSchema,
+	result: emptyResultEnvelopeSchema,
+	id: Joi.alternatives(Joi.number(), Joi.string(), null).required(),
+};
+
+module.exports = {
+	peerSchema: Joi.object(peerSchema),
+	emptyResultEnvelopeSchema: Joi.object(emptyResultEnvelopeSchema).required(),
+	emptyResponseSchema: Joi.object(emptyResponseSchema).required(),
+};


### PR DESCRIPTION
### What was the problem?
This PR resolves #1092 

### How was it solved?
- [x] The following endpoints are available:
  - [x] HTTP: GET /peers
  - [x] RPC: get.peers
- [x] Users are able to filter the peers based on the query params listed below
- [x] Peers are cached at init
- [x] The cache is refreshed every minute
- [x] Integration tests are implemented

### How was it tested?
Local
