### PR TITLE
Add endpoint to fetch all blockchain apps - Closes #1110

### DIFF
--- a/services/blockchain-indexer/methods/dataService/blockchainApps.js
+++ b/services/blockchain-indexer/methods/dataService/blockchainApps.js
@@ -16,12 +16,25 @@
 
 const {
 	getBlockchainAppsStatistics,
-} = require('./controllers/blockchainAppsStatistics');
+	getBlockchainApps,
+} = require('./controllers/blockchainApps');
 
 module.exports = [
 	{
 		name: 'blockchain.apps.statistics',
 		controller: getBlockchainAppsStatistics,
 		params: {},
+	},
+	{
+		name: 'blockchain.apps',
+		controller: getBlockchainApps,
+		params: {
+			chainID: { optional: true, type: 'string' },
+			name: { optional: true, type: 'string' },
+			state: { optional: true, type: 'string' },
+			search: { optional: true, type: 'string' },
+			limit: { optional: true, type: 'number' },
+			offset: { optional: true, type: 'number' },
+		},
 	},
 ];

--- a/services/blockchain-indexer/methods/dataService/controllers/blockchainApps.js
+++ b/services/blockchain-indexer/methods/dataService/controllers/blockchainApps.js
@@ -20,6 +20,12 @@ const getBlockchainAppsStatistics = async () => {
 	return result;
 };
 
+const getBlockchainApps = async () => {
+	const result = await dataService.getBlockchainApps();
+	return result;
+};
+
 module.exports = {
 	getBlockchainAppsStatistics,
+	getBlockchainApps,
 };

--- a/services/blockchain-indexer/shared/dataService/blockchainApps.js
+++ b/services/blockchain-indexer/shared/dataService/blockchainApps.js
@@ -27,6 +27,30 @@ const getBlockchainAppsStatistics = async () => {
 	};
 };
 
+const getBlockchainApps = async () => {
+	// TODO: Replace it with the real implementation with the issue https://github.com/LiskHQ/lisk-service/issues/1111
+	const response = [{
+		name: 'test',
+		chainID: '2ba563cf98003d',
+		state: 'active',
+		address: 'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu',
+		lastCertificateHeight: '20',
+		lastUpdated: '1651756153',
+
+	}];
+
+	return {
+		data: response,
+		meta: {
+			count: 1,
+			offset: 0,
+			total: 150,
+
+		},
+	};
+};
+
 module.exports = {
 	getBlockchainAppsStatistics,
+	getBlockchainApps,
 };

--- a/services/blockchain-indexer/shared/dataService/index.js
+++ b/services/blockchain-indexer/shared/dataService/index.js
@@ -56,7 +56,10 @@ const {
 	performLastBlockUpdate,
 } = require('./blocks');
 
