### PR TITLE
Update endpoint for market prices - Closes #1117 #1118

### DIFF
--- a/services/gateway/apis/http-version3/methods/market.js
+++ b/services/gateway/apis/http-version3/methods/market.js
@@ -1,0 +1,27 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const marketPricesSource = require('../../../sources/version3/marketPrices');
+const envelope = require('../../../sources/version3/mappings/stdEnvelope');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/market/prices',
+	rpcMethod: 'get.market.prices',
+	tags: ['Market'],
+	params: {},
+	source: marketPricesSource,
+	envelope,
+};

--- a/services/gateway/apis/http-version3/methods/newsfeed.js
+++ b/services/gateway/apis/http-version3/methods/newsfeed.js
@@ -1,0 +1,32 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const newsfeedSource = require('../../../sources/version3/newsfeed');
+const envelope = require('../../../sources/version3/mappings/stdEnvelope');
+const regex = require('../../../shared/regex');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/newsfeed',
+	rpcMethod: 'get.newsfeed',
+	tags: ['Newsfeed'],
+	params: {
+		source: { optional: true, type: 'string', min: 1, pattern: regex.NEWSFEED_SOURCE },
+		limit: { optional: true, type: 'number', min: 1, max: 100, default: 10 },
+		offset: { optional: true, type: 'number', min: 0, default: 0 },
+	},
+	source: newsfeedSource,
+	envelope,
+};

--- a/services/gateway/shared/regex.js
+++ b/services/gateway/shared/regex.js
@@ -19,6 +19,7 @@ const NONCE = /^[0-9]+$/;
 const TIMESTAMP = /([0-9]+|[0-9]+:[0-9]+)/;
 const NAME = /^[a-z0-9!@$&_.]{1,20}$/;
 const TRANSACTION_EXECUTION_STATUS = /^(?:\b(?:pending|succeeded|failed|any)\b|\b(?:pending|succeeded|failed|any|,){3,}\b){1}$/;
