### PR TITLE
Add endpoint to fetch supported tokens - Closes #1217 #1226

### DIFF
--- a/jenkins/mariadb/docker-compose.yml
+++ b/jenkins/mariadb/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       - "127.0.0.1:3306:3306"
     healthcheck:
       test: ['CMD', 'bash', '/healthcheck.sh']
-      interval: 1m
-      timeout: 5s
 
 volumes:
   db-data:

--- a/jenkins/mariadb/mysql-healthcheck.sh
+++ b/jenkins/mariadb/mysql-healthcheck.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mysql -h"$HOSTNAME" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" --silent -e"use $MYSQL_DATABASE"
+mysql -h"$HOSTNAME" -u"$MARIADB_USER" -p"$MARIADB_PASSWORD" --silent -e"use $MARIADB_DATABASE" 

--- a/jenkins/mariadb/mysql-healthcheck.sh
+++ b/jenkins/mariadb/mysql-healthcheck.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mysql -h"$HOSTNAME" -u"$MARIADB_USER" -p"$MARIADB_PASSWORD" --silent -e"use $MARIADB_DATABASE" 
+mysql -h"$HOSTNAME" -u"$MARIADB_USER" -p"$MARIADB_PASSWORD" --silent -e"use $MARIADB_DATABASE"

--- a/services/blockchain-indexer/methods/dataService/controllers/tokens.js
+++ b/services/blockchain-indexer/methods/dataService/controllers/tokens.js
@@ -50,7 +50,20 @@ const getTopLiskAddresses = async params => {
 	return topLiskAddresses;
 };
 
+const getSupportedTokens = async params => {
+	const supportedTokens = {
+		data: {},
+		meta: {},
+	};
+	const response = await dataService.getSupportedTokens(params);
+	if (response.data) supportedTokens.data = response.data;
+	if (response.meta) supportedTokens.meta = response.meta;
+
+	return supportedTokens;
+};
+
 module.exports = {
 	getTokens,
 	getTopLiskAddresses,
+	getSupportedTokens,
 };

--- a/services/blockchain-indexer/methods/dataService/tokens.js
+++ b/services/blockchain-indexer/methods/dataService/tokens.js
@@ -16,6 +16,7 @@
 const {
 	getTokens,
 	getTopLiskAddresses,
+	getSupportedTokens,
 } = require('./controllers/tokens');
 
 module.exports = [
@@ -36,6 +37,14 @@ module.exports = [
 			limit: { optional: true, type: 'number' },
 			offset: { optional: true, type: 'number' },
 			sort: { optional: true, type: 'string' },
+		},
+	},
+	{
+		name: 'tokens.supported',
+		controller: getSupportedTokens,
+		params: {
+			limit: { optional: true, type: 'number' },
+			offset: { optional: true, type: 'number' },
 		},
 	},
 ];