-const { getBlockchainAppsStatistics } = require('./blockchainAppsStatistics');
+const {
+	getBlockchainAppsStatistics,
+	getBlockchainApps,
+} = require('./blockchainApps');
 
 const {
 	reloadDelegateCache,
@@ -130,6 +133,7 @@ module.exports = {
 	getTotalNumberOfBlocks,
 	performLastBlockUpdate,
 	getBlockchainAppsStatistics,
+	getBlockchainApps,
 	reloadDelegateCache,
 	getTotalNumberOfDelegates,
 	getDelegates,

--- a/services/gateway/apis/http-version3/methods/blockchainApps.js
+++ b/services/gateway/apis/http-version3/methods/blockchainApps.js
@@ -1,0 +1,35 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const blockchainAppsSchemaSource = require('../../../sources/version3/blockchainAppsSchema');
+const envelope = require('../../../sources/version3/mappings/stdEnvelope');
+const regex = require('../../../shared/regex');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/blockchain/apps',
+	rpcMethod: 'get.blockchain.apps',
+	tags: ['Blockchain Applications'],
+	params: {
+		chainID: { optional: true, type: 'string', min: 1, max: 32 },
+		name: { optional: true, type: 'string', min: 1, max: 20, pattern: regex.NAME },
+		state: { optional: true, type: 'string', enum: ['registered', 'active', 'terminated', 'any'], default: 'any' },
+		search: { optional: true, type: 'string' },
+		limit: { optional: true, type: 'number', min: 1, max: 100, default: 10, pattern: regex.LIMIT },
+		offset: { optional: true, type: 'number', min: 0, default: 0, pattern: regex.OFFSET },
+	},
+	source: blockchainAppsSchemaSource,
+	envelope,
+};

--- a/services/gateway/sources/version3/blockchainAppsSchema.js
+++ b/services/gateway/sources/version3/blockchainAppsSchema.js
@@ -13,16 +13,26 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const PUBLIC_KEY = /^([A-Fa-f0-9]{2}){32}$/;
-const ADDRESS_BASE32 = /^lsk[a-hjkm-z2-9]{38}$/;
-const LIMIT = /^\b((?:[1-9][0-9]?)|100)\b$/;
-const OFFSET = /^\b([0-9][0-9]*)\b$/;
-const NAME = /^[a-z0-9!@$&_.]{1,20}$/;
+const blockchainApp = require('./mappings/blockchainApp');
 
 module.exports = {
-	PUBLIC_KEY,
-	ADDRESS_BASE32,
-	LIMIT,
-	OFFSET,
-	NAME,
+	type: 'moleculer',
+	method: 'indexer.blockchain.apps',
+	params: {
+		chainID: '=,string',
+		name: '=,string',
+		search: '=,string',
+		state: '=,string',
+		offset: '=,number',
+		limit: '=,number',
+	},
+	definition: {
+		data: ['data', blockchainApp],
+		meta: {
+			count: '=,number',
+			offset: '=,number',
+			total: '=,number',
+		},
+		links: {},
+	},
 };

--- a/services/gateway/sources/version3/mappings/blockchainApp.js
+++ b/services/gateway/sources/version3/mappings/blockchainApp.js
@@ -13,16 +13,11 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const PUBLIC_KEY = /^([A-Fa-f0-9]{2}){32}$/;
-const ADDRESS_BASE32 = /^lsk[a-hjkm-z2-9]{38}$/;
-const LIMIT = /^\b((?:[1-9][0-9]?)|100)\b$/;
-const OFFSET = /^\b([0-9][0-9]*)\b$/;
-const NAME = /^[a-z0-9!@$&_.]{1,20}$/;
-
 module.exports = {
-	PUBLIC_KEY,
-	ADDRESS_BASE32,
-	LIMIT,
-	OFFSET,
-	NAME,
+	name: '=,string',
+	chainID: '=,string',
+	state: '=,string',
+	address: '=,string',
+	lastCertificateHeight: '=,string',
+	lastUpdated: '=,string',
 };

--- a/tests/integration/api_v3/http/blockchainApps.test.js
+++ b/tests/integration/api_v3/http/blockchainApps.test.js
@@ -1,0 +1,100 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+const { api } = require('../../../helpers/api');
+
+const {
+	badRequestSchema,
+	goodRequestSchema,
+	metaSchema,
+} = require('../../../schemas/httpGenerics.schema');
+
+const {
+	blockchainAppSchema,
+} = require('../../../schemas/api_v3/blockchainAppsSchema.schema');
+
+const baseUrl = config.SERVICE_ENDPOINT;
+const baseUrlV3 = `${baseUrl}/api/v3`;
+const endpoint = `${baseUrlV3}/blockchain/apps`;
+
+describe('Blockchain apps API', () => {
+	it('retrieves list of all blockchain applications', async () => {
+		const response = await api.get(endpoint);
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toBeInstanceOf(Array);
+		expect(response.data.length).toBeGreaterThanOrEqual(1);
+		expect(response.data.length).toBeLessThanOrEqual(10);
+		response.data.map(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	it('retrieves list of all blockchain applications with limit=10', async () => {
+		const response = await api.get(`${endpoint}?limit=10`);
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toBeInstanceOf(Array);
+		expect(response.data.length).toBeGreaterThanOrEqual(1);
+		expect(response.data.length).toBeLessThanOrEqual(10);
+		response.data.map(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	it('retrieves list of all blockchain applications with limit=10 and offset=1', async () => {
+		const response = await api.get(`${endpoint}?limit=10&offset=1`);
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toBeInstanceOf(Array);
+		expect(response.data.length).toBeGreaterThanOrEqual(1);
+		expect(response.data.length).toBeLessThanOrEqual(10);
+		response.data.map(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	// TODO: Update test case once implementation for indexing blockchain apps is done
+	xit('retrieves blockchain application by chainID', async () => {
+		const response = await api.get(`${endpoint}?chainID=`);
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toBeInstanceOf(Array);
+		expect(response.data.length).toEqual(1);
+		response.data.map(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	// TODO: Update test case once implementation for indexing blockchain apps is done
+	xit('retrieves blockchain applications by status', async () => {
+		const response = await api.get(`${endpoint}?status=active`);
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toBeInstanceOf(Array);
+		expect(response.data.length).toBeGreaterThanOrEqual(1);
+		expect(response.data.length).toBeLessThanOrEqual(10);
+		response.data.map(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	// TODO: Update test case once implementation for indexing blockchain apps is done
+	xit('retrieves blockchain applications by partial search', async () => {
+		const response = await api.get(`${endpoint}?search=`);
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toBeInstanceOf(Array);
+		expect(response.data.length).toBeGreaterThanOrEqual(1);
+		expect(response.data.length).toBeLessThanOrEqual(10);
+		response.data.map(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	it('invalid request param -> bad request', async () => {
+		const response = await api.get(`${endpoint}?invalidParam=invalid`, 400);
+		expect(response).toMap(badRequestSchema);
+	});
+});

--- a/tests/integration/api_v3/http/blockchainAppsStatistics.test.js
+++ b/tests/integration/api_v3/http/blockchainAppsStatistics.test.js
@@ -23,7 +23,7 @@ const {
 const {
 	blockchainAppsStatsSchema,
 	goodRequestSchema,
-} = require('../../../schemas/api_v3/blockchainAppsStatsSchema.schema');
+} = require('../../../schemas/api_v3/blockchainAppsSchema.schema');
 
 const baseUrl = config.SERVICE_ENDPOINT;
 const baseUrlV3 = `${baseUrl}/api/v3`;

--- a/tests/integration/api_v3/rpc/blockchainApps.test.js
+++ b/tests/integration/api_v3/rpc/blockchainApps.test.js
@@ -1,0 +1,108 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+
+const {
+	request,
+} = require('../../../helpers/socketIoRpcRequest');
+
+const {
+	invalidParamsSchema,
+	jsonRpcEnvelopeSchema,
+	metaSchema,
+} = require('../../../schemas/rpcGenerics.schema');
+
+const {
+	blockchainAppSchema,
+} = require('../../../schemas/api_v3/blockchainAppsSchema.schema');
+
+const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
+const getBlockchainApps = async (params) => request(wsRpcUrl, 'get.blockchain.apps', params);
+
+describe('get.blockchain.apps', () => {
+	it('returns list of all blockchain applications', async () => {
+		const response = await getBlockchainApps();
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data).toBeInstanceOf(Array);
+		expect(result.data.length).toBeGreaterThanOrEqual(1);
+		expect(result.data.length).toBeLessThanOrEqual(10);
+		result.data.forEach(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	it('returns list of all blockchain applications with limit=10', async () => {
+		const response = await getBlockchainApps({ limit: 10 });
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data).toBeInstanceOf(Array);
+		expect(result.data.length).toBeGreaterThanOrEqual(1);
+		expect(result.data.length).toBeLessThanOrEqual(10);
+		result.data.forEach(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	it('returns list of all blockchain applications with limit=10 and offset=1', async () => {
+		const response = await getBlockchainApps({ limit: 10, offset: 1 });
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data).toBeInstanceOf(Array);
+		expect(result.data.length).toBeGreaterThanOrEqual(1);
+		expect(result.data.length).toBeLessThanOrEqual(10);
+		result.data.forEach(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	// TODO: Update test case once implementation for indexing blockchain apps is done
+	xit('returns list of all blockchain applications by chainID', async () => {
+		const response = await getBlockchainApps({ chainID: '' });
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data).toBeInstanceOf(Array);
+		expect(result.data.length).toEqual(1);
+		result.data.forEach(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	// TODO: Update test case once implementation for indexing blockchain apps is done
+	xit('returns list of all blockchain applications by state', async () => {
+		const response = await getBlockchainApps({ state: 'active' });
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data).toBeInstanceOf(Array);
+		expect(result.data.length).toBeGreaterThanOrEqual(1);
+		expect(result.data.length).toBeLessThanOrEqual(10);
+		result.data.forEach(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	// TODO: Update test case once implementation for indexing blockchain apps is done
+	xit('returns list of all blockchain applications by partial search', async () => {
+		const response = await getBlockchainApps({ search: '' });
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data).toBeInstanceOf(Array);
+		expect(result.data.length).toBeGreaterThanOrEqual(1);
+		expect(result.data.length).toBeLessThanOrEqual(10);
+		result.data.forEach(blockchainApp => expect(blockchainApp).toMap(blockchainAppSchema));
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	it('invalid request param -> invalid param', async () => {
+		const response = await getBlockchainApps({ invalidParam: 'invalid' });
+		expect(response).toMap(invalidParamsSchema);
+	});
+});

--- a/tests/integration/api_v3/rpc/blockchainAppsStatistics.test.js
+++ b/tests/integration/api_v3/rpc/blockchainAppsStatistics.test.js
@@ -26,7 +26,7 @@ const {
 const {
 	blockchainAppsStatsSchema,
 	goodRequestSchema,
-} = require('../../../schemas/api_v3/blockchainAppsStatsSchema.schema');
+} = require('../../../schemas/api_v3/blockchainAppsSchema.schema');
 
 const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
 const getBlockchainAppsStatistics = async (params) => request(wsRpcUrl, 'get.blockchain.apps.statistics', params);

--- a/tests/schemas/api_v3/blockchainAppsSchema.schema.js
+++ b/tests/schemas/api_v3/blockchainAppsSchema.schema.js
@@ -14,6 +14,9 @@
  *
  */
 import Joi from 'joi';
+import regex from './regex';
+
+const validStatuses = ['registered', 'active', 'terminated', 'any'];
 
 const goodRequestSchema = {
 	data: Joi.object().required(),
@@ -27,7 +30,17 @@ const blockchainAppsStatsSchema = {
 	terminated: Joi.number().integer().min(0).required(),
 };
 
+const blockchainAppSchema = {
+	name: Joi.string().pattern(regex.NAME).required(),
+	chainID: Joi.string().required(),
+	state: Joi.string().valid(...validStatuses).required(),
+	address: Joi.string().pattern(regex.ADDRESS_BASE32).required(),
+	lastCertificateHeight: Joi.string().required(),
+	lastUpdated: Joi.string().required(),
+};
+
 module.exports = {
 	blockchainAppsStatsSchema: Joi.object(blockchainAppsStatsSchema).required(),
+	blockchainAppSchema: Joi.object(blockchainAppSchema).required(),
 	goodRequestSchema: Joi.object(goodRequestSchema).required(),
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #1110 

### How was it solved?
- [ ] The following endpoints are available:
  - [ ] HTTP: GET /blockchain/apps
  - [ ] RPC: get.blockchain.apps
- [ ] Users are able to filter the applications based on the query params
- [ ] Add placeholder for real implementation
- [ ] Add Integration tests

### How was it tested?
Local