+const NEWSFEED_SOURCE = /^\b(?:(?:drupal_lisk(?:_general|_announcements)|twitter_lisk),?)+\b$/;
 
 module.exports = {
 	PUBLIC_KEY,
@@ -27,4 +28,5 @@ module.exports = {
 	TIMESTAMP,
 	NAME,
 	TRANSACTION_EXECUTION_STATUS,
+	NEWSFEED_SOURCE,
 };

--- a/services/gateway/sources/version3/mappings/marketPrice.js
+++ b/services/gateway/sources/version3/mappings/marketPrice.js
@@ -1,0 +1,23 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+module.exports = {
+	code: '=,string',
+	from: '=,string',
+	rate: '=,string',
+	to: '=,string',
+	updateTimestamp: '=,number',
+	sources: '=',
+};

--- a/services/gateway/sources/version3/mappings/newsfeed.js
+++ b/services/gateway/sources/version3/mappings/newsfeed.js
@@ -1,0 +1,28 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+module.exports = {
+	author: '=,string',
+	content: 'content_t,string',
+	image_url: '=,string',
+	imageUrl: 'image_url,string',
+	source: '=,string',
+	sourceId: 'source_id,string',
+	timestamp: 'modified_at,number',
+	createdAt: 'created_at,number',
+	modifiedAt: 'modified_at,number',
+	title: '=,string',
+	url: '=,string',
+};

--- a/services/gateway/sources/version3/marketPrices.js
+++ b/services/gateway/sources/version3/marketPrices.js
@@ -1,0 +1,29 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const marketPrice = require('./mappings/marketPrice');
+
+module.exports = {
+	type: 'moleculer',
+	method: 'market.prices',
+	params: {},
+	definition: {
+		data: ['data', marketPrice],
+		meta: {
+			count: '=,number',
+		},
+		links: {},
+	},
+};

--- a/services/gateway/sources/version3/newsfeed.js
+++ b/services/gateway/sources/version3/newsfeed.js
@@ -1,0 +1,35 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const newsfeed = require('./mappings/newsfeed');
+
+module.exports = {
+	type: 'moleculer',
+	method: 'newsfeed.articles',
+	params: {
+		source: '=,string',
+		offset: '=,number',
+		limit: '=,number',
+	},
+	definition: {
+		data: ['data', newsfeed],
+		meta: {
+			count: '=,number',
+			limit: '=,number',
+			offset: '=,number',
+		},
+		links: {},
+	},
+};

--- a/services/newsfeed/jobs/twitter.js
+++ b/services/newsfeed/jobs/twitter.js
@@ -13,6 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+const util = require('util');
 const { Logger, MySQL: { getTableInstance } } = require('lisk-service-framework');
 
 const { normalizeData } = require('../shared/normalizers');
@@ -32,12 +33,18 @@ const getNewsFeedIndex = () => getTableInstance(
 );
 
 const refreshTwitterData = async () => {
-	logger.debug('Updating Twitter data...');
-	const newsfeedDB = await getNewsFeedIndex();
+	try {
+		logger.debug('Updating Twitter data...');
+		const newsfeedDB = await getNewsFeedIndex();
 
-	const response = await getData();
-	const normalizedData = normalizeData(config.sources.twitter_lisk, response);
-	await newsfeedDB.upsert(normalizedData);
+		const response = await getData();
+		const normalizedData = normalizeData(config.sources.twitter_lisk, response);
+		await newsfeedDB.upsert(normalizedData);
+	} catch (error) {
+		let errorMsg = error.message;
+		if (Array.isArray(error)) errorMsg = error.map(e => e.message).join('\n');
+		logger.error(`Unable to retrieve data from Twitter: ${errorMsg}`);
+	}
 };
 
 module.exports = [

--- a/tests/integration/api_v3/http/market.test.js
+++ b/tests/integration/api_v3/http/market.test.js
@@ -1,0 +1,57 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+const { api } = require('../../../helpers/api');
+
+const {
+	goodRequestSchema,
+	badRequestSchema,
+	metaSchema,
+	serviceUnavailableSchema,
+} = require('../../../schemas/httpGenerics.schema');
+
+const {
+	marketPriceSchema,
+} = require('../../../schemas/api_v3/marketPrice.schema');
+
+const baseUrl = config.SERVICE_ENDPOINT;
+const baseUrlV3 = `${baseUrl}/api/v3`;
+const endpoint = `${baseUrlV3}/market/prices`;
+
+describe('Market API', () => {
+	describe('Retrieve prices', () => {
+		it('returns market prices or 503 SERVICE UNAVAILABLE', async () => {
+			try {
+				const response = await api.get(`${endpoint}`);
+				expect(response).toMap(goodRequestSchema);
+				expect(response.data).toBeInstanceOf(Array);
+				expect(response.data.length).toBeGreaterThanOrEqual(1);
+				response.data.forEach(account => expect(account).toMap(marketPriceSchema));
+				expect(response.meta).toMap(metaSchema);
+			} catch (_) {
+				const expectedResponseCode = 503;
+				const response = await api.get(`${endpoint}`, expectedResponseCode);
+				expect(response).toMap(serviceUnavailableSchema);
+			}
+		});
+
+		it('returns 400 BAD REQUEST with params', async () => {
+			const expectedResponseCode = 400;
+			const response = await api.get(`${endpoint}?limit=10`, expectedResponseCode);
+			expect(response).toMap(badRequestSchema);
+		});
+	});
+});

--- a/tests/integration/api_v3/http/newsfeed.test.js
+++ b/tests/integration/api_v3/http/newsfeed.test.js
@@ -1,0 +1,146 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+const { api } = require('../../../helpers/api');
+
+const {
+	goodRequestSchema,
+	badRequestSchema,
+	serviceUnavailableSchema,
+} = require('../../../schemas/httpGenerics.schema');
+
+const {
+	newsfeedSchema,
+	newsfeedMetaSchema,
+} = require('../../../schemas/api_v3/newsfeed.schema');
+
+const baseUrl = config.SERVICE_ENDPOINT;
+const baseUrlV3 = `${baseUrl}/api/v3`;
+const endpoint = `${baseUrlV3}/newsfeed`;
+
+describe('Newsfeed API', () => {
+	describe('Retrieve news/blog posts', () => {
+		it('returns news or 503 SERVICE UNAVAILABLE', async () => {
+			try {
+				const response = await api.get(`${endpoint}`);
+				expect(response).toMap(goodRequestSchema);
+				expect(response.data).toBeInstanceOf(Array);
+				expect(response.data.length).toBeGreaterThanOrEqual(1);
+				expect(response.data.length).toBeLessThanOrEqual(10);
+				response.data.forEach(news => expect(news).toMap(newsfeedSchema));
+				expect(response.meta).toMap(newsfeedMetaSchema);
+			} catch (err) {
+				const expectedResponseCode = 503;
+				const response = await api.get(`${endpoint}`, expectedResponseCode);
+				expect(response).toMap(serviceUnavailableSchema);
+			}
+		});
+
+		it('retrieve news by param: drupal_lisk_general', async () => {
+			const response = await api.get(`${endpoint}?source=drupal_lisk_general`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(news => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toEqual('drupal_lisk_general');
+			});
+			expect(response.meta).toMap(newsfeedMetaSchema);
+		});
+
+		xit('retrieve news by param: twitter_lisk', async () => {
+			const response = await api.get(`${endpoint}?source=twitter_lisk`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(news => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toEqual('twitter_lisk');
+			});
+			expect(response.meta).toMap(newsfeedMetaSchema);
+		});
+
+		it('retrieve news by multiple params', async () => {
+			const response = await api.get(`${endpoint}?source=drupal_lisk_general,drupal_lisk_announcements`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach(news => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toMatch(/^\b(?:(?:drupal_lisk(?:_general|_announcements)|),?)+\b$/);
+			});
+			expect(response.meta).toMap(newsfeedMetaSchema);
+		});
+
+		it('retrieve news with limit & offset', async () => {
+			const limit = 5;
+			const offset = 1;
+			const response = await api.get(`${endpoint}?source=drupal_lisk_general&limit=${limit}&offset=${offset}`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(limit);
+			response.data.forEach(news => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toEqual('drupal_lisk_general');
+			});
+			expect(response.meta).toMap(newsfeedMetaSchema);
+			expect(response.meta.offset).toEqual(offset);
+		});
+
+		it('retrieve news by multiple params with limit & offset', async () => {
+			const limit = 5;
+			const offset = 1;
+			const response = await api.get(`${endpoint}?source=drupal_lisk_general,drupal_lisk_announcements&limit=${limit}&offset=${offset}`);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(limit);
+			response.data.forEach(news => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toMatch(/^\bdrupal_lisk(?:_general|_announcements)\b$/);
+			});
+			expect(response.meta).toMap(newsfeedMetaSchema);
+			expect(response.meta.offset).toEqual(offset);
+		});
+
+		it('ensure retrieved news is in reverse chronology', async () => {
+			const response = await api.get(endpoint);
+			expect(response).toMap(goodRequestSchema);
+			expect(response.data).toBeInstanceOf(Array);
+			expect(response.data.length).toBeGreaterThanOrEqual(1);
+			expect(response.data.length).toBeLessThanOrEqual(10);
+			response.data.forEach((news, index) => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toMatch(/^\b(?:(?:drupal_lisk(?:_general|_announcements)|twitter_lisk),?)+\b$/);
+				if (index) {
+					const prevNews = response.data[index - 1];
+					expect(prevNews.createdAt).toBeGreaterThanOrEqual(news.createdAt);
+				}
+			});
+			expect(response.meta).toMap(newsfeedMetaSchema);
+		});
+
+		it('returns 400 BAD REQUEST with invalid params', async () => {
+			const expectedResponseCode = 400;
+			const response = await api.get(`${endpoint}?invalidParam=4584a7d2db15920e130eeaf1014f87c99b5af329`, expectedResponseCode);
+			expect(response).toMap(badRequestSchema);
+		});
+	});
+});

