### PR TITLE
Add endpoint to fetch network statistics - Closes #1094

### DIFF
--- a/services/gateway/apis/http-version3/methods/networkStatistics.js
+++ b/services/gateway/apis/http-version3/methods/networkStatistics.js
@@ -1,0 +1,26 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const networkStatisticsSource = require('../../../sources/version3/networkStatistics');
+const envelope = require('../../../sources/version3/mappings/stdEnvelope');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/network/statistics',
+	rpcMethod: 'get.network.statistics',
+	tags: ['Network'],
+	source: networkStatisticsSource,
+	envelope,
+};

--- a/services/gateway/sources/version3/networkStatistics.js
+++ b/services/gateway/sources/version3/networkStatistics.js
@@ -1,0 +1,29 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+module.exports = {
+	type: 'moleculer',
+	method: 'indexer.peers.statistics',
+	params: {},
+	definition: {
+		data: {
+			basic: '=',
+			height: '=',
+			networkVersion: '=',
+		},
+		meta: {},
+		links: {},
+	},
+};

--- a/tests/integration/api_v3/http/networkStatistics.test.js
+++ b/tests/integration/api_v3/http/networkStatistics.test.js
@@ -17,6 +17,10 @@ const config = require('../../../config');
 const { api } = require('../../../helpers/api');
 
 const {
+	badRequestSchema,
+} = require('../../../schemas/httpGenerics.schema');
+
+const {
 	networkStatisticsSchema,
 	goodRequestSchema,
 } = require('../../../schemas/api_v3/networkStatistics.schema');
@@ -31,5 +35,10 @@ xdescribe(`GET ${endpoint}`, () => {
 		const response = await api.get(endpoint);
 		expect(response).toMap(goodRequestSchema);
 		expect(response.data).toMap(networkStatisticsSchema);
+	});
+
+	it('invalid request param -> bad request', async () => {
+		const response = await api.get(`${endpoint}?invalidParam=invalid`, 400);
+		expect(response).toMap(badRequestSchema);
 	});
 });

--- a/tests/integration/api_v3/http/networkStatistics.test.js
+++ b/tests/integration/api_v3/http/networkStatistics.test.js
@@ -1,0 +1,35 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+const { api } = require('../../../helpers/api');
+
+const {
+	networkStatisticsSchema,
+	goodRequestSchema,
+} = require('../../../schemas/api_v3/networkStatistics.schema');
+
+const baseUrl = config.SERVICE_ENDPOINT;
+const baseUrlV3 = `${baseUrl}/api/v3`;
+const endpoint = `${baseUrlV3}/network/statistics`;
+
+// TODO: Enable when peers endpoint is available from sdk
+xdescribe(`GET ${endpoint}`, () => {
+	it('retrieves network statistics -> ok', async () => {
+		const response = await api.get(endpoint);
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toMap(networkStatisticsSchema);
+	});
+});

--- a/tests/integration/api_v3/http/networkStatistics.test.js
+++ b/tests/integration/api_v3/http/networkStatistics.test.js
@@ -29,9 +29,9 @@ const baseUrl = config.SERVICE_ENDPOINT;
 const baseUrlV3 = `${baseUrl}/api/v3`;
 const endpoint = `${baseUrlV3}/network/statistics`;
 