--- a/services/blockchain-indexer/shared/dataService/business/index.js
+++ b/services/blockchain-indexer/shared/dataService/business/index.js
@@ -62,6 +62,7 @@ const {
 const {
 	getTokens,
 	getTopLiskAddresses,
+	getSupportedTokens,
 } = require('./tokens');
 
 const {
@@ -106,6 +107,7 @@ module.exports = {
 	postTransactions,
 	getTokens,
 	getTopLiskAddresses,
+	getSupportedTokens,
 	getPendingTransactions,
 	loadAllPendingTransactions,
 	getTransactions,

--- a/services/blockchain-indexer/shared/dataService/business/tokens.js
+++ b/services/blockchain-indexer/shared/dataService/business/tokens.js
@@ -42,7 +42,7 @@ const getTopLSKAddressesIndex = () => getTableInstance(
 const getTokenMetadataByID = async (tokenID) => {
 	if (!tokenID.match(regex.TOKEN_ID)) throw new ValidationException('Invalid TokenID');
 
-	const chainID = tokenID.slice(0, 8)
+	const chainID = tokenID.slice(0, 8);
 	const tokenMetadata = await requestAppRegistry('blockchain.apps.meta.tokens', { chainID, tokenID });
 	return tokenMetadata;
 };

--- a/services/blockchain-indexer/shared/dataService/business/tokens.js
+++ b/services/blockchain-indexer/shared/dataService/business/tokens.js
@@ -43,8 +43,7 @@ const getTokenMetadataByID = async (tokenID) => {
 	if (!tokenID.match(regex.TOKEN_ID)) throw new ValidationException('Invalid TokenID');
 
 	const chainID = tokenID.split(0, 8);
-	const localID = tokenID.split(8);
-	const tokenMetadata = await requestAppRegistry('blockchain.apps.meta.tokens', { chainID, localID });
+	const tokenMetadata = await requestAppRegistry('blockchain.apps.meta.tokens', { chainID, tokenID });
 	return tokenMetadata;
 };
 
@@ -148,7 +147,9 @@ const getSupportedTokens = async (params) => {
 	supportedTokensList.data.supportedTokens = await BluebirdPromise.map(
 		response.tokenIDs,
 		async (tokenID) => {
-			const [tokenMetadata] = (await getTokenMetadataByID(tokenID)).data;
+			const tokenMetadataResponse = await getTokenMetadataByID(tokenID);
+			const [tokenMetadata = {}] = tokenMetadataResponse.data || [];
+
 			return {
 				tokenID,
 				symbol: tokenMetadata.symbol,

--- a/services/blockchain-indexer/shared/dataService/business/tokens.js
+++ b/services/blockchain-indexer/shared/dataService/business/tokens.js
@@ -42,7 +42,7 @@ const getTopLSKAddressesIndex = () => getTableInstance(
 const getTokenMetadataByID = async (tokenID) => {
 	if (!tokenID.match(regex.TOKEN_ID)) throw new ValidationException('Invalid TokenID');
 
-	const chainID = tokenID.split(0, 8);
+	const chainID = tokenID.slice(0, 8)
 	const tokenMetadata = await requestAppRegistry('blockchain.apps.meta.tokens', { chainID, tokenID });
 	return tokenMetadata;
 };

--- a/services/blockchain-indexer/shared/dataService/index.js
+++ b/services/blockchain-indexer/shared/dataService/index.js
@@ -76,6 +76,7 @@ const {
 const {
 	getTokens,
 	getTopLiskAddresses,
+	getSupportedTokens,
 } = require('./token');
 
 const {
@@ -138,6 +139,7 @@ module.exports = {
 	getLegacyAccountInfo,
 	getTokens,
 	getTopLiskAddresses,
+	getSupportedTokens,
 	getBlocks,
 	getBlocksAssets,
 	setLastBlock,

--- a/services/blockchain-indexer/shared/dataService/token/index.js
+++ b/services/blockchain-indexer/shared/dataService/token/index.js
@@ -16,9 +16,11 @@
 const {
 	getTokens,
 	getTopLiskAddresses,
+	getSupportedTokens,
 } = require('./token');
 
 module.exports = {
 	getTokens,
 	getTopLiskAddresses,
+	getSupportedTokens,
 };

--- a/services/blockchain-indexer/shared/utils/regex.js
+++ b/services/blockchain-indexer/shared/utils/regex.js
@@ -13,16 +13,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const dataService = require('../business');
-
-const getTokens = async (params) => dataService.getTokens(params);
-
-const getTopLiskAddresses = async (params) => dataService.getTopLiskAddresses(params);
-
-const getSupportedTokens = async (params) => dataService.getSupportedTokens(params);
+const TOKEN_ID = /[0-9A-Fa-f]{16}/g;
 
 module.exports = {
-	getTokens,
-	getTopLiskAddresses,
-	getSupportedTokens,
+	TOKEN_ID,
 };

--- a/services/blockchain-indexer/shared/utils/request.js
+++ b/services/blockchain-indexer/shared/utils/request.js
@@ -27,7 +27,10 @@ const requestRpc = async (service, method, params = {}) => {
 
 const requestConnector = async (method, params) => requestRpc('connector', method, params);
 
+const requestAppRegistry = async (method, params) => requestRpc('app-registry', method, params);
+
 module.exports = {
 	setAppContext,
 	requestConnector,
+	requestAppRegistry,
 };

--- a/services/gateway/apis/http-version3/methods/supportedTokens.js
+++ b/services/gateway/apis/http-version3/methods/supportedTokens.js
@@ -15,7 +15,6 @@
  */
 const supportedTokensSource = require('../../../sources/version3/supportedTokens');
 const envelope = require('../../../sources/version3/mappings/stdEnvelope');
-const regex = require('../../../shared/regex');
 const { transformParams, response, getSwaggerDescription } = require('../../../shared/utils');
 
 module.exports = {
@@ -24,8 +23,8 @@ module.exports = {
 	rpcMethod: 'get.tokens.supported',
 	tags: ['Tokens'],
 	params: {
-		limit: { optional: true, type: 'number', min: 1, max: 100, default: 10, pattern: regex.LIMIT },
-		offset: { optional: true, type: 'number', min: 0, default: 0, pattern: regex.OFFSET },
+		limit: { optional: true, type: 'number', min: 1, max: 100, default: 10 },
+		offset: { optional: true, type: 'number', min: 0, default: 0 },
 	},
 	get schema() {
 		const SupportedTokenSchema = {};
@@ -34,12 +33,12 @@ module.exports = {
 		SupportedTokenSchema[this.swaggerApiPath].get.summary = 'Requests supported tokens information';
 		SupportedTokenSchema[this.swaggerApiPath].get.description = getSwaggerDescription({
 			rpcMethod: this.rpcMethod,
-			description: 'Returns supported tokens information',
+			description: 'Returns supported tokens information. The \'supportedTokens\' is an empty list when all the tokens are supported on the blockchain application.',
 		});
 		SupportedTokenSchema[this.swaggerApiPath].get.parameters = transformParams('tokens', this.params);
 		SupportedTokenSchema[this.swaggerApiPath].get.responses = {
 			200: {
-				description: 'Returns supported tokens information',
+				description: 'Returns supported tokens information. The \'supportedTokens\' is an empty list when all the tokens are supported on the blockchain application.',
 				schema: {
 					$ref: '#/definitions/supportedTokenWithEnvelope',
 				},

--- a/services/gateway/apis/http-version3/methods/supportedTokens.js
+++ b/services/gateway/apis/http-version3/methods/supportedTokens.js
@@ -1,0 +1,53 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const supportedTokensSource = require('../../../sources/version3/supportedTokens');
+const envelope = require('../../../sources/version3/mappings/stdEnvelope');
+const regex = require('../../../shared/regex');
+const { transformParams, response, getSwaggerDescription } = require('../../../shared/utils');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/tokens/supported',
+	rpcMethod: 'get.tokens.supported',
+	tags: ['Tokens'],
+	params: {
+		limit: { optional: true, type: 'number', min: 1, max: 100, default: 10, pattern: regex.LIMIT },
+		offset: { optional: true, type: 'number', min: 0, default: 0, pattern: regex.OFFSET },
+	},
+	get schema() {
+		const SupportedTokenSchema = {};
+		SupportedTokenSchema[this.swaggerApiPath] = { get: {} };
+		SupportedTokenSchema[this.swaggerApiPath].get.tags = this.tags;
+		SupportedTokenSchema[this.swaggerApiPath].get.summary = 'Requests supported tokens information';
+		SupportedTokenSchema[this.swaggerApiPath].get.description = getSwaggerDescription({
+			rpcMethod: this.rpcMethod,
+			description: 'Returns supported tokens information',
+		});
+		SupportedTokenSchema[this.swaggerApiPath].get.parameters = transformParams('tokens', this.params);
+		SupportedTokenSchema[this.swaggerApiPath].get.responses = {
+			200: {
+				description: 'Returns supported tokens information',
+				schema: {
+					$ref: '#/definitions/supportedTokenWithEnvelope',
+				},
+			},
+		};
+		Object.assign(SupportedTokenSchema[this.swaggerApiPath].get.responses, response);
+		return SupportedTokenSchema;
+	},
+	source: supportedTokensSource,
+	envelope,
+};

--- a/services/gateway/apis/http-version3/swagger/definitions/tokens.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/tokens.json
@@ -150,8 +150,7 @@
         "properties": {
             "tokenID": {
                 "type": "string",
-                "format": "id",
-                "example": "0001000",
+                "example": "0000000010000000",
                 "description": "The universal identifier for the token within the Lisk ecosystem. It is defined as the concatenated value of the chainID and localID. Example: tokenID for LSK would be '0000000100000000' (chainID: '00000001', localID: '00000000')"
             },
             "name": {

--- a/services/gateway/apis/http-version3/swagger/definitions/tokens.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/tokens.json
@@ -142,6 +142,30 @@
             }
         }
     },
+    "supportedToken": {
+        "type": "object",
+        "required": [
+            "tokenID"
+        ],
+        "properties": {
+            "tokenID": {
+                "type": "string",
+                "format": "id",
+                "example": "0001000",
+                "description": "The universal identifier for the token within the Lisk ecosystem. It is defined as the concatenated value of the chainID and localID. Example: tokenID for LSK would be '0000000100000000' (chainID: '00000001', localID: '00000000')"
+            },
+            "name": {
+                "type": "string",
+                "example": "LISK",
+                "description": "The name of the token. For example Lisk"
+            },
+            "symbol": {
+                "type": "string",
+                "example": "LSK",
+                "description": "Token symbol"
+            }
+        }
+    },
     "supportedTokenWithEnvelope": {
         "type": "object",
         "required": [
@@ -151,23 +175,13 @@
         "properties": {
             "data": {
                 "type": "object",
-                "description": "Information for a given token.",
+                "description": "List of supported tokens",
                 "properties": {
-                    "tokenID": {
-                        "type": "string",
-                        "format": "id",
-                        "example": "0001000",
-                        "description": "The universal identifier for the token within the Lisk ecosystem. It is defined as the concatenated value of the chainID and localID. Example: tokenID for LSK would be '0000000100000000' (chainID: '00000001', localID: '00000000')"
-                    },
-                    "name": {
-                        "type": "string",
-                        "example": "LISK",
-                        "description": "The name of the token. For example Lisk"
-                    },
-                    "symbol": {
-                        "type": "string",
-                        "example": "LSK",
-                        "description": "Token symbol"
+                    "supportedTokens": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/supportedToken"
+                        }
                     }
                 }
             },

--- a/services/gateway/apis/http-version3/swagger/definitions/tokens.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/tokens.json
@@ -141,5 +141,64 @@
                 }
             }
         }
+    },
+    "supportedTokenWithEnvelope": {
+        "type": "object",
+        "required": [
+            "data",
+            "meta"
+        ],
+        "properties": {
+            "data": {
+                "type": "object",
+                "description": "Information for a given token.",
+                "properties": {
+                    "tokenID": {
+                        "type": "string",
+                        "format": "id",
+                        "example": "0001000",
+                        "description": "The universal identifier for the token within the Lisk ecosystem. It is defined as the concatenated value of the chainID and localID. Example: tokenID for LSK would be '0000000100000000' (chainID: '00000001', localID: '00000000')"
+                    },
+                    "name": {
+                        "type": "string",
+                        "example": "LISK",
+                        "description": "The name of the token. For example Lisk"
+                    },
+                    "symbol": {
+                        "type": "string",
+                        "example": "LSK",
+                        "description": "Token symbol"
+                    }
+                }
+            },
+            "meta": {
+                "type": "object",
+                "required": [
+                    "count",
+                    "offset",
+                    "total"
+                ],
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 1,
+                        "minimum": 0,
+                        "description": "Number of items returned in the request."
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "example": 0,
+                        "minimum": 0,
+                        "description": "Number of items skipped in the response."
+                    },
+                    "total": {
+                        "type": "integer",
+                        "example": 5,
+                        "minimum": 0,
+                        "description": "Total number of items matching the request query."
+                    }
+                }
+            }
+        }
     }
 }

--- a/services/gateway/sources/version3/newsfeed.js
+++ b/services/gateway/sources/version3/newsfeed.js
@@ -27,8 +27,8 @@ module.exports = {
 		data: ['data', newsfeed],
 		meta: {
 			count: '=,number',
-			limit: '=,number',
 			offset: '=,number',
+			total: '=,number',
 		},
 		links: {},
 	},

--- a/services/gateway/sources/version3/supportedTokens.js
+++ b/services/gateway/sources/version3/supportedTokens.js
@@ -1,0 +1,34 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+module.exports = {
+	type: 'moleculer',
+	method: 'indexer.tokens.supported',
+	params: {
+		offset: '=,number',
+		limit: '=,number',
+	},
+	definition: {
+		data: {
+			supportedTokens: '=',
+		},
+		meta: {
+			count: '=,number',
+			offset: '=,number',
+			total: '=,number',
+		},
+		links: {},
+	},
+};

--- a/services/newsfeed/shared/newsfeed.js
+++ b/services/newsfeed/shared/newsfeed.js
@@ -26,12 +26,8 @@ const MYSQL_ENDPOINT = config.endpoints.mysql;
 
 const getNewsFeedIndex = () => getTableInstance('newsfeed', newsfeedIndexSchema, MYSQL_ENDPOINT);
 
-const enabledSources = Object.values(config.sources)
-	.filter(({ enabled }) => enabled)
-	.map(({ name }) => name).join(',');
-
 const getNewsfeedArticles = async params => {
-	const { offset, limit, source = enabledSources } = params;
+	const { offset } = params;
 	const newsfeedDB = await getNewsFeedIndex();
 
 	if (params.source) params = {
@@ -53,9 +49,7 @@ const getNewsfeedArticles = async params => {
 		data,
 		meta: {
 			count: data.length,
-			limit,
 			offset,
-			source,
 			total,
 		},
 	};

--- a/services/newsfeed/shared/newsfeed.js
+++ b/services/newsfeed/shared/newsfeed.js
@@ -47,6 +47,8 @@ const getNewsfeedArticles = async params => {
 	// Send 'Service Unavailable' when no data is available
 	if (!data.length) throw new ServiceUnavailableException('Service not available');
 
+	const total = await newsfeedDB.count(params);
+
 	return {
 		data,
 		meta: {
@@ -54,6 +56,7 @@ const getNewsfeedArticles = async params => {
 			limit,
 			offset,
 			source,
+			total,
 		},
 	};
 };

--- a/tests/integration/api_v3/http/supportedTokens.test.js
+++ b/tests/integration/api_v3/http/supportedTokens.test.js
@@ -19,6 +19,7 @@ const { api } = require('../../../helpers/api');
 const {
 	badRequestSchema,
 	metaSchema,
+	wrongInputParamSchema,
 } = require('../../../schemas/httpGenerics.schema');
 
 const {
@@ -56,6 +57,11 @@ describe('Supported Tokens API', () => {
 		expect(response.data.supportedTokens.length).toBeLessThanOrEqual(5);
 		expect(response.data).toMap(supportedTokensSchema);
 		expect(response.meta).toMap(metaSchema);
+	});
+
+	it('invalid query parameter -> 400', async () => {
+		const response = await api.get(`${endpoint}?limit=-5`, 400);
+		expect(response).toMap(wrongInputParamSchema);
 	});
 
 	it('invalid request param -> bad request', async () => {

--- a/tests/integration/api_v3/http/supportedTokens.test.js
+++ b/tests/integration/api_v3/http/supportedTokens.test.js
@@ -1,0 +1,65 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+const { api } = require('../../../helpers/api');
+
+const {
+	badRequestSchema,
+	metaSchema,
+} = require('../../../schemas/httpGenerics.schema');
+
+const {
+	supportedTokensSchema,
+	goodRequestSchemaForSupportedTokens,
+} = require('../../../schemas/api_v3/tokens.schema');
+
+const baseUrl = config.SERVICE_ENDPOINT;
+const baseUrlV3 = `${baseUrl}/api/v3`;
+const endpoint = `${baseUrlV3}/tokens/supported`;
+
+describe('Supported Tokens API', () => {
+	it('retrieves list of supported tokens -> ok', async () => {
+		const response = await api.get(endpoint);
+		expect(response).toMap(goodRequestSchemaForSupportedTokens);
+		expect(response.data.supportedTokens).toBeInstanceOf(Array);
+		expect(response.data.supportedTokens.length).toBeLessThanOrEqual(10);
+		expect(response.data).toMap(supportedTokensSchema);
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	it('retrieves list of supported tokens with limit=5 -> ok', async () => {
+		const response = await api.get(`${endpoint}?limit=5`);
+		expect(response).toMap(goodRequestSchemaForSupportedTokens);
+		expect(response.data.supportedTokens).toBeInstanceOf(Array);
+		expect(response.data.supportedTokens.length).toBeLessThanOrEqual(5);
+		expect(response.data).toMap(supportedTokensSchema);
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	it('retrieves list of supported tokens with limit=5 and offset=1-> ok', async () => {
+		const response = await api.get(`${endpoint}?limit=5&offset=1`);
+		expect(response).toMap(goodRequestSchemaForSupportedTokens);
+		expect(response.data.supportedTokens).toBeInstanceOf(Array);
+		expect(response.data.supportedTokens.length).toBeLessThanOrEqual(5);
+		expect(response.data).toMap(supportedTokensSchema);
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	it('invalid request param -> bad request', async () => {
+		const response = await api.get(`${endpoint}?invalidParam=invalid`, 400);
+		expect(response).toMap(badRequestSchema);
+	});
+});

--- a/tests/integration/api_v3/rpc/supportedTokens.test.js
+++ b/tests/integration/api_v3/rpc/supportedTokens.test.js
@@ -63,6 +63,11 @@ describe('get.tokens.supported', () => {
 		expect(result.meta).toMap(metaSchema);
 	});
 
+	it('returns INVALID_PARAMS error (-32602) on invalid address', async () => {
+		const response = await getSupportedTokens({ limit: -5 });
+		expect(response).toMap(invalidParamsSchema);
+	});
+
 	it('invalid request param -> invalid param', async () => {
 		const response = await getSupportedTokens({ invalidParam: 'invalid' });
 		expect(response).toMap(invalidParamsSchema);

--- a/tests/integration/api_v3/rpc/supportedTokens.test.js
+++ b/tests/integration/api_v3/rpc/supportedTokens.test.js
@@ -1,0 +1,70 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const config = require('../../../config');
+
+const {
+	request,
+} = require('../../../helpers/socketIoRpcRequest');
+
+const {
+	invalidParamsSchema,
+	jsonRpcEnvelopeSchema,
+	metaSchema,
+} = require('../../../schemas/rpcGenerics.schema');
+
+const {
+	supportedTokensSchema,
+} = require('../../../schemas/api_v3/tokens.schema');
+
+const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
+const getSupportedTokens = async (params) => request(wsRpcUrl, 'get.tokens.supported', params);
+
+describe('get.tokens.supported', () => {
+	it('returns list of supported tokens', async () => {
+		const response = await getSupportedTokens();
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data.supportedTokens).toBeInstanceOf(Array);
+		expect(result.data.supportedTokens.length).toBeLessThanOrEqual(10);
+		expect(result.data).toMap(supportedTokensSchema);
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	it('returns list of supported tokens with limit=5', async () => {
+		const response = await getSupportedTokens({ limit: 5 });
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data.supportedTokens).toBeInstanceOf(Array);
+		expect(result.data.supportedTokens.length).toBeLessThanOrEqual(5);
+		expect(result.data).toMap(supportedTokensSchema);
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	it('returns list of supported tokens with limit=5 and offset=1', async () => {
+		const response = await getSupportedTokens({ limit: 5, offset: 1 });
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+		const { result } = response;
+		expect(result.data.supportedTokens).toBeInstanceOf(Array);
+		expect(result.data.supportedTokens.length).toBeLessThanOrEqual(5);
+		expect(result.data).toMap(supportedTokensSchema);
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	it('invalid request param -> invalid param', async () => {
+		const response = await getSupportedTokens({ invalidParam: 'invalid' });
+		expect(response).toMap(invalidParamsSchema);
+	});
+});

--- a/tests/schemas/api_v3/newsfeed.schema.js
+++ b/tests/schemas/api_v3/newsfeed.schema.js
@@ -30,9 +30,9 @@ const newsfeedArticleSchema = {
 };
 
 const newsfeedMetaSchema = {
-	count: Joi.number().required(),
-	total: Joi.number().required(),
-	offset: Joi.number().required(),
+	count: Joi.number().integer().min(1).required(),
+	total: Joi.number().integer().min(1).required(),
+	offset: Joi.number().integer().min(0).required(),
 };
 
 module.exports = {

--- a/tests/schemas/api_v3/newsfeed.schema.js
+++ b/tests/schemas/api_v3/newsfeed.schema.js
@@ -31,7 +31,7 @@ const newsfeedArticleSchema = {
 
 const newsfeedMetaSchema = {
 	count: Joi.number().required(),
-	limit: Joi.number().required(),
+	total: Joi.number().required(),
 	offset: Joi.number().required(),
 };
 

--- a/tests/schemas/api_v3/tokens.schema.js
+++ b/tests/schemas/api_v3/tokens.schema.js
@@ -47,7 +47,7 @@ const supportedTokensSchema = {
 };
 
 const goodRequestSchemaForSupportedTokens = {
-	data: Joi.object().required(),
+	data: Joi.object(supportedTokensSchema).required(),
 	meta: Joi.object().required(),
 };
 

--- a/tests/schemas/api_v3/tokens.schema.js
+++ b/tests/schemas/api_v3/tokens.schema.js
@@ -36,7 +36,24 @@ const tokensSchema = {
 	lockedAmount: Joi.array().items(lockedAmount).required(),
 };
 
+const supportedToken = {
+	tokenID: Joi.string().required(),
+	name: Joi.string().optional(),
+	symbol: Joi.string().optional(),
+};
+
+const supportedTokensSchema = {
+	supportedTokens: Joi.array().items(supportedToken).required(),
+};
+
+const goodRequestSchemaForSupportedTokens = {
+	data: Joi.object().required(),
+	meta: Joi.object().required(),
+};
+
 module.exports = {
 	tokensSchema: Joi.object(tokensSchema).required(),
+	supportedTokensSchema: Joi.object(supportedTokensSchema).required(),
 	tokensMetaSchema: Joi.object(tokensMetaSchema).required(),
+	goodRequestSchemaForSupportedTokens: Joi.object(goodRequestSchemaForSupportedTokens).required(),
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #1217 #1226 

### How was it solved?

- [x] The below-specified endpoints are defined in the gateway:
  - [x] HTTP: GET /api/v3/tokens/supported
  - [x] RPC: get.tokens.supported
- [x] Add controller `indexer.tokens.supported`
- [x] Add implementation to retrieve supported tokens from application
- [x] Add implementation to resolve token off-chain metadata (symbol and name)
- [x] Update `getTokensInfo` method to include symbol and name
- [x] Add Integration tests
- [x] Update swagger specification
- [x] Add `total` to newsfeed meta response

### How was it tested?
<!--- Please describe how you tested your changes -->
