### PR TITLE
Update endpoint to fetch transaction statistics - Closes #1091

### DIFF
--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -159,6 +159,7 @@ pipeline {
 					nvm(readFile('.nvmrc').trim()) {
 						sh 'pm2 start --silent ecosystem.jenkins.config.js' 
 					}
+					sleep(90)
 					waitForHttp('http://localhost:9901/api/v3/blocks')
 				}
 			}

--- a/services/gateway/apis/http-version3/methods/transactionsStatistics.js
+++ b/services/gateway/apis/http-version3/methods/transactionsStatistics.js
@@ -22,14 +22,10 @@ module.exports = {
 	rpcMethod: 'get.transactions.statistics',
 	tags: ['Transactions'],
 	params: {
-		interval: { optional: true, type: 'string', pattern: /^\b(?:day|month)\b$/ },
+		interval: { optional: false, type: 'string', pattern: /^\b(?:day|month)\b$/ },
 		limit: { optional: true, type: 'number', min: 1, max: 100, default: 10, pattern: /^\b((?:[1-9][0-9]?)|100)\b$/ },
 		offset: { optional: true, type: 'number', min: 0, default: 0, pattern: /^\b([0-9][0-9]*)\b$/ },
 	},
-	paramsRequired: true,
-	validParamPairings: [
-		['interval'],
-	],
 	source: transactionsStatisticsSource,
 	envelope,
 };

--- a/services/gateway/apis/http-version3/methods/transactionsStatistics.js
+++ b/services/gateway/apis/http-version3/methods/transactionsStatistics.js
@@ -1,0 +1,35 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const transactionsStatisticsSource = require('../../../sources/version3/transactionsStatistics');
+const envelope = require('../../../sources/version3/mappings/stdEnvelope');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/transactions/statistics',
+	rpcMethod: 'get.transactions.statistics',
+	tags: ['Transactions'],
+	params: {
+		interval: { optional: true, type: 'string' },
+		offset: { optional: true, type: 'number', default: 0, min: 0 },
+		limit: { optional: true, type: 'number', default: 10, min: 1, max: 100 },
+	},
+	paramsRequired: true,
+	validParamPairings: [
+		['interval'],
+	],
+	source: transactionsStatisticsSource,
+	envelope,
+};