-// TODO: Enable when peers endpoint is available from sdk
-xdescribe(`GET ${endpoint}`, () => {
-	it('retrieves network statistics -> ok', async () => {
+describe(`GET ${endpoint}`, () => {
+	// TODO: Enable when peers endpoint is available from sdk
+	xit('retrieves network statistics -> ok', async () => {
 		const response = await api.get(endpoint);
 		expect(response).toMap(goodRequestSchema);
 		expect(response.data).toMap(networkStatisticsSchema);

--- a/tests/integration/api_v3/rpc/networkStatistics.test.js
+++ b/tests/integration/api_v3/rpc/networkStatistics.test.js
@@ -1,0 +1,37 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+
+const {
+	request,
+} = require('../../../helpers/socketIoRpcRequest');
+
+const {
+	networkStatisticsSchema,
+	goodRequestSchema,
+} = require('../../../schemas/api_v3/networkStatistics.schema');
+
+const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
+const getNetworkStatistics = async () => request(wsRpcUrl, 'get.network.statistics');
+
+// TODO: Enable when peers endpoint is available from sdk
+xdescribe('get.network.statistics', () => {
+	it('returns network statistics', async () => {
+		const response = await getNetworkStatistics();
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toMap(networkStatisticsSchema);
+	});
+});

--- a/tests/integration/api_v3/rpc/networkStatistics.test.js
+++ b/tests/integration/api_v3/rpc/networkStatistics.test.js
@@ -20,6 +20,10 @@ const {
 } = require('../../../helpers/socketIoRpcRequest');
 
 const {
+	invalidParamsSchema,
+} = require('../../../schemas/rpcGenerics.schema');
+
+const {
 	networkStatisticsSchema,
 	goodRequestSchema,
 } = require('../../../schemas/api_v3/networkStatistics.schema');
@@ -33,5 +37,10 @@ xdescribe('get.network.statistics', () => {
 		const response = await getNetworkStatistics();
 		expect(response).toMap(goodRequestSchema);
 		expect(response.data).toMap(networkStatisticsSchema);
+	});
+
+	it('invalid request param -> invalid param', async () => {
+		const response = await getNetworkStatistics({ invalidParam: 'invalid' });
+		expect(response).toMap(invalidParamsSchema);
 	});
 });

--- a/tests/integration/api_v3/rpc/networkStatistics.test.js
+++ b/tests/integration/api_v3/rpc/networkStatistics.test.js
@@ -31,9 +31,9 @@ const {
 const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
 const getNetworkStatistics = async (params) => request(wsRpcUrl, 'get.network.statistics', params);
 
-// TODO: Enable when peers endpoint is available from sdk
-xdescribe('get.network.statistics', () => {
-	it('returns network statistics', async () => {
+describe('get.network.statistics', () => {
+	// TODO: Enable when peers endpoint is available from sdk
+	xit('returns network statistics', async () => {
 		const response = await getNetworkStatistics();
 		expect(response).toMap(goodRequestSchema);
 		expect(response.data).toMap(networkStatisticsSchema);

--- a/tests/integration/api_v3/rpc/networkStatistics.test.js
+++ b/tests/integration/api_v3/rpc/networkStatistics.test.js
@@ -29,7 +29,7 @@ const {
 } = require('../../../schemas/api_v3/networkStatistics.schema');
 
 const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
-const getNetworkStatistics = async () => request(wsRpcUrl, 'get.network.statistics');
+const getNetworkStatistics = async (params) => request(wsRpcUrl, 'get.network.statistics', params);
 
 // TODO: Enable when peers endpoint is available from sdk
 xdescribe('get.network.statistics', () => {

--- a/tests/schemas/api_v3/networkStatistics.schema.js
+++ b/tests/schemas/api_v3/networkStatistics.schema.js
@@ -21,12 +21,14 @@ const goodRequestSchema = {
 	links: Joi.object().optional(),
 };
 
+const basicStatsSchema = {
+	totalPeers: Joi.number().integer().min(0).required(),
+	connectedPeers: Joi.number().integer().min(0).required(),
+	disconnectedPeers: Joi.number().integer().min(0).required(),
+};
+
 const networkStatisticsSchema = {
-	basic: Joi.object({
-		totalPeers: Joi.number().integer().min(0).required(),
-		connectedPeers: Joi.number().integer().min(0).required(),
-		disconnectedPeers: Joi.number().integer().min(0).required(),
-	}).required(),
+	basic: Joi.object(basicStatsSchema).required(),
 	height: Joi.object().required(),
 	networkVersion: Joi.object().required(),
 };

--- a/tests/schemas/api_v3/networkStatistics.schema.js
+++ b/tests/schemas/api_v3/networkStatistics.schema.js
@@ -21,7 +21,7 @@ const goodRequestSchema = {
 	links: Joi.object().optional(),
 };
 
-const networkStatisticsSchema = Joi.object({
+const networkStatisticsSchema = {
 	basic: Joi.object({
 		totalPeers: Joi.number().integer().min(0).required(),
 		connectedPeers: Joi.number().integer().min(0).required(),
@@ -29,7 +29,7 @@ const networkStatisticsSchema = Joi.object({
 	}).required(),
 	height: Joi.object().required(),
 	networkVersion: Joi.object().required(),
-}).required();
+};
 
 module.exports = {
 	networkStatisticsSchema: Joi.object(networkStatisticsSchema).required(),

--- a/tests/schemas/api_v3/networkStatistics.schema.js
+++ b/tests/schemas/api_v3/networkStatistics.schema.js
@@ -1,0 +1,37 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import Joi from 'joi';
+
+const goodRequestSchema = {
+	data: Joi.object().required(),
+	meta: Joi.object().required(),
+	links: Joi.object().optional(),
+};
+
+const networkStatisticsSchema = Joi.object({
+	basic: Joi.object({
+		totalPeers: Joi.number().required(),
+		connectedPeers: Joi.number().required(),
+		disconnectedPeers: Joi.number().required(),
+	}).required(),
+	height: Joi.object().required(),
+	networkVersion: Joi.object().required(),
+}).required();
+
+module.exports = {
+	networkStatisticsSchema: Joi.object(networkStatisticsSchema).required(),
+	goodRequestSchema: Joi.object(goodRequestSchema).required(),
+};

--- a/tests/schemas/api_v3/networkStatistics.schema.js
+++ b/tests/schemas/api_v3/networkStatistics.schema.js
@@ -23,9 +23,9 @@ const goodRequestSchema = {
 
 const networkStatisticsSchema = Joi.object({
 	basic: Joi.object({
-		totalPeers: Joi.number().required(),
-		connectedPeers: Joi.number().required(),
-		disconnectedPeers: Joi.number().required(),
+		totalPeers: Joi.number().integer().min(0).required(),
+		connectedPeers: Joi.number().integer().min(0).required(),
+		disconnectedPeers: Joi.number().integer().min(0).required(),
 	}).required(),
 	height: Joi.object().required(),
 	networkVersion: Joi.object().required(),


### PR DESCRIPTION
### What was the problem?
This PR resolves #1094

### How was it solved?

- [x] The following endpoints are available:
  - [x] HTTP: GET /network/statistics
  - [x] RPC: get.network.statistics
- [x] Network statistics is computed and cached every time the peer cache is populated/refreshed
- [x] Integration tests are implemented

### How was it tested?
Local