### PR TITLE
Compute blockchain app stats - Closes #1113

### DIFF
--- a/services/blockchain-connector/config.js
+++ b/services/blockchain-connector/config.js
@@ -53,6 +53,11 @@ config.networks = [
 		identifier: '15f0dacc1060e91818224a94286b13aa04279c640bd5d6f193182031d133df7c',
 		genesisBlockUrl: 'https://downloads.lisk.com/lisk/testnet/genesis_block.json.tar.gz',
 	},
+	{
+		name: 'betanet',
+		identifier: '15f0dacc1060e91818224a94286b13aa04279c640bd5d6f193182031d133df7c',
+		genesisBlockUrl: 'https://downloads.lisk.com/lisk/betanet/genesis_block.json.tar.gz',
+	},
 ];
 
 /**

--- a/services/blockchain-indexer/config.js
+++ b/services/blockchain-indexer/config.js
@@ -75,4 +75,28 @@ config.operations = {
 	isIndexingModeEnabled: Boolean(String(process.env.ENABLE_INDEXING_MODE).toLowerCase() !== 'false'), // Enabled by default
 };
 
+config.networks = [
+	{
+		name: 'mainnet',
+		address: '',
+		serviceURL: 'https://service.lisk.com',
+		identifier: '4c09e6a781fc4c7bdb936ee815de8f94190f8a7519becd9de2081832be309a99',
+		genesisBlockUrl: 'https://downloads.lisk.com/lisk/mainnet/genesis_block.json.tar.gz',
+	},
+	{
+		name: 'testnet',
+		address: '',
+		serviceURL: 'https://testnet-service.lisk.com',
+		identifier: '15f0dacc1060e91818224a94286b13aa04279c640bd5d6f193182031d133df7c',
+		genesisBlockUrl: 'https://downloads.lisk.com/lisk/testnet/genesis_block.json.tar.gz',
+	},
+	{
+		name: 'betanet',
+		address: '',
+		serviceURL: 'https://betanet-service.lisk.com',
+		identifier: '15f0dacc1060e91818224a94286b13aa04279c640bd5d6f193182031d133df7c',
+		genesisBlockUrl: 'https://downloads.lisk.com/lisk/betanet/genesis_block.json.tar.gz',
+	},
+];
+
 module.exports = config;

--- a/services/blockchain-indexer/jobs/dataService/blockchainAppsStats.js
+++ b/services/blockchain-indexer/jobs/dataService/blockchainAppsStats.js
@@ -17,7 +17,7 @@ const logger = require('lisk-service-framework').Logger();
 
 const {
 	reloadBlockchainAppsStats,
-} = require('../../shared/dataService');
+} = require('../../shared/dataService/business');
 
 module.exports = [
 	{

--- a/services/blockchain-indexer/jobs/dataService/blockchainAppsStats.js
+++ b/services/blockchain-indexer/jobs/dataService/blockchainAppsStats.js
@@ -1,0 +1,45 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const logger = require('lisk-service-framework').Logger();
+
+const {
+	reloadBlockchainAppsStats,
+} = require('../../shared/dataService');
+
+module.exports = [
+	{
+		name: 'reload.blockchain.apps.statistics',
+		description: 'Keep the blockchain apps statistics up-to-date',
+		schedule: '*/15 * * * *', // Every 15 min
+		init: async () => {
+			logger.debug('Initializing blockchain apps statistics cache...');
+			try {
+				await reloadBlockchainAppsStats();
+				logger.info('Successfully initialized blockchain apps statistics cache');
+			} catch (err) {
+				logger.warn(`Initializing blockchain apps statistics cache failed due to: ${err.message}`);
+			}
+		},
+		controller: async () => {
+			logger.debug('Reloading blockchain apps statistics cache...');
+			try {
+				await reloadBlockchainAppsStats();
+			} catch (err) {
+				logger.warn(`Reloading blockchain apps statistics cachee failed due to: ${err.message}`);
+			}
+		},
+	},
+];

