### PR TITLE
Extend blockchain apps information - Closes #1181

### DIFF
--- a/services/blockchain-indexer/config.js
+++ b/services/blockchain-indexer/config.js
@@ -99,4 +99,9 @@ config.networks = [
 	},
 ];
 
+const DEFAULT_LISK_APPS = ['Lisk', 'Lisk DEX'];
+const DEFAULT_USER_APPS = String(process.env.DEFAULT_APPS).split(',');
+
+config.defaultApps = DEFAULT_LISK_APPS.concat(DEFAULT_USER_APPS);
+
 module.exports = config;

--- a/services/blockchain-indexer/methods/dataService/blockchainApps.js
+++ b/services/blockchain-indexer/methods/dataService/blockchainApps.js
@@ -29,7 +29,7 @@ module.exports = [
 		name: 'blockchain.apps',
 		controller: getBlockchainApps,
 		params: {
-			chainID: { optional: true, type: 'number' },
+			chainID: { optional: true, type: 'string' },
 			name: { optional: true, type: 'string' },
 			state: { optional: true, type: 'string' },
 			isDefault: { optional: true, type: 'boolean' },

--- a/services/blockchain-indexer/methods/dataService/blockchainApps.js
+++ b/services/blockchain-indexer/methods/dataService/blockchainApps.js
@@ -29,7 +29,7 @@ module.exports = [
 		name: 'blockchain.apps',
 		controller: getBlockchainApps,
 		params: {
-			chainID: { optional: true, type: 'string' },
+			chainID: { optional: true, type: 'number' },
 			name: { optional: true, type: 'string' },
 			state: { optional: true, type: 'string' },
 			isDefault: { optional: true, type: 'boolean' },

--- a/services/blockchain-indexer/methods/dataService/blockchainApps.js
+++ b/services/blockchain-indexer/methods/dataService/blockchainApps.js
@@ -32,6 +32,7 @@ module.exports = [
 			chainID: { optional: true, type: 'string' },
 			name: { optional: true, type: 'string' },
 			state: { optional: true, type: 'string' },
+			isDefault: { optional: true, type: 'boolean' },
 			search: { optional: true, type: 'string' },
 			limit: { optional: true, type: 'number' },
 			offset: { optional: true, type: 'number' },

--- a/services/blockchain-indexer/methods/dataService/controllers/blockchainApps.js
+++ b/services/blockchain-indexer/methods/dataService/controllers/blockchainApps.js
@@ -40,14 +40,25 @@ const getBlockchainApps = async (params) => {
 	// }
 
 	const result = {
-		data: [{
-			name: 'Test app',
-			chainID: 'aq02qkbb35u4jdq8szo3pnsq',
-			state: 'active',
-			address: 'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu',
-			lastCertificateHeight: 1000,
-			lastUpdated: 123456789,
-		}],
+		data: [
+			{
+				name: 'Lisk',
+				chainID: 'qw02kibb35u4jloaoezo3mnch',
+				state: 'active',
+				address: 'lsk123bhithjdq8szo3poyqe5dsxwrnazyqnzqhsy',
+				isDefault: true,
+				lastCertificateHeight: 900,
+				lastUpdated: 123456789,
+			},
+			{
+				name: 'Test app',
+				chainID: 'aq02qkbb35u4jdq8szo3pnsq',
+				state: 'active',
+				address: 'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu',
+				isDefault: false,
+				lastCertificateHeight: 1000,
+				lastUpdated: 123456789,
+			}],
 		meta: {
 			count: 10,
 			offset: params.offset,

--- a/services/blockchain-indexer/methods/dataService/controllers/blockchainApps.js
+++ b/services/blockchain-indexer/methods/dataService/controllers/blockchainApps.js
@@ -43,7 +43,7 @@ const getBlockchainApps = async (params) => {
 		data: [
 			{
 				name: 'Lisk',
-				chainID: 100,
+				chainID: 1,
 				state: 'active',
 				address: 'lsk123bhithjdq8szo3poyqe5dsxwrnazyqnzqhsy',
 				isDefault: true,

--- a/services/blockchain-indexer/methods/dataService/controllers/blockchainApps.js
+++ b/services/blockchain-indexer/methods/dataService/controllers/blockchainApps.js
@@ -43,7 +43,7 @@ const getBlockchainApps = async (params) => {
 		data: [
 			{
 				name: 'Lisk',
-				chainID: 'qw02kibb35u4jloaoezo3mnch',
+				chainID: 100,
 				state: 'active',
 				address: 'lsk123bhithjdq8szo3poyqe5dsxwrnazyqnzqhsy',
 				isDefault: true,
@@ -52,7 +52,7 @@ const getBlockchainApps = async (params) => {
 			},
 			{
 				name: 'Test app',
-				chainID: 'aq02qkbb35u4jdq8szo3pnsq',
+				chainID: 120,
 				state: 'active',
 				address: 'lsk24cd35u4jdq8szo3pnsqe5dsxwrnazyqqqg5eu',
 				isDefault: false,

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
@@ -53,19 +53,19 @@ const getBlockchainApps = async (params) => {
 
 	blockchainAppsInfo.data = await BluebirdPromise.map(
 		response,
-		async (entry) => {
-			if (!entry.isDefault) {
-				const isDefault = !!config.defaultApps.some(e => e.includes(entry.name));
+		async (appInfo) => {
+			if (!appInfo.isDefault) {
+				const isDefault = !!config.defaultApps.some(e => e.includes(appInfo.name));
 
 				const blockchainAppInfo = {
-					...entry,
+					...appInfo,
 					isDefault,
 				};
 
 				if (isDefault) await blockchainAppsDB.upsert(blockchainAppInfo);
 				return blockchainAppInfo;
 			}
-			return entry;
+			return appInfo;
 		},
 		{ concurrency: response.length },
 	);

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
@@ -55,7 +55,7 @@ const getBlockchainApps = async (params) => {
 		response,
 		async (appInfo) => {
 			if (!appInfo.isDefault) {
-				const isDefault = !!config.defaultApps.some(e => e.includes(appInfo.name));
+				const isDefault = config.defaultApps.some(e => e === appInfo.name);
 
 				const blockchainAppInfo = {
 					...appInfo,

--- a/services/blockchain-indexer/shared/database/schema/blockchainApps.js
+++ b/services/blockchain-indexer/shared/database/schema/blockchainApps.js
@@ -21,6 +21,7 @@ module.exports = {
 		name: { type: 'string' },
 		state: { type: 'string' },
 		address: { type: 'string' },
+		isDefault: { type: 'boolean', null: false, defaultValue: false },
 		lastUpdated: { type: 'string' },
 		lastCertificateHeight: { type: 'string' },
 	},
@@ -28,6 +29,7 @@ module.exports = {
 		chainID: { type: 'key' },
 		state: { type: 'key' },
 		name: { type: 'key' },
+		isDefault: { type: 'key' },
 	},
 	purge: {},
 };

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/ccuMainchain.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/ccuMainchain.js
@@ -47,7 +47,6 @@ const applyTransaction = async (blockHeader, tx, dbTrx) => {
 
 	// TODO: Get more apps information directly from SDK once issue https://github.com/LiskHQ/lisk-sdk/issues/7225 is closed
 	const appInfo = {
-		name: '',
 		chainID: tx.sendingChainID,
 		state: tx.status, // TODO: Verify and update
 		address: '', // TODO: Verify and update address

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/ccuSidechain.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/ccuSidechain.js
@@ -47,7 +47,6 @@ const applyTransaction = async (blockHeader, tx, dbTrx) => {
 
 	// TODO: Get more apps information directly from SDK once issue https://github.com/LiskHQ/lisk-sdk/issues/7225 is closed
 	const appInfo = {
-		name: '',
 		chainID: tx.sendingChainID,
 		state: tx.status, // TODO: Verify and update
 		address: '', // TODO: Verify and update address

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerMainchain.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerMainchain.js
@@ -49,6 +49,7 @@ const applyTransaction = async (blockHeader, tx, dbTrx) => {
 		name: tx.params.ownName,
 		chainID: tx.params.ownChainID,
 		address: '', // TODO: Verify and update address
+		isDefault: !!config.defaultApps.some(e => e.includes(tx.params.ownName)),
 		state: tx.status,
 	};
 	await blockchainAppsDB.upsert(appInfo, dbTrx);

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerMainchain.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerMainchain.js
@@ -49,7 +49,7 @@ const applyTransaction = async (blockHeader, tx, dbTrx) => {
 		name: tx.params.ownName,
 		chainID: tx.params.ownChainID,
 		address: '', // TODO: Verify and update address
-		isDefault: !!config.defaultApps.some(e => e.includes(tx.params.ownName)),
+		isDefault: config.defaultApps.some(e => e === tx.params.ownName),
 		state: tx.status,
 	};
 	await blockchainAppsDB.upsert(appInfo, dbTrx);

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerSidechain.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerSidechain.js
@@ -50,7 +50,7 @@ const applyTransaction = async (blockHeader, tx, dbTrx) => {
 		name: tx.params.name,
 		chainID: '',
 		address: '', // TODO: Verify and update address
-		isDefault: !!config.defaultApps.some(e => e.includes(tx.params.name)),
+		isDefault: config.defaultApps.some(e => e === tx.params.name),
 		state: tx.status,
 	};
 	await blockchainAppsDB.upsert(appInfo, dbTrx);

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerSidechain.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerSidechain.js
@@ -50,6 +50,7 @@ const applyTransaction = async (blockHeader, tx, dbTrx) => {
 		name: tx.params.name,
 		chainID: '',
 		address: '', // TODO: Verify and update address
+		isDefault: !!config.defaultApps.some(e => e.includes(tx.params.name)),
 		state: tx.status,
 	};
 	await blockchainAppsDB.upsert(appInfo, dbTrx);

--- a/services/gateway/apis/http-version3/methods/blockchainApps.js
+++ b/services/gateway/apis/http-version3/methods/blockchainApps.js
@@ -24,6 +24,7 @@ module.exports = {
 	tags: ['Blockchain Applications'],
 	params: {
 		chainID: { optional: true, type: 'string', min: 1, max: 32 },
+		isDefault: { optional: true, type: 'boolean', min: 1, pattern: regex.IS_DEFAULT },
 		name: { optional: true, type: 'string', min: 1, max: 20, pattern: regex.NAME },
 		state: { optional: true, type: 'string', enum: ['registered', 'active', 'terminated', 'any'], default: 'any' },
 		search: { optional: true, type: 'string' },

--- a/services/gateway/apis/http-version3/methods/blockchainApps.js
+++ b/services/gateway/apis/http-version3/methods/blockchainApps.js
@@ -23,7 +23,7 @@ module.exports = {
 	rpcMethod: 'get.blockchain.apps',
 	tags: ['Blockchain Applications'],
 	params: {
-		chainID: { optional: true, type: 'number', min: 1, max: 32 },
+		chainID: { optional: true, type: 'string', min: 1, max: 21, pattern: regex.CHAINID_RANGE },
 		isDefault: { optional: true, type: 'boolean' },
 		name: { optional: true, type: 'string', min: 1, max: 20, pattern: regex.NAME },
 		state: { optional: true, type: 'string', enum: ['registered', 'active', 'terminated', 'any'], default: 'any' },

--- a/services/gateway/apis/http-version3/methods/blockchainApps.js
+++ b/services/gateway/apis/http-version3/methods/blockchainApps.js
@@ -23,8 +23,8 @@ module.exports = {
 	rpcMethod: 'get.blockchain.apps',
 	tags: ['Blockchain Applications'],
 	params: {
-		chainID: { optional: true, type: 'string', min: 1, max: 32 },
-		isDefault: { optional: true, type: 'boolean', min: 1, pattern: regex.IS_DEFAULT },
+		chainID: { optional: true, type: 'number', min: 1, max: 32 },
+		isDefault: { optional: true, type: 'boolean' },
 		name: { optional: true, type: 'string', min: 1, max: 20, pattern: regex.NAME },
 		state: { optional: true, type: 'string', enum: ['registered', 'active', 'terminated', 'any'], default: 'any' },
 		search: { optional: true, type: 'string' },

--- a/services/gateway/shared/regex.js
+++ b/services/gateway/shared/regex.js
@@ -25,7 +25,6 @@ const NEWSFEED_SOURCE = /^\b(?:(?:drupal_lisk(?:_general|_announcements)|twitter
 const HASH_SHA256 = /^\b([A-Fa-f0-9]){1,64}\b$/;
 const CCM_STATUS = /^(?:\b(?:ok|module_not_supported|ccm_not_supported|channel_unavailable|recovered)\b|\b(?:ok|module_not_supported|ccm_not_supported|channel_unavailable|recovered|,){3,}\b){1}$/;
 const INTERVAL = /^\b((\d{4})-((1[012])|(0?[1-9]))-(([012][1-9])|([123]0)|31))(:((\d{4})-((1[012])|(0?[1-9]))-(([012][1-9])|([123]0)|31)))?\b$/g;
-const IS_DEFAULT = /^(true|false)$/;
 
 module.exports = {
 	PUBLIC_KEY,
@@ -40,5 +39,4 @@ module.exports = {
 	HEIGHT_RANGE,
 	CCM_STATUS,
 	INTERVAL,
-	IS_DEFAULT,
 };

--- a/services/gateway/shared/regex.js
+++ b/services/gateway/shared/regex.js
@@ -25,6 +25,7 @@ const NEWSFEED_SOURCE = /^\b(?:(?:drupal_lisk(?:_general|_announcements)|twitter
 const HASH_SHA256 = /^\b([A-Fa-f0-9]){1,64}\b$/;
 const CCM_STATUS = /^(?:\b(?:ok|module_not_supported|ccm_not_supported|channel_unavailable|recovered)\b|\b(?:ok|module_not_supported|ccm_not_supported|channel_unavailable|recovered|,){3,}\b){1}$/;
 const INTERVAL = /^\b((\d{4})-((1[012])|(0?[1-9]))-(([012][1-9])|([123]0)|31))(:((\d{4})-((1[012])|(0?[1-9]))-(([012][1-9])|([123]0)|31)))?\b$/g;
+const IS_DEFAULT = /^(true|false)$/;
 
 module.exports = {
 	PUBLIC_KEY,
@@ -39,4 +40,5 @@ module.exports = {
 	HEIGHT_RANGE,
 	CCM_STATUS,
 	INTERVAL,
+	IS_DEFAULT,
 };

--- a/services/gateway/shared/regex.js
+++ b/services/gateway/shared/regex.js
@@ -25,6 +25,7 @@ const NEWSFEED_SOURCE = /^\b(?:(?:drupal_lisk(?:_general|_announcements)|twitter
 const HASH_SHA256 = /^\b([A-Fa-f0-9]){1,64}\b$/;
 const CCM_STATUS = /^(?:\b(?:ok|module_not_supported|ccm_not_supported|channel_unavailable|recovered)\b|\b(?:ok|module_not_supported|ccm_not_supported|channel_unavailable|recovered|,){3,}\b){1}$/;
 const INTERVAL = /^\b((\d{4})-((1[012])|(0?[1-9]))-(([012][1-9])|([123]0)|31))(:((\d{4})-((1[012])|(0?[1-9]))-(([012][1-9])|([123]0)|31)))?\b$/g;
+const CHAINID_RANGE = /^\b(?:[0-9]{1,10}(?::[0-9]{1,10})?)\b$/;
 
 module.exports = {
 	PUBLIC_KEY,
@@ -39,4 +40,5 @@ module.exports = {
 	HEIGHT_RANGE,
 	CCM_STATUS,
 	INTERVAL,
+	CHAINID_RANGE,
 };

--- a/services/gateway/sources/version3/blockchainAppsSchema.js
+++ b/services/gateway/sources/version3/blockchainAppsSchema.js
@@ -20,6 +20,7 @@ module.exports = {
 	method: 'indexer.blockchain.apps',
 	params: {
 		chainID: '=,string',
+		isDefault: '=,boolean',
 		name: '=,string',
 		search: '=,string',
 		state: '=,string',

--- a/services/gateway/sources/version3/blockchainAppsSchema.js
+++ b/services/gateway/sources/version3/blockchainAppsSchema.js
@@ -19,7 +19,7 @@ module.exports = {
 	type: 'moleculer',
 	method: 'indexer.blockchain.apps',
 	params: {
-		chainID: '=,number',
+		chainID: '=,string',
 		isDefault: '=,boolean',
 		name: '=,string',
 		search: '=,string',

--- a/services/gateway/sources/version3/blockchainAppsSchema.js
+++ b/services/gateway/sources/version3/blockchainAppsSchema.js
@@ -19,7 +19,7 @@ module.exports = {
 	type: 'moleculer',
 	method: 'indexer.blockchain.apps',
 	params: {
-		chainID: '=,string',
+		chainID: '=,number',
 		isDefault: '=,boolean',
 		name: '=,string',
 		search: '=,string',

--- a/services/gateway/sources/version3/mappings/blockchainApp.js
+++ b/services/gateway/sources/version3/mappings/blockchainApp.js
@@ -18,6 +18,7 @@ module.exports = {
 	chainID: '=,string',
 	state: '=,string',
 	address: '=,string',
+	isDefault: '=,boolean',
 	lastCertificateHeight: '=,number',
 	lastUpdated: '=,number',
 };

--- a/services/gateway/sources/version3/mappings/blockchainApp.js
+++ b/services/gateway/sources/version3/mappings/blockchainApp.js
@@ -15,7 +15,7 @@
  */
 module.exports = {
 	name: '=,string',
-	chainID: '=,string',
+	chainID: '=,number',
 	state: '=,string',
 	address: '=,string',
 	isDefault: '=,boolean',

--- a/tests/integration/api_v3/http/blockchainApps.test.js
+++ b/tests/integration/api_v3/http/blockchainApps.test.js
@@ -61,6 +61,30 @@ describe('Blockchain apps API', () => {
 		expect(response.meta).toMap(metaSchema);
 	});
 
+	// TODO: Enable test case once blockchain app implementation is done
+	xit('retrieves list of all default blockchain applications', async () => {
+		const response = await api.get(`${endpoint}?isDefault=true`);
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toBeInstanceOf(Array);
+		expect(response.data.length).toBeGreaterThanOrEqual(1);
+		expect(response.data.length).toBeLessThanOrEqual(10);
+		response.data.map(blockchainApp => expect(blockchainApp)
+			.toMap(blockchainAppSchema, { isDefault: true }));
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	// TODO: Enable test case once blockchain app implementation is done
+	xit('retrieves list of all non-default blockchain applications', async () => {
+		const response = await api.get(`${endpoint}?isDefault=false`);
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toBeInstanceOf(Array);
+		expect(response.data.length).toBeGreaterThanOrEqual(1);
+		expect(response.data.length).toBeLessThanOrEqual(10);
+		response.data.map(blockchainApp => expect(blockchainApp)
+			.toMap(blockchainAppSchema, { isDefault: false }));
+		expect(response.meta).toMap(metaSchema);
+	});
+
 	// TODO: Update test case once implementation for indexing blockchain apps is done
 	xit('retrieves blockchain application by chainID', async () => {
 		const response = await api.get(`${endpoint}?chainID=`);

--- a/tests/integration/api_v3/rpc/blockchainApps.test.js
+++ b/tests/integration/api_v3/rpc/blockchainApps.test.js
@@ -66,6 +66,32 @@ describe('get.blockchain.apps', () => {
 		expect(result.meta).toMap(metaSchema);
 	});
 
+	// TODO: Enable test case once blockchain app implementation is done
+	xit('returns list of all default blockchain applications', async () => {
+		const response = await getBlockchainApps({ isDefault: true });
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data).toBeInstanceOf(Array);
+		expect(result.data.length).toBeGreaterThanOrEqual(1);
+		expect(result.data.length).toBeLessThanOrEqual(10);
+		result.data.forEach(blockchainApp => expect(blockchainApp)
+			.toMap(blockchainAppSchema, { isDefault: true }));
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	// TODO: Enable test case once blockchain app implementation is done
+	xit('returns list of all non-default blockchain applications', async () => {
+		const response = await getBlockchainApps({ isDefault: false });
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data).toBeInstanceOf(Array);
+		expect(result.data.length).toBeGreaterThanOrEqual(1);
+		expect(result.data.length).toBeLessThanOrEqual(10);
+		result.data.forEach(blockchainApp => expect(blockchainApp)
+			.toMap(blockchainAppSchema, { isDefault: false }));
+		expect(result.meta).toMap(metaSchema);
+	});
+
 	// TODO: Update test case once implementation for indexing blockchain apps is done
 	xit('returns list of all blockchain applications by chainID', async () => {
 		const response = await getBlockchainApps({ chainID: '' });

--- a/tests/schemas/api_v3/blockchainAppsSchema.schema.js
+++ b/tests/schemas/api_v3/blockchainAppsSchema.schema.js
@@ -35,6 +35,7 @@ const blockchainAppSchema = {
 	chainID: Joi.string().required(),
 	state: Joi.string().valid(...validStatuses).required(),
 	address: Joi.string().pattern(regex.ADDRESS_BASE32).required(),
+	isDefault: Joi.boolean().required(),
 	lastCertificateHeight: Joi.string().required(),
 	lastUpdated: Joi.string().required(),
 };

--- a/tests/schemas/api_v3/blockchainAppsSchema.schema.js
+++ b/tests/schemas/api_v3/blockchainAppsSchema.schema.js
@@ -32,7 +32,7 @@ const blockchainAppsStatsSchema = {
 
 const blockchainAppSchema = {
 	name: Joi.string().pattern(regex.NAME).required(),
-	chainID: Joi.string().required(),
+	chainID: Joi.number().integer().min(1).required(),
 	state: Joi.string().valid(...validStatuses).required(),
 	address: Joi.string().pattern(regex.ADDRESS_BASE32).required(),
 	isDefault: Joi.boolean().required(),


### PR DESCRIPTION
### What was the problem?
This PR resolves #1181

### How was it solved?

- [x] Extend the supported request params list to include isDefault
  - [x] When specified should only return a list of blockchain applications matching the param value
  - [x] By default, return a list of default applications followed by the non-default applications
- [x] Extend the response object to include isDefault
  - [x] Add a new column (isDefault) to the blockchain_apps table of type boolean defaulting to false
  - [x] Ensure Lisk and Lisk DEX applications are set true by default while indexing
  - [x] Allow users to extend the default application list with an environment variable
- [x] Unit/Integration tests are up-to-date

### How was it tested?
Local