--- a/services/gateway/apis/http-version3/methods/transactionsStatistics.js
+++ b/services/gateway/apis/http-version3/methods/transactionsStatistics.js
@@ -22,9 +22,9 @@ module.exports = {
 	rpcMethod: 'get.transactions.statistics',
 	tags: ['Transactions'],
 	params: {
-		interval: { optional: true, type: 'string' },
-		offset: { optional: true, type: 'number', default: 0, min: 0 },
-		limit: { optional: true, type: 'number', default: 10, min: 1, max: 100 },
+		interval: { optional: true, type: 'string', pattern: /^\b(?:day|month)\b$/ },
+		limit: { optional: true, type: 'number', min: 1, max: 100, default: 10, pattern: /^\b((?:[1-9][0-9]?)|100)\b$/ },
+		offset: { optional: true, type: 'number', min: 0, default: 0, pattern: /^\b([0-9][0-9]*)\b$/ },
 	},
 	paramsRequired: true,
 	validParamPairings: [

--- a/services/gateway/apis/http-version3/methods/transactionsStatistics.js
+++ b/services/gateway/apis/http-version3/methods/transactionsStatistics.js
@@ -22,7 +22,7 @@ module.exports = {
 	rpcMethod: 'get.transactions.statistics',
 	tags: ['Transactions'],
 	params: {
-		interval: { optional: false, type: 'string', pattern: /^\b(?:day|month)\b$/ },
+		interval: { optional: false, type: 'string', enum: ['day', 'month'] },
 		limit: { optional: true, type: 'number', min: 1, max: 100, default: 10, pattern: /^\b((?:[1-9][0-9]?)|100)\b$/ },
 		offset: { optional: true, type: 'number', min: 0, default: 0, pattern: /^\b([0-9][0-9]*)\b$/ },
 	},

--- a/services/gateway/sources/version3/mappings/transactionsStatistics.js
+++ b/services/gateway/sources/version3/mappings/transactionsStatistics.js
@@ -1,0 +1,20 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+module.exports = {
+	timeline: '=',
+	distributionByType: '=',
+	distributionByAmount: '=',
+};

--- a/services/gateway/sources/version3/transactionsStatistics.js
+++ b/services/gateway/sources/version3/transactionsStatistics.js
@@ -1,0 +1,38 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const transactionsStatistics = require('./mappings/transactionsStatistics');
+
+module.exports = {
+	type: 'moleculer',
+	method: 'statistics.transactions.statistics',
+	params: {
+		interval: '=,string',
+		offset: '=',
+		limit: '=',
+	},
+	definition: {
+		data: ['data', transactionsStatistics],
+		meta: {
+			limit: '=,number',
+			offset: '=,number',
+			aggregateBy: '=,string',
+			dateFormat: '=,string',
+			dateFrom: '=,string',
+			dateTo: '=,string',
+		},
+		links: {},
+	},
+};

--- a/services/gateway/sources/version3/transactionsStatistics.js
+++ b/services/gateway/sources/version3/transactionsStatistics.js
@@ -24,7 +24,7 @@ module.exports = {
 		limit: '=',
 	},
 	definition: {
-		data: ['data', transactionsStatistics],
+		data: transactionsStatistics,
 		meta: {
 			limit: '=,number',
 			offset: '=,number',

--- a/services/gateway/sources/version3/transactionsStatistics.js
+++ b/services/gateway/sources/version3/transactionsStatistics.js
@@ -20,8 +20,8 @@ module.exports = {
 	method: 'statistics.transactions.statistics',
 	params: {
 		interval: '=,string',
-		offset: '=',
-		limit: '=',
+		offset: '=,number',
+		limit: '=,number',
 	},
 	definition: {
 		data: transactionsStatistics,

--- a/services/transaction-statistics/methods/transactions.js
+++ b/services/transaction-statistics/methods/transactions.js
@@ -15,25 +15,17 @@
  */
 
 const {
-	getTransactionsStatisticsDay,
-	getTransactionsStatisticsMonth,
+	getTransactionsStatistics,
 } = require('./controllers/transactions');
 
 module.exports = [
 	{
-		name: 'transactions.statistics.day',
-		controller: getTransactionsStatisticsDay,
+		name: 'transactions.statistics',
+		controller: getTransactionsStatistics,
 		params: {
-			limit: { optional: true, type: 'any' },
-			offset: { optional: true, type: 'any' },
-		},
-	},
-	{
-		name: 'transactions.statistics.month',
-		controller: getTransactionsStatisticsMonth,
-		params: {
-			limit: { optional: true, type: 'any' },
-			offset: { optional: true, type: 'any' },
+			interval: { optional: false, type: 'string' },
+			limit: { optional: true, type: 'number' },
+			offset: { optional: true, type: 'number' },
 		},
 	},
 ];

--- a/services/transaction-statistics/shared/transactionStatistics.js
+++ b/services/transaction-statistics/shared/transactionStatistics.js
@@ -48,7 +48,7 @@ const getSelector = async (params) => {
 
 	if (!numTrxTypes) {
 		const networkStatus = await requestConnector('getNetworkStatus');
-		numTrxTypes = networkStatus.data.moduleAssets.length;
+		numTrxTypes = networkStatus.data.registeredModules.length;
 	}
 
 	return {

--- a/services/transaction-statistics/shared/transactionStatistics.js
+++ b/services/transaction-statistics/shared/transactionStatistics.js
@@ -48,7 +48,7 @@ const getSelector = async (params) => {
 	if (params.dateTo) result.to = params.dateTo.unix();
 
 	if (!numTrxTypes) {
-		const networkStatus = await requestIndexer('getNetworkStatus');
+		const networkStatus = await requestIndexer('network.status');
 		numTrxTypes = networkStatus.data.moduleCommands.length;
 	}
 

--- a/services/transaction-statistics/shared/transactionStatistics.js
+++ b/services/transaction-statistics/shared/transactionStatistics.js
@@ -30,6 +30,7 @@ const moment = require('moment');
 const BigNumber = require('big-number');
 
 const { requestConnector, requestIndexer } = require('./utils/request');
+const requestAll = require('./utils/requestAll');
 
 const txStatisticsIndexSchema = require('./database/schemas/transactionStatistics');
 const config = require('../config');
@@ -150,9 +151,9 @@ const fetchTransactions = async (date) => {
 	const params = {
 		timestamp: `${moment.unix(date).unix()}:${moment.unix(date).add(1, 'day').unix()}`,
 	};
-	// TODO: Use requestAll (paginated calls) instead of setting limit to maxCount
-	// const maxCount = (await requestIndexer('transactions', { ...params, limit: 1 })).meta.total;
-	const result = await requestIndexer('transactions', { ...params, limit: 10000 });
+	const txMeta = (await requestIndexer('transactions', { ...params, limit: 1 })).meta;
+	const maxCount = txMeta ? txMeta.total : 1000;
+	const result = await requestAll(requestIndexer, 'transactions', { ...params, limit: 100 }, maxCount);
 	const transactions = result.data.error ? [] : result.data;
 	return transactions;
 };

--- a/services/transaction-statistics/shared/transactionStatistics.js
+++ b/services/transaction-statistics/shared/transactionStatistics.js
@@ -154,7 +154,7 @@ const fetchTransactions = async (date) => {
 	const txMeta = (await requestIndexer('transactions', { ...params, limit: 1 })).meta;
 	const maxCount = txMeta ? txMeta.total : 1000;
 	const result = await requestAll(requestIndexer, 'transactions', { ...params, limit: 100 }, maxCount);
-	const transactions = result.data.error ? [] : result.data;
+	const transactions = result.error ? [] : result;
 	return transactions;
 };
 

--- a/services/transaction-statistics/shared/transactionStatistics.js
+++ b/services/transaction-statistics/shared/transactionStatistics.js
@@ -29,7 +29,7 @@ const {
 const moment = require('moment');
 const BigNumber = require('big-number');
 
-const { requestConnector, requestIndexer } = require('./utils/request');
+const { requestIndexer } = require('./utils/request');
 const requestAll = require('./utils/requestAll');
 
 const txStatisticsIndexSchema = require('./database/schemas/transactionStatistics');
@@ -48,8 +48,8 @@ const getSelector = async (params) => {
 	if (params.dateTo) result.to = params.dateTo.unix();
 
 	if (!numTrxTypes) {
-		const networkStatus = await requestConnector('getNetworkStatus');
-		numTrxTypes = networkStatus.data.registeredModules.length;
+		const networkStatus = await requestIndexer('getNetworkStatus');
+		numTrxTypes = networkStatus.data.moduleCommands.length;
 	}
 
 	return {

--- a/services/transaction-statistics/shared/utils/requestAll.js
+++ b/services/transaction-statistics/shared/utils/requestAll.js
@@ -13,10 +13,10 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const requestAll = async (fn, methodName, params, limit) => {
+const requestAll = async (fn, method, params, limit) => {
 	const defaultMaxAmount = limit || 1000;
 	const oneRequestLimit = params.limit || 100;
-	const firstRequest = await fn(methodName,
+	const firstRequest = await fn(method,
 		{
 			...params,
 			...{
@@ -33,7 +33,7 @@ const requestAll = async (fn, methodName, params, limit) => {
 		if (maxAmount > oneRequestLimit) {
 			for (let page = 1; page < Math.ceil(maxAmount / oneRequestLimit); page++) {
 				/* eslint-disable-next-line no-await-in-loop */
-				const result = await fn(methodName, {
+				const result = await fn(method, {
 					...params,
 					...{
 						limit: oneRequestLimit,

--- a/services/transaction-statistics/shared/utils/requestAll.js
+++ b/services/transaction-statistics/shared/utils/requestAll.js
@@ -1,0 +1,50 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const requestAll = async (fn, methodName, params, limit) => {
+	const defaultMaxAmount = limit || 1000;
+	const oneRequestLimit = params.limit || 100;
+	const firstRequest = await fn(methodName,
+		{
+			...params,
+			...{
+				limit: oneRequestLimit,
+				offset: 0,
+			},
+		});
+	const { data } = firstRequest;
+	const maxAmount = !firstRequest.meta.total || firstRequest.meta.total > defaultMaxAmount
+		? defaultMaxAmount
+		: firstRequest.meta.total;
+
+	if (maxAmount > oneRequestLimit) {
+		for (let page = 1; page < Math.ceil(maxAmount / oneRequestLimit); page++) {
+			/* eslint-disable no-await-in-loop */
+			const result = await fn({
+				...params,
+				...{
+					limit: oneRequestLimit,
+					offset: oneRequestLimit * page,
+				},
+			});
+			if (!result.data.length) break;
+			data.push(...result.data);
+			/* eslint-enable no-await-in-loop */
+		}
+	}
+	return data;
+};
+
+module.exports = requestAll;

--- a/services/transaction-statistics/shared/utils/requestAll.js
+++ b/services/transaction-statistics/shared/utils/requestAll.js
@@ -25,23 +25,24 @@ const requestAll = async (fn, methodName, params, limit) => {
 			},
 		});
 	const { data } = firstRequest;
-	const maxAmount = !firstRequest.meta.total || firstRequest.meta.total > defaultMaxAmount
-		? defaultMaxAmount
-		: firstRequest.meta.total;
+	if (!data.error) {
+		const maxAmount = !firstRequest.meta.total || firstRequest.meta.total > defaultMaxAmount
+			? defaultMaxAmount
+			: firstRequest.meta.total;
 
-	if (maxAmount > oneRequestLimit) {
-		for (let page = 1; page < Math.ceil(maxAmount / oneRequestLimit); page++) {
-			/* eslint-disable no-await-in-loop */
-			const result = await fn({
-				...params,
-				...{
-					limit: oneRequestLimit,
-					offset: oneRequestLimit * page,
-				},
-			});
-			if (!result.data.length) break;
-			data.push(...result.data);
-			/* eslint-enable no-await-in-loop */
+		if (maxAmount > oneRequestLimit) {
+			for (let page = 1; page < Math.ceil(maxAmount / oneRequestLimit); page++) {
+				/* eslint-disable-next-line no-await-in-loop */
+				const result = await fn(methodName, {
+					...params,
+					...{
+						limit: oneRequestLimit,
+						offset: oneRequestLimit * page,
+					},
+				});
+				if (!result.data.length) break;
+				data.push(...result.data);
+			}
 		}
 	}
 	return data;

--- a/tests/integration/api_v3/http/transactionStatistics.test.js
+++ b/tests/integration/api_v3/http/transactionStatistics.test.js
@@ -20,7 +20,7 @@ const { api } = require('../../../helpers/api');
 
 const {
 	wrongInputParamSchema,
-	notFoundSchema,
+	badRequestSchema,
 } = require('../../../schemas/httpGenerics.schema');
 
 const {
@@ -133,9 +133,9 @@ describe('Transaction statistics API', () => {
 		});
 
 		describe('GET /transactions/statistics/year', () => {
-			it('returns error 404 if called without any params as years are not supported', async () => {
-				const response = await api.get(`${baseEndpoint}?interval=year}`, 404);
-				expect(response).toMap(notFoundSchema);
+			it('returns error if called without any params as years are not supported', async () => {
+				const response = await api.get(`${baseEndpoint}?interval=year}`, 400);
+				expect(response).toMap(badRequestSchema);
 			});
 		});
 	});

--- a/tests/integration/api_v3/http/transactionStatistics.test.js
+++ b/tests/integration/api_v3/http/transactionStatistics.test.js
@@ -1,0 +1,142 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import moment from 'moment';
+
+const config = require('../../../config');
+const { api } = require('../../../helpers/api');
+
+const {
+	wrongInputParamSchema,
+	notFoundSchema,
+} = require('../../../schemas/httpGenerics.schema');
+
+const {
+	timelineItemSchema,
+	transactionStatisticsSchema,
+	goodRequestSchema,
+	metaSchema,
+} = require('../../../schemas/api_v3/transactionStatistics.schema');
+
+const baseUrl = config.SERVICE_ENDPOINT;
+const baseUrlV3 = `${baseUrl}/api/v3`;
+const baseEndpoint = `${baseUrlV3}/transactions/statistics`;
+
+describe('Transaction statistics API', () => {
+	describe('GET /transactions/statistics', () => {
+		[{
+			interval: 'day',
+			dateFormat: 'YYYY-MM-DD',
+		},
+		{
+			interval: 'month',
+			dateFormat: 'YYYY-MM',
+		}].forEach(({ interval, dateFormat }) => {
+			describe(`GET /transactions/statistics?interval=${interval}`, () => {
+				const startOfUnitUtc = moment().utc().startOf(interval);
+
+				it(`returns stats for last 10 ${interval}s if called without any params`, async () => {
+					const response = await api.get(`${baseEndpoint}?interval=${interval}`);
+					expect(response).toMap(goodRequestSchema);
+					expect(response.data).toMap(transactionStatisticsSchema);
+					response.data.timeline.forEach((timelineItem, i) => {
+						const date = moment(startOfUnitUtc).subtract(i, interval);
+						expect(timelineItem).toMap(timelineItemSchema, {
+							date: date.format(dateFormat),
+							timestamp: date.unix(),
+						});
+					});
+					expect(response.meta).toMap(metaSchema);
+				});
+
+				it(`returns stats for this ${interval} if called with ?limit=1`, async () => {
+					const limit = 1;
+					const response = await api.get(`${baseEndpoint}?interval=${interval}&limit=${limit}`);
+					expect(response).toMap(goodRequestSchema);
+					expect(response.data.timeline).toHaveLength(1);
+					response.data.timeline.forEach(timelineItem => expect(timelineItem)
+						.toMap(timelineItemSchema, {
+							date: startOfUnitUtc.format(dateFormat),
+							timestamp: startOfUnitUtc.unix(),
+						}));
+					expect(response.meta).toMap(metaSchema, { limit });
+				});
+
+				it(`returns stats for previous ${interval} if called with ?limit=1&offset=1`, async () => {
+					if (interval === 'day') {
+						const limit = 1;
+						const offset = 1;
+						const startOfYesterday = moment(startOfUnitUtc).subtract(1, interval);
+
+						const response = await api.get(`${baseEndpoint}?interval=${interval}&limit=${limit}&offset=${offset}`);
+						expect(response).toMap(goodRequestSchema);
+						expect(response.data).toMap(transactionStatisticsSchema);
+						expect(response.data.timeline).toHaveLength(1);
+						response.data.timeline.forEach(timelineItem => expect(timelineItem)
+							.toMap(timelineItemSchema, {
+								date: startOfYesterday.format(dateFormat),
+								timestamp: startOfYesterday.unix(),
+							}));
+						expect(response.meta).toMap(metaSchema, {
+							limit,
+							offset,
+							dateFormat,
+							dateFrom: startOfYesterday.format(dateFormat),
+							dateTo: startOfYesterday.format(dateFormat),
+						});
+					}
+				});
+
+				it(`returns stats for previous ${interval} and the ${interval} before if called with ?limit=2&offset=1`, async () => {
+					if (interval === 'day') {
+						const limit = 2;
+						const offset = 1;
+
+						const response = await api.get(`${baseEndpoint}?interval=${interval}&limit=${limit}&offset=${offset}`);
+						expect(response).toMap(goodRequestSchema);
+						expect(response.data).toMap(transactionStatisticsSchema);
+						expect(response.data.timeline).toBeInstanceOf(Array);
+						expect(response.data.timeline.length).toBeGreaterThanOrEqual(1);
+						expect(response.data.timeline.length).toBeLessThanOrEqual(limit);
+						response.data.timeline.forEach((timelineItem, i) => {
+							const date = moment(startOfUnitUtc).subtract(i + offset, interval);
+							expect(timelineItem).toMap(timelineItemSchema, {
+								date: date.format(dateFormat),
+								timestamp: date.unix(),
+							});
+						});
+						expect(response.meta).toMap(metaSchema, {
+							limit,
+							offset,
+							dateFormat,
+						});
+					}
+				});
+
+				it('returns error 400 if called with ?limit=101 or higher', async () => {
+					const response = await api.get(`${baseEndpoint}?interval=${interval}&limit=101`, 400);
+					expect(response).toMap(wrongInputParamSchema);
+				});
+			});
+		});
+
+		describe('GET /transactions/statistics/year', () => {
+			it('returns error 404 if called without any params as years are not supported', async () => {
+				const response = await api.get(`${baseEndpoint}?interval=year}`, 404);
+				expect(response).toMap(notFoundSchema);
+			});
+		});
+	});
+});

--- a/tests/integration/api_v3/http/transactionStatistics.test.js
+++ b/tests/integration/api_v3/http/transactionStatistics.test.js
@@ -132,7 +132,7 @@ describe('Transaction statistics API', () => {
 			});
 		});
 
-		describe('GET /transactions/statistics/year', () => {
+		describe('GET /transactions/statistics?interval=year', () => {
 			it('returns error if called without any params as years are not supported', async () => {
 				const response = await api.get(`${baseEndpoint}?interval=year}`, 400);
 				expect(response).toMap(badRequestSchema);

--- a/tests/integration/api_v3/rpc/transactionStatistics.test.js
+++ b/tests/integration/api_v3/rpc/transactionStatistics.test.js
@@ -130,7 +130,7 @@ describe('get.transactions.statistics', () => {
 		});
 	});
 
-	describe('GET get.transactions.statistics.year', () => {
+	describe('GET get.transactions.statistics with interval: \'year\'', () => {
 		it('returns invalid param error (-32602) if called without any params as years are not supported', async () => {
 			const response = await requestTransactionStatistics({ interval: 'year' });
 			expect(response).toMap(invalidParamsSchema);

--- a/tests/integration/api_v3/rpc/transactionStatistics.test.js
+++ b/tests/integration/api_v3/rpc/transactionStatistics.test.js
@@ -1,0 +1,140 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import moment from 'moment';
+
+const config = require('../../../config');
+const { request } = require('../../../helpers/socketIoRpcRequest');
+
+const {
+	invalidParamsSchema,
+	jsonRpcEnvelopeSchema,
+	wrongMethodSchema,
+} = require('../../../schemas/rpcGenerics.schema');
+
+const {
+	timelineItemSchema,
+	transactionStatisticsSchema,
+	goodRequestSchema,
+	metaSchema,
+} = require('../../../schemas/api_v3/transactionStatistics.schema');
+
+const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
+const requestTransactionStatistics = async (params) => request(wsRpcUrl, 'get.transactions.statistics', params);
+
+describe('get.transactions.statistics', () => {
+	[{
+		interval: 'day',
+		dateFormat: 'YYYY-MM-DD',
+	},
+	{
+		interval: 'month',
+		dateFormat: 'YYYY-MM',
+	}].forEach(({ interval, dateFormat }) => {
+		describe(`get.transactions.statistics by interval as ${interval}`, () => {
+			const startOfUnitUtc = moment().utc().startOf(interval);
+
+			it(`returns stats for aggregated by ${interval}, if called without any params`, async () => {
+				const response = await requestTransactionStatistics({ interval });
+				expect(response).toMap(jsonRpcEnvelopeSchema);
+				const { result } = response;
+				expect(result).toMap(goodRequestSchema);
+				expect(result.data).toMap(transactionStatisticsSchema);
+				expect(result.meta).toMap(metaSchema);
+			});
+
+			it(`returns stats for this ${interval} if called with ?limit=1`, async () => {
+				const limit = 1;
+				const response = await requestTransactionStatistics({ interval, limit });
+				expect(response).toMap(jsonRpcEnvelopeSchema);
+				const { result } = response;
+				expect(result).toMap(goodRequestSchema);
+				expect(result.data).toMap(transactionStatisticsSchema);
+				expect(result.data.timeline).toHaveLength(1);
+				result.data.timeline.forEach(timelineItem => expect(timelineItem)
+					.toMap(timelineItemSchema, {
+						date: startOfUnitUtc.format(dateFormat),
+						timestamp: startOfUnitUtc.unix(),
+					}));
+				expect(result.meta).toMap(metaSchema, { limit });
+			});
+
+			it(`returns stats for previous ${interval} if called with ?limit=1&offset=1`, async () => {
+				if (interval === 'day') {
+					const limit = 1;
+					const offset = 1;
+					const startOfYesterday = moment(startOfUnitUtc).subtract(1, interval);
+
+					const response = await requestTransactionStatistics({ interval, limit, offset });
+					expect(response).toMap(jsonRpcEnvelopeSchema);
+					const { result } = response;
+					expect(result).toMap(goodRequestSchema);
+					expect(result.data).toMap(transactionStatisticsSchema);
+					expect(result.data.timeline).toHaveLength(1);
+					result.data.timeline.forEach(timelineItem => expect(timelineItem)
+						.toMap(timelineItemSchema, {
+							date: startOfYesterday.format(dateFormat),
+							timestamp: startOfYesterday.unix(),
+						}));
+					expect(result.meta).toMap(metaSchema, {
+						limit,
+						offset,
+						dateFormat,
+						dateFrom: startOfYesterday.format(dateFormat),
+						dateTo: startOfYesterday.format(dateFormat),
+					});
+				}
+			});
+
+			it(`returns stats for previous ${interval} and the ${interval} before if called with ?limit=2&offset=1`, async () => {
+				if (interval === 'day') {
+					const limit = 2;
+					const offset = 1;
+
+					const response = await requestTransactionStatistics({ interval, limit, offset });
+					expect(response).toMap(jsonRpcEnvelopeSchema);
+					const { result } = response;
+					expect(result).toMap(goodRequestSchema);
+					expect(result.data).toMap(transactionStatisticsSchema);
+					expect(result.data.timeline).toHaveLength(2);
+					result.data.timeline.forEach((timelineItem, i) => {
+						const date = moment(startOfUnitUtc).subtract(i + offset, interval);
+						expect(timelineItem).toMap(timelineItemSchema, {
+							date: date.format(dateFormat),
+							timestamp: date.unix(),
+						});
+					});
+					expect(result.meta).toMap(metaSchema, {
+						limit,
+						offset,
+						dateFormat,
+					});
+				}
+			});
+
+			it('returns invalid param error (-32602) if called with ?limit=101 or higher', async () => {
+				const response = await requestTransactionStatistics({ interval, limit: 101 });
+				expect(response).toMap(invalidParamsSchema);
+			});
+		});
+	});
+
+	describe('GET get.transactions.statistics.year', () => {
+		it('returns error METHOD_NOT_FOUND (-32601)) if called without any params as years are not supported', async () => {
+			const response = await requestTransactionStatistics({ interval: 'year' });
+			expect(response).toMap(wrongMethodSchema);
+		});
+	});
+});

--- a/tests/integration/api_v3/rpc/transactionStatistics.test.js
+++ b/tests/integration/api_v3/rpc/transactionStatistics.test.js
@@ -21,7 +21,6 @@ const { request } = require('../../../helpers/socketIoRpcRequest');
 const {
 	invalidParamsSchema,
 	jsonRpcEnvelopeSchema,
-	wrongMethodSchema,
 } = require('../../../schemas/rpcGenerics.schema');
 
 const {
@@ -132,9 +131,9 @@ describe('get.transactions.statistics', () => {
 	});
 
 	describe('GET get.transactions.statistics.year', () => {
-		it('returns error METHOD_NOT_FOUND (-32601)) if called without any params as years are not supported', async () => {
+		it('returns invalid param error (-32602) if called without any params as years are not supported', async () => {
 			const response = await requestTransactionStatistics({ interval: 'year' });
-			expect(response).toMap(wrongMethodSchema);
+			expect(response).toMap(invalidParamsSchema);
 		});
 	});
 });

--- a/tests/schemas/api_v3/transactionStatistics.schema.js
+++ b/tests/schemas/api_v3/transactionStatistics.schema.js
@@ -1,0 +1,53 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import Joi from 'joi';
+
+const allowedDateFormats = ['YYYY-MM-DD', 'YYYY-MM'];
+
+const goodRequestSchema = {
+	data: Joi.object().required(),
+	meta: Joi.object().required(),
+	links: Joi.object().optional(),
+};
+
+const timelineItemSchema = {
+	timestamp: Joi.number().integer().positive().required(),
+	date: Joi.string().required(),
+	transactionCount: Joi.number().integer().min(0).required(),
+	volume: Joi.number().integer().min(0).required(),
+};
+
+const transactionStatisticsSchema = {
+	timeline: Joi.array().items(timelineItemSchema).required(),
+	distributionByType: Joi.object().required(),
+	distributionByAmount: Joi.object().required(),
+};
+
+const metaSchema = {
+	limit: Joi.number().required(),
+	offset: Joi.number().required(),
+	aggregateBy: Joi.string().optional(),
+	dateFormat: Joi.string().valid(...allowedDateFormats).required(),
+	dateFrom: Joi.string().required(),
+	dateTo: Joi.string().required(),
+};
+
+module.exports = {
+	timelineItemSchema: Joi.object(timelineItemSchema).required(),
+	transactionStatisticsSchema: Joi.object(transactionStatisticsSchema).required(),
+	goodRequestSchema: Joi.object(goodRequestSchema).required(),
+	metaSchema: Joi.object(metaSchema).required(),
+};


### PR DESCRIPTION
### What was the problem?
This PR resolves #1091 

### How was it solved?
- [x] The following endpoints are available: 
  - [x] HTTP: GET /transactions/statistics
  - [x] RPC: get.transactions.statistics
- [x] Users are able to filter the statistics based on the query params listed below
  - [x] interval
  - [x] limit, offset
- [x] Transactions are requested from the connector using pagination
- [x] Implement requestAll method when computing the stats
- [x] Integration tests are implemented

### How was it tested?
Local