--- a/tests/integration/api_v3/rpc/market.test.js
+++ b/tests/integration/api_v3/rpc/market.test.js
@@ -1,0 +1,56 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+const { request } = require('../../../helpers/socketIoRpcRequest');
+
+const {
+	invalidParamsSchema,
+	jsonRpcEnvelopeSchema,
+	metaSchema,
+	serviceUnavailableSchema,
+} = require('../../../schemas/rpcGenerics.schema');
+
+const {
+	marketPriceSchema,
+} = require('../../../schemas/api_v3/marketPrice.schema');
+
+const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
+const getMarketPrices = async params => request(wsRpcUrl, 'get.market.prices', params);
+
+describe('Method get.market.prices', () => {
+	describe('is able to retrieve market prices', () => {
+		it('returns market prices with no params', async () => {
+			try {
+				const response = await getMarketPrices({});
+				expect(response).toMap(jsonRpcEnvelopeSchema);
+				const { result } = response;
+				expect(result.data).toBeInstanceOf(Array);
+				expect(result.data.length).toBeGreaterThanOrEqual(1);
+				expect(result.data.length).toBeLessThanOrEqual(10);
+				result.data.forEach(account => expect(account).toMap(marketPriceSchema));
+				expect(result.meta).toMap(metaSchema);
+			} catch (_) {
+				const response = await getMarketPrices({}).catch(e => e);
+				expect(response).toMap(serviceUnavailableSchema);
+			}
+		});
+
+		it('returns invalid params with params', async () => {
+			const response = await getMarketPrices({ limit: 10 });
+			expect(response).toMap(invalidParamsSchema);
+		});
+	});
+});

