### PR TITLE
Add endpoint to fetch generators - Closes #1096

### DIFF
--- a/services/blockchain-indexer/events/blockchain.js
+++ b/services/blockchain-indexer/events/blockchain.js
@@ -19,8 +19,8 @@ const { Logger, Signals } = require('lisk-service-framework');
 const {
 	reloadAllPendingTransactions,
 	getTransactionsByBlockId,
-	// reloadNextForgersCache,
-	// getForgers,
+	reloadGeneratorsCache,
+	getGenerators,
 } = require('../shared/dataService');
 
 const logger = Logger();
@@ -80,23 +80,22 @@ module.exports = [
 			Signals.get('newBlock').add(newTransactionsListener);
 		},
 	},
-	// TODO: Enable when getForgers method is available from core
-	// {
-	// 	name: 'forgers.change',
-	// 	description: 'Track round change updates',
-	// 	controller: callback => {
-	// 		const forgersChangeListener = async () => {
-	// 			try {
-	// 				await reloadNextForgersCache();
-	// 				const forgers = await getForgers({ limit: 25, offset: 0 });
-	// 				callback(forgers);
-	// 			} catch (err) {
-	// 				logger.error(`Error occured when processing 'forgers.change' event:\n${err.stack}`);
-	// 			}
-	// 		};
-	// 		Signals.get('newBlock').add(forgersChangeListener);
-	// 	},
-	// },
+	{
+		name: 'generators.change',
+		description: 'Keep generators list up-to-date',
+		controller: callback => {
+			const generatorsChangeListener = async () => {
+				try {
+					await reloadGeneratorsCache();
+					const generators = await getGenerators({ limit: 25, offset: 0 });
+					callback(generators);
+				} catch (err) {
+					logger.error(`Error occured when processing 'generators.change' event:\n${err.stack}`);
+				}
+			};
+			Signals.get('newBlock').add(generatorsChangeListener);
+		},
+	},
 	{
 		name: 'round.change',
 		description: 'Track round change updates',

--- a/services/blockchain-indexer/events/blockchain.js
+++ b/services/blockchain-indexer/events/blockchain.js
@@ -87,7 +87,7 @@ module.exports = [
 			const generatorsChangeListener = async () => {
 				try {
 					await reloadGeneratorsCache();
-					const generators = await getGenerators({ limit: 25, offset: 0 });
+					const generators = await getGenerators({ limit: 103 });
 					callback(generators);
 				} catch (err) {
 					logger.error(`Error occured when processing 'generators.change' event:\n${err.stack}`);

--- a/services/blockchain-indexer/shared/dataService/business/generators.js
+++ b/services/blockchain-indexer/shared/dataService/business/generators.js
@@ -28,7 +28,7 @@ const getGenerators = async () => {
 			address: getBase32AddressFromHex(address),
 			name: await getNameByAddress(address),
 			// TODO: Update when nextForgingTime is available from SDK
-			// nextForgingTime
+			nextForgingTime: Math.floor(Date.now() / 1000) + 1000,
 		}));
 
 	return generators;

--- a/services/blockchain-indexer/shared/dataService/business/generators.js
+++ b/services/blockchain-indexer/shared/dataService/business/generators.js
@@ -13,46 +13,23 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-// const BluebirdPromise = require('bluebird');
-const { Utils } = require('lisk-service-framework');
-const {
-	// getIndexedAccountInfo,
-	getBase32AddressFromHex,
-} = require('../../utils/accountUtils');
+const BluebirdPromise = require('bluebird');
 
+const { getBase32AddressFromHex } = require('../../utils/accountUtils');
 const { getGenesisConfig } = require('../../constants');
-
 const { requestConnector } = require('../../utils/request');
-
-const ObjectUtilService = Utils.Data;
-const { isProperObject } = ObjectUtilService;
+const { getNameByAddress } = require('../../utils/delegateUtils');
 
 const getGenerators = async () => {
-	const generators = await requestConnector('getGenerators');
-	generators.data = generators
-		.map(generator => ({
-			...generator,
-			address: getBase32AddressFromHex(generator.address),
+	const { list: generatorsAddresses } = await requestConnector('getGenerators');
+	const generators = await BluebirdPromise.map(
+		generatorsAddresses,
+		async address => ({
+			address: getBase32AddressFromHex(address),
+			name: await getNameByAddress(address),
 		}));
 
-	// TODO: Update when generators list is available from SDK
-	// generators.data = await BluebirdPromise.map(
-	// 	generators.data,
-	// 	async forger => {
-	// 		const account = await getIndexedAccountInfo(
-	// 			{ address: forger.address, limit: 1 },
-	// 			['address', 'username', 'totalVotesReceived']);
-	// 		forger.username = account && account.username
-	// 			? account.username
-	// 			: null;
-	// 		forger.totalVotesReceived = account && account.totalVotesReceived
-	// 			? Number(account.totalVotesReceived)
-	// 			: null;
-	// 		return forger;
-	// 	},
-	// 	{ concurrency: generators.data.length },
-	// );
-	return isProperObject(generators) && Array.isArray(generators.data) ? generators.data : [];
+	return generators;
 };
 
 const getNumberOfGenerators = async () => {

--- a/services/blockchain-indexer/shared/dataService/business/generators.js
+++ b/services/blockchain-indexer/shared/dataService/business/generators.js
@@ -27,6 +27,8 @@ const getGenerators = async () => {
 		async address => ({
 			address: getBase32AddressFromHex(address),
 			name: await getNameByAddress(address),
+			// TODO: Update when nextForgingTime is available from SDK
+			// nextForgingTime
 		}));
 
 	return generators;

--- a/services/gateway/apis/http-version3/methods/generators.js
+++ b/services/gateway/apis/http-version3/methods/generators.js
@@ -15,15 +15,14 @@
  */
 const generatorsSource = require('../../../sources/version3/generators');
 const envelope = require('../../../sources/version3/mappings/stdEnvelope');
-const regex = require('../../../shared/regex');
 
 module.exports = {
 	version: '2.0',
 	swaggerApiPath: '/generators',
 	rpcMethod: 'get.generators',
 	params: {
-		limit: { optional: true, type: 'number', min: 1, max: 103, default: 10, pattern: regex.LIMIT },
-		offset: { optional: true, type: 'number', min: 0, default: 0, pattern: regex.OFFSET },
+		limit: { optional: true, type: 'number', min: 1, max: 103, default: 10 },
+		offset: { optional: true, type: 'number', min: 0, default: 0 },
 	},
 	tags: ['Generators'],
 	source: generatorsSource,

--- a/services/gateway/apis/http-version3/methods/generators.js
+++ b/services/gateway/apis/http-version3/methods/generators.js
@@ -1,0 +1,31 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const generatorsSource = require('../../../sources/version3/generators');
+const envelope = require('../../../sources/version3/mappings/stdEnvelope');
+const regex = require('../../../shared/regex');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/generators',
+	rpcMethod: 'get.generators',
+	params: {
+		limit: { optional: true, type: 'number', min: 1, max: 103, default: 10, pattern: regex.LIMIT },
+		offset: { optional: true, type: 'number', min: 0, default: 0, pattern: regex.OFFSET },
+	},
+	tags: ['Generators'],
+	source: generatorsSource,
+	envelope,
+};

--- a/services/gateway/app.js
+++ b/services/gateway/app.js
@@ -37,7 +37,7 @@ const { genDocs } = require('./shared/generateDocs');
 const mapper = require('./shared/customMapper');
 const { definition: blocksDefinition } = require('./sources/version3/blocks');
 const { definition: feesDefinition } = require('./sources/version2/fees');
-const { definition: forgersDefinition } = require('./sources/version2/forgers');
+const { definition: generatorsDefinition } = require('./sources/version3/generators');
 const { definition: transactionsDefinition } = require('./sources/version3/transactions');
 
 const { host, port } = config;
@@ -136,7 +136,7 @@ const gatewayConfig = {
 		'block.change': (payload) => sendSocketIoEvent('update.block', mapper(payload, blocksDefinition)),
 		'transactions.new': (payload) => sendSocketIoEvent('update.transactions', mapper(payload, transactionsDefinition)),
 		'round.change': (payload) => sendSocketIoEvent('update.round', payload),
-		'forgers.change': (payload) => sendSocketIoEvent('update.forgers', mapper(payload, forgersDefinition)),
+		'generators.change': (payload) => sendSocketIoEvent('update.generators', mapper(payload, generatorsDefinition)),
 		'update.fee_estimates': (payload) => sendSocketIoEvent('update.fee_estimates', mapper(payload, feesDefinition)),
 		'coreService.Ready': (payload) => updateSvcStatus(payload),
 	},

--- a/services/gateway/sources/version3/generators.js
+++ b/services/gateway/sources/version3/generators.js
@@ -1,0 +1,34 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const generators = require('./mappings/generators');
+
+module.exports = {
+	type: 'moleculer',
+	method: 'indexer.generators',
+	params: {
+		limit: '=',
+		offset: '=',
+	},
+	definition: {
+		data: ['data', generators],
+		meta: {
+			count: '=,number',
+			offset: '=,number',
+			total: '=,number',
+		},
+		links: {},
+	},
+};

--- a/services/gateway/sources/version3/mappings/generators.js
+++ b/services/gateway/sources/version3/mappings/generators.js
@@ -1,0 +1,20 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+module.exports = {
+	address: '=,string',
+	name: '=,string',
+	nextForgingTime: '=,number',
+};

--- a/tests/integration/api_v3/http/generators.test.js
+++ b/tests/integration/api_v3/http/generators.test.js
@@ -31,24 +31,54 @@ const endpoint = `${baseUrl}/api/v3`;
 
 describe('Generators API', () => {
 	describe('GET /generators', () => {
-		it('limit = 100 -> ok', async () => {
+		it('retrieve generators list -> ok', async () => {
+			const response = await api.get(`${endpoint}/generators`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(103);
+			response.data.map(generator => expect(generator).toMap(generatorSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('retrieve generators list with limit=100 -> ok', async () => {
 			const response = await api.get(`${endpoint}/generators?limit=100`);
 			expect(response).toMap(goodRequestSchema);
-			expect(response.data).toBeArrayOfSize(100);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
+			response.data.map(generator => expect(generator).toMap(generatorSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('retrieve generators list with limit=100 and offset=1 -> ok', async () => {
+			const response = await api.get(`${endpoint}/generators?limit=100&offset=1`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(100);
 			response.data.map(generator => expect(generator).toMap(generatorSchema));
 			expect(response.meta).toMap(metaSchema);
 		});
 
 		it('limit = 0 -> 400', async () => {
-			const response = await api.get(`${endpoint}/generatorSchema?limit=0`, 400);
+			const response = await api.get(`${endpoint}/generators?limit=0`, 400);
 			expect(response).toMap(badRequestSchema);
 		});
 
 		it('empty limit -> all generators', async () => {
-			const response = await api.get(`${endpoint}/generatorSchema?limit=`);
+			const response = await api.get(`${endpoint}/generators?limit=`);
 			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(103);
 			response.data.map(generator => expect(generator).toMap(generatorSchema));
 			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('invalid request param -> bad request', async () => {
+			const response = await api.get(`${endpoint}/generators?invalidParam=invalid`, 400);
+			expect(response).toMap(badRequestSchema);
 		});
 	});
 });

--- a/tests/integration/api_v3/http/generators.test.js
+++ b/tests/integration/api_v3/http/generators.test.js
@@ -1,0 +1,54 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+const { api } = require('../../../helpers/api');
+
+const {
+	badRequestSchema,
+	goodRequestSchema,
+	metaSchema,
+} = require('../../../schemas/httpGenerics.schema');
+
+const {
+	generatorSchema,
+} = require('../../../schemas/api_v3/generatorSchema.schema');
+
+const baseUrl = config.SERVICE_ENDPOINT;
+const endpoint = `${baseUrl}/api/v3`;
+
+describe('Generators API', () => {
+	describe('GET /generators', () => {
+		it('limit = 100 -> ok', async () => {
+			const response = await api.get(`${endpoint}/generators?limit=100`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeArrayOfSize(100);
+			response.data.map(generator => expect(generator).toMap(generatorSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+
+		it('limit = 0 -> 400', async () => {
+			const response = await api.get(`${endpoint}/generatorSchema?limit=0`, 400);
+			expect(response).toMap(badRequestSchema);
+		});
+
+		it('empty limit -> all generators', async () => {
+			const response = await api.get(`${endpoint}/generatorSchema?limit=`);
+			expect(response).toMap(goodRequestSchema);
+			response.data.map(generator => expect(generator).toMap(generatorSchema));
+			expect(response.meta).toMap(metaSchema);
+		});
+	});
+});

--- a/tests/integration/api_v3/rpc/generators.test.js
+++ b/tests/integration/api_v3/rpc/generators.test.js
@@ -1,0 +1,58 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+const { request } = require('../../../helpers/socketIoRpcRequest');
+
+const {
+	resultEnvelopeSchema,
+	jsonRpcEnvelopeSchema,
+	metaSchema,
+	invalidParamsSchema,
+} = require('../../../schemas/rpcGenerics.schema');
+
+const {
+	generatorSchema,
+} = require('../../../schemas/api_v3/generatorSchema.schema');
+
+const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
+const getGenerators = async params => request(wsRpcUrl, 'get.generators', params);
+
+describe('Generators API', () => {
+	describe('GET /generators', () => {
+		it('limit = 100 -> ok', async () => {
+			const response = await getGenerators({ limit: 100 });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result).toMap(resultEnvelopeSchema);
+			result.data.map(generator => expect(generator).toMap(generatorSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('limit = 0 -> -32602', async () => {
+			const response = await getGenerators({ limit: 0 }).catch(e => e);
+			expect(response).toMap(invalidParamsSchema);
+		});
+
+		it('empty limit -> all generators', async () => {
+			const response = await getGenerators({ limit: '' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result).toMap(resultEnvelopeSchema);
+			result.data.map(generator => expect(generator).toMap(generatorSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+	});
+});

--- a/tests/integration/api_v3/rpc/generators.test.js
+++ b/tests/integration/api_v3/rpc/generators.test.js
@@ -32,18 +32,40 @@ const getGenerators = async params => request(wsRpcUrl, 'get.generators', params
 
 describe('Generators API', () => {
 	describe('GET /generators', () => {
-		it('limit = 100 -> ok', async () => {
-			const response = await getGenerators({ limit: 100 });
+		it('returns generators list -> ok', async () => {
+			const response = await getGenerators();
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
 			expect(result).toMap(resultEnvelopeSchema);
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(103);
 			result.data.map(generator => expect(generator).toMap(generatorSchema));
 			expect(result.meta).toMap(metaSchema);
 		});
 
-		it('limit = 0 -> -32602', async () => {
-			const response = await getGenerators({ limit: 0 }).catch(e => e);
-			expect(response).toMap(invalidParamsSchema);
+		it('returns generators list with limit=100 -> ok', async () => {
+			const response = await getGenerators({ limit: 100 });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result).toMap(resultEnvelopeSchema);
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(100);
+			result.data.map(generator => expect(generator).toMap(generatorSchema));
+			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('returns generators list with limit=100 and offset=1 -> ok', async () => {
+			const response = await getGenerators({ limit: 100, offset: 1 });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result).toMap(resultEnvelopeSchema);
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(100);
+			result.data.map(generator => expect(generator).toMap(generatorSchema));
+			expect(result.meta).toMap(metaSchema);
 		});
 
 		it('empty limit -> all generators', async () => {
@@ -51,8 +73,21 @@ describe('Generators API', () => {
 			expect(response).toMap(jsonRpcEnvelopeSchema);
 			const { result } = response;
 			expect(result).toMap(resultEnvelopeSchema);
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(103);
 			result.data.map(generator => expect(generator).toMap(generatorSchema));
 			expect(result.meta).toMap(metaSchema);
+		});
+
+		it('limit=0 -> -32602', async () => {
+			const response = await getGenerators({ limit: 0 }).catch(e => e);
+			expect(response).toMap(invalidParamsSchema);
+		});
+
+		it('invalid request param -> invalid param', async () => {
+			const response = await getGenerators({ invalidParam: 'invalid' });
+			expect(response).toMap(invalidParamsSchema);
 		});
 	});
 });

--- a/tests/schemas/api_v3/generatorSchema.schema.js
+++ b/tests/schemas/api_v3/generatorSchema.schema.js
@@ -16,10 +16,12 @@
 import Joi from 'joi';
 import regex from './regex';
 
+const getCurrentTimestamp = () => Math.floor(Date.now() / 1000);
+
 const generatorSchema = {
 	address: Joi.string().pattern(regex.ADDRESS).required(),
 	name: Joi.string().pattern(regex.NAME).optional(),
-	nextForgingTime: Joi.number().integer().optional(),
+	nextForgingTime: Joi.number().integer().min(getCurrentTimestamp()).optional(),
 };
 
 module.exports = {

--- a/tests/schemas/api_v3/generatorSchema.schema.js
+++ b/tests/schemas/api_v3/generatorSchema.schema.js
@@ -21,7 +21,7 @@ const getCurrentTimestamp = () => Math.floor(Date.now() / 1000);
 const generatorSchema = {
 	address: Joi.string().pattern(regex.ADDRESS_BASE32).required(),
 	name: Joi.string().pattern(regex.NAME).optional(),
-	nextForgingTime: Joi.number().integer().min(getCurrentTimestamp()).optional(),
+	nextForgingTime: Joi.number().integer().min(getCurrentTimestamp()).required(),
 };
 
 module.exports = {

--- a/tests/schemas/api_v3/generatorSchema.schema.js
+++ b/tests/schemas/api_v3/generatorSchema.schema.js
@@ -1,0 +1,27 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import Joi from 'joi';
+import regex from './regex';
+
+const generatorSchema = {
+	address: Joi.string().pattern(regex.ADDRESS).required(),
+	name: Joi.string().pattern(regex.NAME).optional(),
+	nextForgingTime: Joi.number().integer().optional(),
+};
+
+module.exports = {
+	generatorSchema: Joi.object(generatorSchema).required(),
+};

--- a/tests/schemas/api_v3/generatorSchema.schema.js
+++ b/tests/schemas/api_v3/generatorSchema.schema.js
@@ -19,7 +19,7 @@ import regex from './regex';
 const getCurrentTimestamp = () => Math.floor(Date.now() / 1000);
 
 const generatorSchema = {
-	address: Joi.string().pattern(regex.ADDRESS).required(),
+	address: Joi.string().pattern(regex.ADDRESS_BASE32).required(),
 	name: Joi.string().pattern(regex.NAME).optional(),
 	nextForgingTime: Joi.number().integer().min(getCurrentTimestamp()).optional(),
 };

--- a/tests/schemas/api_v3/regex.js
+++ b/tests/schemas/api_v3/regex.js
@@ -20,6 +20,7 @@ const MODULE_COMMAND_ID = /^\b(?:[0-9]+:[0-9]+)\b$/;
 const MODULE_COMMAND_NAME = /^\b(?:[0-9a-zA-Z]+:[0-9a-zA-Z]+)\b$/;
 const SEMVER = /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/;
 const PUBLIC_KEY = /^([A-Fa-f0-9]{2}){32}$/;
+const NAME = /^[a-z0-9!@$&_.]{1,20}$/;
 
 module.exports = {
 	ADDRESS,
@@ -29,4 +30,5 @@ module.exports = {
 	MODULE_COMMAND_NAME,
 	PUBLIC_KEY,
 	SEMVER,
+	NAME,
 };

--- a/tests/schemas/api_v3/regex.js
+++ b/tests/schemas/api_v3/regex.js
@@ -13,7 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const ADDRESS = /^lsk[a-hjkm-z2-9]{38}$/;
+const ADDRESS_BASE32 = /^lsk[a-hjkm-z2-9]{38}$/;
 const IP = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 const HASH_SHA256 = /^\b([A-Fa-f0-9]){1,64}\b$/;
 const MODULE_COMMAND_ID = /^\b(?:[0-9]+:[0-9]+)\b$/;
@@ -23,7 +23,7 @@ const PUBLIC_KEY = /^([A-Fa-f0-9]{2}){32}$/;
 const NAME = /^[a-z0-9!@$&_.]{1,20}$/;
 
 module.exports = {
-	ADDRESS,
+	ADDRESS_BASE32,
 	IP,
 	HASH_SHA256,
 	MODULE_COMMAND_ID,


### PR DESCRIPTION
### What was the problem?
This PR resolves #1096 

### How was it solved?
- [x] The following endpoints are available:
  - [x] HTTP: GET /generators
  - [x] RPC: get.generators
- [x] Generators list is refreshed every new block and cached in-memory
- [x] Refreshed generators list is emit using ‘newGenerators’ event
- [x] Requests are served from the cache
- [x] Add Integration tests

### How was it tested?
Local