--- a/services/blockchain-indexer/jobs/dataService/blockchainAppsStats.js
+++ b/services/blockchain-indexer/jobs/dataService/blockchainAppsStats.js
@@ -17,7 +17,7 @@ const logger = require('lisk-service-framework').Logger();
 
 const {
 	reloadBlockchainAppsStats,
-} = require('../../shared/dataService/business');
+} = require('../../shared/dataService');
 
 module.exports = [
 	{

--- a/services/blockchain-indexer/methods/dataService/controllers/blockchainApps.js
+++ b/services/blockchain-indexer/methods/dataService/controllers/blockchainApps.js
@@ -14,27 +14,30 @@
  *
  */
 // TODO: Enable when available from SDK
+// const { HTTP } = require('lisk-service-framework');
 // const dataService = require('../../../shared/dataService');
 
-const getBlockchainAppsStatistics = async () => {
-	// const result = await dataService.getBlockchainAppsStatistics();
+// const isMainchain = async () => {
+// 	// TODO: Implement logic
+// };
 
-	const result = {
-		data: {
-			registered: 2503,
-			active: 2328,
-			terminated: 35,
-			totalSupplyLSK: '5000000',
-			stakedLSK: '3000000',
-			inflationRate: '4.50',
-		},
-	};
-
-	return result;
-};
+// const resolveServiceURL = async () => {
+// 	// TODO: Implement logic
+// }
 
 const getBlockchainApps = async (params) => {
-	// const result = await dataService.getBlockchainApps(params);
+	// if (await isMainchain()) {
+	// 	const result = await dataService.getBlockchainApps(params);
+	// } else {
+	// 	// Redirect call to the mainchain service
+	// 	const serviceURL = await resolveServiceURL();
+	// 	const blockchainAppsEndpoint = `${serviceURL}/api/v3/blockchain/apps`
+	// 	const response = HTTP.request(
+	// 		blockchainAppsEndpoint,
+	// 		params,
+	// 	)
+	// 	return response;
+	// }
 
 	const result = {
 		data: [{
@@ -55,7 +58,32 @@ const getBlockchainApps = async (params) => {
 	return result;
 };
 
+const getBlockchainAppsStatistics = async () => {
+	// if (await isMainchain()) {
+	// 	 const result = await dataService.getBlockchainAppsStatistics();
+	// } else {
+	// 	// Redirect call to the mainchain service
+	// 	const serviceURL = await resolveServiceURL();
+	// 	const blockchainAppsStatsEndpoint = `${serviceURL}/api/v3/blockchain/apps/statistics`
+	// 	const response = HTTP.get(blockchainAppsStatsEndpoint);
+	// 	return response;
+	// }
+
+	const result = {
+		data: {
+			registered: 2503,
+			active: 2328,
+			terminated: 35,
+			totalSupplyLSK: '5000000',
+			stakedLSK: '3000000',
+			inflationRate: '4.50',
+		},
+	};
+
+	return result;
+};
+
 module.exports = {
-	getBlockchainAppsStatistics,
 	getBlockchainApps,
+	getBlockchainAppsStatistics,
 };

--- a/services/blockchain-indexer/shared/dataService/business/index.js
+++ b/services/blockchain-indexer/shared/dataService/business/index.js
@@ -39,6 +39,7 @@ const {
 const {
 	getBlockchainApps,
 	getBlockchainAppsStatistics,
+	reloadBlockchainAppsStats,
 } = require('./interoperability');
 
 const {
@@ -106,6 +107,7 @@ module.exports = {
 	getBlocksAssets,
 	getBlockchainApps,
 	getBlockchainAppsStatistics,
+	reloadBlockchainAppsStats,
 	getDelegates,
 	getAllDelegates,
 	isDposModuleRegistered,

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainAppsStats.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainAppsStats.js
@@ -13,7 +13,12 @@
 * Removal or modification of this copyright notice is prohibited.
 *
 */
-const { MySQL: { getTableInstance } } = require('lisk-service-framework');
+const {
+	Logger,
+	MySQL: { getTableInstance },
+} = require('lisk-service-framework');
+
+const logger = Logger();
 
 const { APP_STATE } = require('./constants');
 const config = require('../../../../config');
@@ -24,30 +29,46 @@ const blockchainAppsIndexSchema = require('../../../database/schema/blockchainAp
 
 const getBlockchainAppsIndex = () => getTableInstance('blockchain_apps', blockchainAppsIndexSchema, MYSQL_ENDPOINT);
 
+let blockchainAppsStatsCache = {};
+
 const getBlockchainAppsStatistics = async () => {
-	// TODO: Update implementation once interoperability_getOwnChainAccount is available
-	const blockchainAppsDB = await getBlockchainAppsIndex();
-
-	const numActiveChains = await blockchainAppsDB.count({ state: APP_STATE.ACTIVE });
-	const numRegisteredChains = await blockchainAppsDB.count({ state: APP_STATE.REGISTERED });
-	const numTerminatedChains = await blockchainAppsDB.count({ state: APP_STATE.TERMINATED });
-
-	const response = {
-		registered: numRegisteredChains,
-		active: numActiveChains,
-		terminated: numTerminatedChains,
-		// TODO: Get these information directly from SDK once issue https://github.com/LiskHQ/lisk-sdk/issues/7225 is closed
-		totalSupplyLSK: '',
-		stakedLSK: '',
-		inflationRate: '',
-	};
-
-	return {
-		data: response,
+	const blockchainAppsStats = {
+		data: {},
 		meta: {},
 	};
+
+	blockchainAppsStats.data = blockchainAppsStatsCache;
+	return blockchainAppsStats;
+};
+
+const reloadBlockchainAppsStats = async () => {
+	try {
+		// TODO: Update implementation once interoperability_getOwnChainAccount is available
+		const blockchainAppsDB = await getBlockchainAppsIndex();
+
+		const numActiveChains = await blockchainAppsDB.count({ state: APP_STATE.ACTIVE });
+		const numRegisteredChains = await blockchainAppsDB.count({ state: APP_STATE.REGISTERED });
+		const numTerminatedChains = await blockchainAppsDB.count({ state: APP_STATE.TERMINATED });
+
+		logger.debug('Updating blockchain apps statistics cache');
+
+		blockchainAppsStatsCache = {
+			registered: numRegisteredChains,
+			active: numActiveChains,
+			terminated: numTerminatedChains,
+			// TODO: Get these information directly from SDK once issue https://github.com/LiskHQ/lisk-sdk/issues/7225 is closed
+			totalSupplyLSK: '',
+			stakedLSK: '',
+			inflationRate: '',
+		};
+
+		logger.info('Updated blockchain apps statistics cache');
+	} catch (err) {
+		logger.warn(`Failed to update blockchain apps statistics cache due to: ${err.message}`);
+	}
 };
 
 module.exports = {
 	getBlockchainAppsStatistics,
+	reloadBlockchainAppsStats,
 };

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/index.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/index.js
@@ -14,9 +14,10 @@
  *
  */
 const { getBlockchainApps } = require('./blockchainApps');
-const { getBlockchainAppsStatistics } = require('./blockchainAppsStats');
+const { getBlockchainAppsStatistics, reloadBlockchainAppsStats } = require('./blockchainAppsStats');
 
 module.exports = {
 	getBlockchainApps,
 	getBlockchainAppsStatistics,
+	reloadBlockchainAppsStats,
 };

--- a/services/blockchain-indexer/shared/dataService/index.js
+++ b/services/blockchain-indexer/shared/dataService/index.js
@@ -93,7 +93,6 @@ const {
 const {
 	getBlockchainApps,
 	getBlockchainAppsStatistics,
-	reloadBlockchainAppsStats,
 } = require('./interoperability');
 
 const { getEvents } = require('./events');
@@ -137,7 +136,6 @@ module.exports = {
 	getTotalNumberOfBlocks,
 	performLastBlockUpdate,
 	getBlockchainAppsStatistics,
-	reloadBlockchainAppsStats,
 	getBlockchainApps,
 	reloadDelegateCache,
 	getTotalNumberOfDelegates,

--- a/services/blockchain-indexer/shared/dataService/index.js
+++ b/services/blockchain-indexer/shared/dataService/index.js
@@ -93,6 +93,7 @@ const {
 const {
 	getBlockchainApps,
 	getBlockchainAppsStatistics,
+	reloadBlockchainAppsStats,
 } = require('./interoperability');
 
 const { getEvents } = require('./events');
@@ -136,6 +137,7 @@ module.exports = {
 	getTotalNumberOfBlocks,
 	performLastBlockUpdate,
 	getBlockchainAppsStatistics,
+	reloadBlockchainAppsStats,
 	getBlockchainApps,
 	reloadDelegateCache,
 	getTotalNumberOfDelegates,

--- a/services/blockchain-indexer/shared/dataService/interoperability/blockchainAppsStats.js
+++ b/services/blockchain-indexer/shared/dataService/interoperability/blockchainAppsStats.js
@@ -20,9 +20,6 @@ const getBlockchainAppsStatistics = async params => {
 	return response;
 };
 
-const reloadBlockchainAppsStats = async () => dataService.reloadBlockchainAppsStats();
-
 module.exports = {
 	getBlockchainAppsStatistics,
-	reloadBlockchainAppsStats,
 };

--- a/services/blockchain-indexer/shared/dataService/interoperability/blockchainAppsStats.js
+++ b/services/blockchain-indexer/shared/dataService/interoperability/blockchainAppsStats.js
@@ -20,6 +20,9 @@ const getBlockchainAppsStatistics = async params => {
 	return response;
 };
 
+const reloadBlockchainAppsStats = async () => dataService.reloadBlockchainAppsStats();
+
 module.exports = {
 	getBlockchainAppsStatistics,
+	reloadBlockchainAppsStats,
 };

--- a/services/blockchain-indexer/shared/dataService/interoperability/index.js
+++ b/services/blockchain-indexer/shared/dataService/interoperability/index.js
@@ -14,10 +14,9 @@
  *
  */
 const { getBlockchainApps } = require('./blockchainApps');
-const { getBlockchainAppsStatistics, reloadBlockchainAppsStats } = require('./blockchainAppsStats');
+const { getBlockchainAppsStatistics } = require('./blockchainAppsStats');
 
 module.exports = {
 	getBlockchainApps,
 	getBlockchainAppsStatistics,
-	reloadBlockchainAppsStats,
 };

--- a/services/blockchain-indexer/shared/dataService/interoperability/index.js
+++ b/services/blockchain-indexer/shared/dataService/interoperability/index.js
@@ -14,9 +14,10 @@
  *
  */
 const { getBlockchainApps } = require('./blockchainApps');
-const { getBlockchainAppsStatistics } = require('./blockchainAppsStats');
+const { getBlockchainAppsStatistics, reloadBlockchainAppsStats } = require('./blockchainAppsStats');
 
 module.exports = {
 	getBlockchainApps,
 	getBlockchainAppsStatistics,
+	reloadBlockchainAppsStats,
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #1113 

### How was it solved?
- [x] Lisk Service tracks the blocks for interoperability transactions and indexes the following information: (already handled in the issue #1111 )
  - [x] Additional state information of the current chain
  - [x] ChainID
  - [x] name
- [x] Add a job to compute the stats every 15 mins and cache the result in-memory
- [x] Proxy the information from the mainchain (Lisk Core) if Lisk Service is connected to any other chain

### How was it tested?
Local