--- a/tests/integration/api_v3/rpc/newsfeed.test.js
+++ b/tests/integration/api_v3/rpc/newsfeed.test.js
@@ -1,0 +1,158 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+const { request } = require('../../../helpers/socketIoRpcRequest');
+
+const {
+	invalidParamsSchema,
+	jsonRpcEnvelopeSchema,
+	serviceUnavailableSchema,
+} = require('../../../schemas/rpcGenerics.schema');
+
+const {
+	newsfeedSchema,
+	newsfeedMetaSchema,
+} = require('../../../schemas/api_v3/newsfeed.schema');
+
+const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
+const getNewsfeed = async params => request(wsRpcUrl, 'get.newsfeed', params);
+
+describe('Method get.newsfeed.articles', () => {
+	describe('is able to retrieve news/blog posts', () => {
+		it('returns news', async () => {
+			try {
+				const response = await getNewsfeed({});
+				expect(response).toMap(jsonRpcEnvelopeSchema);
+				const { result } = response;
+				expect(result.data).toBeInstanceOf(Array);
+				expect(result.data.length).toBeGreaterThanOrEqual(1);
+				expect(result.data.length).toBeLessThanOrEqual(10);
+				result.data.forEach(news => expect(news).toMap(newsfeedSchema));
+				expect(result.meta).toMap(newsfeedMetaSchema);
+			} catch (_) {
+				const response = await getNewsfeed({}).catch(e => e);
+				expect(response).toMap(serviceUnavailableSchema);
+			}
+		});
+
+		it('retrieve news by param: drupal_lisk_general', async () => {
+			const response = await getNewsfeed({ source: 'drupal_lisk_general' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(news => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toEqual('drupal_lisk_general');
+			});
+			expect(result.meta).toMap(newsfeedMetaSchema);
+		});
+
+		xit('retrieve news by param: twitter_lisk', async () => {
+			const response = await getNewsfeed({ source: 'twitter_lisk' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(news => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toEqual('twitter_lisk');
+			});
+			expect(result.meta).toMap(newsfeedMetaSchema);
+		});
+
+		it('retrieve news by multiple sources', async () => {
+			const response = await getNewsfeed({ source: 'drupal_lisk_general,drupal_lisk_announcements' });
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach(news => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toMatch(/^\bdrupal_lisk(?:_general|_announcements)\b$/);
+			});
+			expect(result.meta).toMap(newsfeedMetaSchema);
+		});
+
+		it('retrieve news with limit & offset', async () => {
+			const limit = 5;
+			const offset = 1;
+			const response = await getNewsfeed({
+				source: 'drupal_lisk_general',
+				limit,
+				offset,
+			});
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(limit);
+			result.data.forEach(news => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toEqual('drupal_lisk_general');
+			});
+			expect(result.meta).toMap(newsfeedMetaSchema);
+			expect(result.meta.offset).toEqual(offset);
+		});
+
+		it('retrieve news by multiple params with limit & offset', async () => {
+			const limit = 5;
+			const offset = 1;
+			const response = await getNewsfeed({
+				source: 'drupal_lisk_general,drupal_lisk_announcements',
+				limit,
+				offset,
+			});
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(limit);
+			result.data.forEach(news => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toMatch(/^\b(?:(?:drupal_lisk(?:_general|_announcements)|),?)+\b$/);
+			});
+			expect(result.meta).toMap(newsfeedMetaSchema);
+			expect(result.meta.offset).toEqual(offset);
+		});
+
+		it('ensure retrieved news is in reverse chronology', async () => {
+			const response = await getNewsfeed({});
+			expect(response).toMap(jsonRpcEnvelopeSchema);
+			const { result } = response;
+			expect(result.data).toBeInstanceOf(Array);
+			expect(result.data.length).toBeGreaterThanOrEqual(1);
+			expect(result.data.length).toBeLessThanOrEqual(10);
+			result.data.forEach((news, index) => {
+				expect(news).toMap(newsfeedSchema);
+				expect(news.source).toMatch(/^\b(?:(?:drupal_lisk(?:_general|_announcements)|twitter_lisk),?)+\b$/);
+				if (index) {
+					const prevNews = result.data[index - 1];
+					expect(prevNews.createdAt).toBeGreaterThanOrEqual(news.createdAt);
+				}
+			});
+			expect(result.meta).toMap(newsfeedMetaSchema);
+		});
+
+		it('error when invalid params', async () => {
+			const response = await getNewsfeed({ invalidParam: '4584a7d2db15920e130eeaf1014f87c99b5af329' });
+			expect(response).toMap(invalidParamsSchema);
+		});
+	});
+});

--- a/tests/schemas/api_v3/marketPrice.schema.js
+++ b/tests/schemas/api_v3/marketPrice.schema.js
@@ -1,0 +1,29 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import Joi from 'joi';
+
+const marketPriceSchema = {
+	code: Joi.string().required(),
+	from: Joi.string().required(),
+	rate: Joi.string().required(),
+	to: Joi.string().required(),
+	updateTimestamp: Joi.number().integer().positive().required(),
+	sources: Joi.array().items(Joi.string().required()).required(),
+};
+
+module.exports = {
+	marketPriceSchema: Joi.object(marketPriceSchema).required(),
+};

--- a/tests/schemas/api_v3/newsfeed.schema.js
+++ b/tests/schemas/api_v3/newsfeed.schema.js
@@ -1,0 +1,41 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import Joi from 'joi';
+
+const newsfeedArticleSchema = {
+	author: Joi.string().required(),
+	content: Joi.string().required(),
+	imageUrl: Joi.string().allow(null).required(),
+	image_url: Joi.string().allow(null).required(),
+	source: Joi.string().pattern(/^\b[a-z]+(?:_[a-z]+){1,2}\b$/).required(),
+	sourceId: Joi.string().required(),
+	timestamp: Joi.number().integer().positive().required(),
+	createdAt: Joi.number().integer().positive().required(),
+	modifiedAt: Joi.number().integer().positive().required(),
+	title: Joi.string().allow('', null).required(),
+	url: Joi.string().required(),
+};
+
+const newsfeedMetaSchema = {
+	count: Joi.number().required(),
+	limit: Joi.number().required(),
+	offset: Joi.number().required(),
+};
+
+module.exports = {
+	newsfeedSchema: Joi.object(newsfeedArticleSchema).required(),
+	newsfeedMetaSchema: Joi.object(newsfeedMetaSchema).required(),
+};

--- a/tests/schemas/api_v3/regex.js
+++ b/tests/schemas/api_v3/regex.js
@@ -21,6 +21,7 @@ const MODULE_COMMAND_NAME = /^\b(?:[0-9a-zA-Z]+:[0-9a-zA-Z]+)\b$/;
 const SEMVER = /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/;
 const PUBLIC_KEY = /^([A-Fa-f0-9]{2}){32}$/;
 const NAME = /^[a-z0-9!@$&_.]{1,20}$/;
+const NEWSFEED_SOURCE = /^\b(?:(?:drupal_lisk(?:_general|_announcements)|twitter_lisk),?)+\b$/;
 
 module.exports = {
 	ADDRESS_BASE32,
@@ -31,4 +32,5 @@ module.exports = {
 	PUBLIC_KEY,
 	SEMVER,
 	NAME,
+	NEWSFEED_SOURCE,
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #1117 #1118 

### How was it solved?
- [ ] The following endpoints are available:
  - [ ] HTTP: GET /newsfeed
  - [ ] RPC: get.newsfeed
  - [ ] HTTP: GET /market/prices
  - [ ] RPC: get.market.prices
- [ ] Users are able to filter the news based on the specified query params
- [ ] Fix issue with Twitter API
- [ ] Add Integration tests:
  - [ ] newsfeed API
  - [ ] Market API
  
### How was it tested?
Local