### PR TITLE
Implement reward sharing

### DIFF
--- a/services/blockchain-indexer/package-lock.json
+++ b/services/blockchain-indexer/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@liskhq/lisk-cryptography": "4.0.0-alpha.4",
         "@liskhq/lisk-transactions": "6.0.0-alpha.5",
+        "@liskhq/lisk-utils": "0.3.0-alpha.1",
         "bluebird": "^3.7.2",
         "bull": "^4.8.1",
         "camelcase": "^6.3.0",

--- a/services/blockchain-indexer/package.json
+++ b/services/blockchain-indexer/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@liskhq/lisk-cryptography": "4.0.0-alpha.4",
     "@liskhq/lisk-transactions": "6.0.0-alpha.5",
+    "@liskhq/lisk-utils": "0.3.0-alpha.1",
     "bluebird": "^3.7.2",
     "bull": "^4.8.1",
     "camelcase": "^6.3.0",

--- a/services/blockchain-indexer/shared/constants.js
+++ b/services/blockchain-indexer/shared/constants.js
@@ -98,6 +98,8 @@ const LENGTH_LOCAL_ID = 4 * 2; // Each byte is represented with 2 nibbles
 const PATTERN_ANY_TOKEN_ID = '*';
 const PATTERN_ANY_LOCAL_ID = '*'.repeat(LENGTH_LOCAL_ID);
 
+const MAX_COMMISSION = BigInt('10000');
+
 module.exports = {
 	updateFinalizedHeight,
 	getFinalizedHeight,
@@ -115,4 +117,5 @@ module.exports = {
 	PATTERN_ANY_LOCAL_ID,
 	MODULE,
 	COMMAND,
+	MAX_COMMISSION,
 };

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -180,10 +180,10 @@ const indexBlock = async job => {
 			if (blockRewardEvent) {
 				blockReward = BigInt(blockRewardEvent.data.amount || '0');
 
-				if (blockReward) {
+				if (blockReward !== BigInt('0')) {
 					// TODO: Implement proper logic
-					const commission = calculateCommission(blockReward);
-					const selfStakeReward = calculateSelfStakeRewards(blockReward);
+					const commission = await calculateCommission(blockReward);
+					const selfStakeReward = await calculateSelfStakeRewards(block.generatorAddress);
 
 					await validatorsTable.increment({
 						increment: { totalCommission: BigInt(commission) },

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -183,7 +183,11 @@ const indexBlock = async job => {
 				if (blockReward !== BigInt('0')) {
 					// TODO: Implement proper logic
 					const commission = await calcCommission(block.generatorAddress, blockReward);
-					const selfStakeReward = await calcSelfStakeReward(block.generatorAddress, blockReward);
+					const selfStakeReward = await calcSelfStakeReward(
+						block.generatorAddress,
+						blockReward,
+						commission,
+					);
 
 					await validatorsTable.increment({
 						increment: { totalCommission: BigInt(commission) },

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -44,7 +44,7 @@ const {
 const { getLisk32AddressFromPublicKey, updateAccountPublicKey } = require('../utils/accountUtils');
 const { normalizeTransaction } = require('../utils/transactionsUtils');
 const { getEventsInfoToIndex } = require('../utils/eventsUtils');
-const { calculateCommission, calculateSelfStakeRewards } = require('../utils/validatorUtils');
+const { calcCommission, calcSelfStakeReward } = require('../utils/validatorUtils');
 
 const { updateAddressBalanceQueue } = require('./tokenIndex');
 
@@ -182,8 +182,8 @@ const indexBlock = async job => {
 
 				if (blockReward !== BigInt('0')) {
 					// TODO: Implement proper logic
-					const commission = await calculateCommission(block.generatorAddress, blockReward);
-					const selfStakeReward = await calculateSelfStakeRewards(block.generatorAddress);
+					const commission = await calcCommission(block.generatorAddress, blockReward);
+					const selfStakeReward = await calcSelfStakeReward(block.generatorAddress, blockReward);
 
 					await validatorsTable.increment({
 						increment: { totalCommission: BigInt(commission) },

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -181,7 +181,6 @@ const indexBlock = async job => {
 				blockReward = BigInt(blockRewardEvent.data.amount || '0');
 
 				if (blockReward !== BigInt('0')) {
-					// TODO: Implement proper logic
 					const commission = await calcCommission(block.generatorAddress, blockReward);
 					const selfStakeReward = await calcSelfStakeReward(
 						block.generatorAddress,

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -44,6 +44,7 @@ const {
 const { getLisk32AddressFromPublicKey, updateAccountPublicKey } = require('../utils/accountUtils');
 const { normalizeTransaction } = require('../utils/transactionsUtils');
 const { getEventsInfoToIndex } = require('../utils/eventsUtils');
+const { calculateCommission, calculateSelfStakeRewards } = require('../utils/validatorUtils');
 
 const { updateAddressBalanceQueue } = require('./tokenIndex');
 
@@ -98,25 +99,6 @@ const getValidatorsTable = () => getTableInstance(
 );
 
 const INDEX_VERIFIED_HEIGHT = 'indexVerifiedHeight';
-
-// const getGeneratorPkInfoArray = async (blocks) => {
-// 	const blocksTable = await getBlocksIndex();
-// 	const pkInfoArray = [];
-// 	await BluebirdPromise.map(
-// 		blocks,
-// 		async block => {
-// 			const [blockInfo] = await blocksTable.find({ id: block.id, limit: 1 }, ['id']);
-// 			pkInfoArray.push({
-// 				publicKey: block.generatorPublicKey,
-// 				reward: block.reward,
-// 				isForger: true,
-// 				isBlockIndexed: !!blockInfo,
-// 			});
-// 		},
-// 		{ concurrency: blocks.length },
-// 	);
-// 	return pkInfoArray;
-// };
 
 const validateBlock = (block) => !!block && block.height >= 0;
 
@@ -198,18 +180,20 @@ const indexBlock = async job => {
 			if (blockRewardEvent) {
 				blockReward = BigInt(blockRewardEvent.data.amount || '0');
 
-				// TODO: Implement proper logic
-				const commission = blockReward;
-				const selfStakeReward = blockReward;
+				if (blockReward) {
+					// TODO: Implement proper logic
+					const commission = calculateCommission(blockReward);
+					const selfStakeReward = calculateSelfStakeRewards(blockReward);
 
-				await validatorsTable.increment({
-					increment: { totalCommission: commission },
-					where: { address: block.generatorAddress },
-				}, dbTrx);
-				await validatorsTable.increment({
-					increment: { totalSelfStakeRewards: selfStakeReward },
-					where: { address: block.generatorAddress },
-				}, dbTrx);
+					await validatorsTable.increment({
+						increment: { totalCommission: BigInt(commission) },
+						where: { address: block.generatorAddress },
+					}, dbTrx);
+					await validatorsTable.increment({
+						increment: { totalSelfStakeRewards: BigInt(selfStakeReward) },
+						where: { address: block.generatorAddress },
+					}, dbTrx);
+				}
 			}
 		}
 

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -182,7 +182,7 @@ const indexBlock = async job => {
 
 				if (blockReward !== BigInt('0')) {
 					// TODO: Implement proper logic
-					const commission = await calculateCommission(blockReward);
+					const commission = await calculateCommission(block.generatorAddress, blockReward);
 					const selfStakeReward = await calculateSelfStakeRewards(block.generatorAddress);
 
 					await validatorsTable.increment({

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -314,7 +314,7 @@ const deleteIndexedBlocks = async job => {
 };
 
 // Initialize queues
-const indexBlocksQueue = Queue(config.endpoints.cache, 'indexBlocksQueue', indexBlock, 30);
+const indexBlocksQueue = Queue(config.endpoints.cache, 'indexBlocksQueue', indexBlock, 1);
 const updateBlockIndexQueue = Queue(config.endpoints.cache, 'updateBlockIndexQueue', updateBlockIndex, 1);
 const deleteIndexedBlocksQueue = Queue(config.endpoints.cache, 'deleteIndexedBlocksQueue', deleteIndexedBlocks, 1);
 

--- a/services/blockchain-indexer/shared/indexer/indexStatus.js
+++ b/services/blockchain-indexer/shared/indexer/indexStatus.js
@@ -23,8 +23,8 @@ const {
 const logger = Logger();
 
 const {
-	indexCommissionInfo,
-	indexStakeInfo,
+	indexValidatorCommissionInfo,
+	indexStakersInfo,
 } = require('./validatorIndex');
 
 const {
@@ -143,9 +143,9 @@ const init = async () => {
 
 	const genesisBlock = await getBlockByHeight(await getGenesisHeight());
 
-	// Index stake and commission information available in genesis block
-	await indexCommissionInfo(genesisBlock);
-	await indexStakeInfo(genesisBlock);
+	// Index stakers and commission information available in genesis block
+	await indexValidatorCommissionInfo(genesisBlock);
+	await indexStakersInfo(genesisBlock);
 };
 
 module.exports = {

--- a/services/blockchain-indexer/shared/indexer/indexStatus.js
+++ b/services/blockchain-indexer/shared/indexer/indexStatus.js
@@ -23,10 +23,19 @@ const {
 const logger = Logger();
 
 const {
+	indexCommissionInfo,
+	indexStakeInfo,
+} = require('./validatorIndex');
+
+const {
 	getCurrentHeight,
 	getGenesisHeight,
 	updateFinalizedHeight,
 } = require('../constants');
+
+const {
+	getBlockByHeight,
+} = require('../dataService');
 
 const blocksTableSchema = require('../database/schema/blocks');
 
@@ -131,6 +140,12 @@ const init = async () => {
 	// Register event listeners
 	Signals.get('newBlock').add(checkIndexReadiness);
 	Signals.get('chainNewBlock').add(updateFinalizedHeight);
+
+	const genesisBlock = await getBlockByHeight(await getGenesisHeight());
+
+	// Index stake and commission information available in genesis block
+	await indexCommissionInfo(genesisBlock);
+	await indexStakeInfo(genesisBlock);
 };
 
 module.exports = {

--- a/services/blockchain-indexer/shared/indexer/validatorIndex.js
+++ b/services/blockchain-indexer/shared/indexer/validatorIndex.js
@@ -17,6 +17,7 @@ const {
 	MySQL: { getTableInstance },
 } = require('lisk-service-framework');
 
+const { MODULE } = require('../constants');
 const commissionsTableSchema = require('../database/schema/commissions');
 const stakesTableSchema = require('../database/schema/stakes');
 
@@ -49,7 +50,7 @@ const indexValidatorCommissionInfo = async (genesisBlock) => {
 
 const indexStakersInfo = async (genesisBlock) => {
 	const stakesTable = await getStakesTable();
-	const { stakers } = (genesisBlock.assets.find(asset => asset.module === 'pos')).data;
+	const { stakers } = (genesisBlock.assets.find(asset => asset.module === MODULE.POS)).data;
 	const stakestoIndex = [];
 	await stakers.forEach(async staker => staker.sentStakes.forEach(stake => {
 		stakestoIndex.push({

--- a/services/blockchain-indexer/shared/indexer/validatorIndex.js
+++ b/services/blockchain-indexer/shared/indexer/validatorIndex.js
@@ -1,0 +1,49 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2022 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const {
+	MySQL: { getTableInstance },
+} = require('lisk-service-framework');
+
+const commissionsTableSchema = require('../database/schema/commissions');
+const config = require('../../config');
+
+const MYSQL_ENDPOINT = config.endpoints.mysql;
+
+const getCommissionsTable = () => getTableInstance(
+	commissionsTableSchema.tableName,
+	commissionsTableSchema,
+	MYSQL_ENDPOINT,
+);
+
+const indexCommissionInfo = async (genesisBlock) => {
+	const commissionsTable = await getCommissionsTable();
+	const { validators } = (genesisBlock.assets.find(asset => asset.module === 'pos')).data;
+	const commissionInfo = validators.map(validator => ({
+		address: validator.address,
+		height: genesisBlock.height,
+		commission: validator.commission,
+	}));
+	await commissionsTable.upsert(commissionInfo);
+};
+
+const indexStakeInfo = async (genesisBlock) => {
+	const { stakers } = (genesisBlock.assets.find(asset => asset.module === 'pos')).data;
+};
+
+module.exports = {
+	indexCommissionInfo,
+	indexStakeInfo,
+};

--- a/services/blockchain-indexer/shared/utils/validatorUtils.js
+++ b/services/blockchain-indexer/shared/utils/validatorUtils.js
@@ -73,7 +73,7 @@ const calcCommission = async (generatorAddress, reward) => {
 	const commissionsTable = await getCommissionsTable();
 	const [{ commission: currentCommission }] = await commissionsTable
 		.find({ address: generatorAddress, sort: 'height:desc', limit: 1 }, 'commission');
-	const commission = (reward * BigInt(currentCommission)) / MAX_COMMISSION;
+	const commission = (BigInt(reward) * BigInt(currentCommission)) / MAX_COMMISSION;
 	return commission;
 };
 
@@ -89,7 +89,7 @@ const calcSelfStakeReward = async (generatorAddress, reward, commission) => {
 		const selfStakesInfo = stakerInfo.filter(stake => stake.stakerAddress === generatorAddress);
 		const selfStakes = selfStakesInfo.reduce((a, b) => BigInt(a.amount) + BigInt(b.amount));
 		const totalStakes = stakerInfo.reduce((a, b) => BigInt(a.amount) + BigInt(b.amount));
-		selfStakeReward = (reward * (MAX_COMMISSION - commission) * selfStakes)
+		selfStakeReward = (BigInt(reward) * (MAX_COMMISSION - BigInt(commission)) * selfStakes)
 			/ (totalStakes * MAX_COMMISSION);
 	}
 

--- a/services/blockchain-indexer/shared/utils/validatorUtils.js
+++ b/services/blockchain-indexer/shared/utils/validatorUtils.js
@@ -67,7 +67,7 @@ const getAddressByName = async (name) => {
 	return null;
 };
 
-const calculateCommission = async (generatorAddress, reward) => {
+const calcCommission = async (generatorAddress, reward) => {
 	const commissionsTable = await getCommissionsTable();
 	const [{ commission: currentCommission }] = await commissionsTable
 		.find({ address: generatorAddress, sort: 'height:desc', limit: 1 }, 'commission');
@@ -76,7 +76,7 @@ const calculateCommission = async (generatorAddress, reward) => {
 };
 
 // TODO: Verify
-const calculateSelfStakeRewards = async (generatorAddress) => {
+const calcSelfStakeReward = async (generatorAddress, reward) => {
 	const stakesTable = await getStakesTable();
 	const stakerInfo = await stakesTable.find({ validatorAddress: generatorAddress });
 	const selfStakes = stakerInfo.map(stake => stake.stakerAddress === generatorAddress);
@@ -84,13 +84,13 @@ const calculateSelfStakeRewards = async (generatorAddress) => {
 	const selfStakeWeight = selfStakes.reduce((a, b) => a.amount + b.amount);
 	const totalStakeWeight = stakerInfo.reduce((a, b) => a.amount + b.amount);
 
-	const selfStakeReward = (selfStakeWeight / totalStakeWeight) * 100;
+	const selfStakeReward = reward * ((selfStakeWeight / totalStakeWeight) * 100);
 	return selfStakeReward;
 };
 
 module.exports = {
 	getNameByAddress,
 	getAddressByName,
-	calculateCommission,
-	calculateSelfStakeRewards,
+	calcCommission,
+	calcSelfStakeReward,
 };

--- a/services/blockchain-indexer/shared/utils/validatorUtils.js
+++ b/services/blockchain-indexer/shared/utils/validatorUtils.js
@@ -20,13 +20,22 @@ const {
 
 const config = require('../../config');
 const accountsIndexSchema = require('../database/schema/accounts');
+const commissionsTableSchema = require('../database/schema/commissions');
+
+const MYSQL_ENDPOINT = config.endpoints.mysql;
 
 const validatorCache = CacheRedis('validator', config.endpoints.cache);
 
 const getAccountsIndex = () => getTableInstance(
 	accountsIndexSchema.tableName,
 	accountsIndexSchema,
-	config.endpoints.mysql,
+	MYSQL_ENDPOINT,
+);
+
+const getCommissionsTable = () => getTableInstance(
+	commissionsTableSchema.tableName,
+	commissionsTableSchema,
+	MYSQL_ENDPOINT,
 );
 
 const getNameByAddress = async (address) => {
@@ -51,7 +60,20 @@ const getAddressByName = async (name) => {
 	return null;
 };
 
+const calculateCommission = async (reward) => {
+	const commissionsTable = await getCommissionsTable();
+	const [{ commission: currentCommission }] = await commissionsTable.find({ sort: 'height:desc', limit: 1 }, 'commission');
+	const commission = (reward * currentCommission) / 100;
+	return commission;
+};
+
+const calculateSelfStakeRewards = async (reward) => {
+
+};
+
 module.exports = {
 	getNameByAddress,
 	getAddressByName,
+	calculateCommission,
+	calculateSelfStakeRewards,
 };

--- a/services/blockchain-indexer/shared/utils/validatorUtils.js
+++ b/services/blockchain-indexer/shared/utils/validatorUtils.js
@@ -19,6 +19,7 @@ const {
 } = require('lisk-service-framework');
 
 const config = require('../../config');
+const { MAX_COMMISSION } = require('../constants');
 const accountsIndexSchema = require('../database/schema/accounts');
 const commissionsTableSchema = require('../database/schema/commissions');
 const stakesTableSchema = require('../database/schema/stakes');
@@ -44,8 +45,6 @@ const getStakesTable = () => getTableInstance(
 	stakesTableSchema,
 	MYSQL_ENDPOINT,
 );
-
-const MAX_COMMISSION = BigInt('10000');
 
 const getNameByAddress = async (address) => {
 	if (address) {

--- a/services/blockchain-indexer/shared/utils/validatorUtils.js
+++ b/services/blockchain-indexer/shared/utils/validatorUtils.js
@@ -77,15 +77,12 @@ const calculateCommission = async (generatorAddress, reward) => {
 
 // TODO: Verify
 const calculateSelfStakeRewards = async (generatorAddress) => {
-	let selfStakeWeight = BigInt('0');
-	let totalStakeWeight = BigInt('0');
-
 	const stakesTable = await getStakesTable();
 	const stakerInfo = await stakesTable.find({ validatorAddress: generatorAddress });
 	const selfStakes = stakerInfo.map(stake => stake.stakerAddress === generatorAddress);
 
-	selfStakeWeight = selfStakes.reduce((a, b) => a.amount + b.amount);
-	totalStakeWeight = stakerInfo.reduce((a, b) => a.amount + b.amount);
+	const selfStakeWeight = selfStakes.reduce((a, b) => a.amount + b.amount);
+	const totalStakeWeight = stakerInfo.reduce((a, b) => a.amount + b.amount);
 
 	const selfStakeReward = (selfStakeWeight / totalStakeWeight) * 100;
 	return selfStakeReward;

--- a/services/blockchain-indexer/shared/utils/validatorUtils.js
+++ b/services/blockchain-indexer/shared/utils/validatorUtils.js
@@ -13,6 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+const { math: { q96 } } = require('@liskhq/lisk-utils');
 const {
 	CacheRedis,
 	MySQL: { getTableInstance },
@@ -72,8 +73,12 @@ const calcCommission = async (generatorAddress, reward) => {
 	const commissionsTable = await getCommissionsTable();
 	const [{ commission: currentCommission }] = await commissionsTable
 		.find({ address: generatorAddress, sort: 'height:desc', limit: 1 }, 'commission');
-	const commission = (BigInt(reward) * BigInt(currentCommission)) / MAX_COMMISSION;
-	return commission;
+
+	const rewardQ = q96(reward);
+	const currentCommissionQ = q96(BigInt(currentCommission));
+	const maxCommissionQ = q96(MAX_COMMISSION);
+	const commission = (rewardQ.mul(currentCommissionQ)).div(maxCommissionQ);
+	return commission.floor();
 };
 
 const calcSelfStakeReward = async (generatorAddress, reward, commission) => {

--- a/services/blockchain-indexer/shared/utils/validatorUtils.js
+++ b/services/blockchain-indexer/shared/utils/validatorUtils.js
@@ -89,7 +89,8 @@ const calcSelfStakeReward = async (generatorAddress, reward, commission) => {
 		const selfStakesInfo = stakerInfo.filter(stake => stake.stakerAddress === generatorAddress);
 		const selfStakes = selfStakesInfo.reduce((a, b) => BigInt(a.amount) + BigInt(b.amount));
 		const totalStakes = stakerInfo.reduce((a, b) => BigInt(a.amount) + BigInt(b.amount));
-		selfStakeReward = (reward * (MAX_COMMISSION - commission) * selfStakes) / (totalStakes * MAX_COMMISSION);
+		selfStakeReward = (reward * (MAX_COMMISSION - commission) * selfStakes)
+			/ (totalStakes * MAX_COMMISSION);
 	}
 
 	return selfStakeReward;

--- a/services/blockchain-indexer/shared/utils/validatorUtils.js
+++ b/services/blockchain-indexer/shared/utils/validatorUtils.js
@@ -76,7 +76,7 @@ const calcCommission = async (generatorAddress, reward) => {
 };
 
 // TODO: Verify
-const calcSelfStakeReward = async (generatorAddress, reward) => {
+const calcSelfStakeReward = async (generatorAddress, reward, commission) => {
 	let selfStakeReward = BigInt('0');
 
 	const stakesTable = await getStakesTable();
@@ -87,9 +87,10 @@ const calcSelfStakeReward = async (generatorAddress, reward) => {
 
 	if (stakerInfo.length) {
 		const selfStakesInfo = stakerInfo.filter(stake => stake.stakerAddress === generatorAddress);
+		// TODO: from validator endpoint
 		const selfStakes = selfStakesInfo.reduce((a, b) => BigInt(a.amount) + BigInt(b.amount));
 		const totalStakes = stakerInfo.reduce((a, b) => BigInt(a.amount) + BigInt(b.amount));
-		selfStakeReward = reward * ((selfStakes / totalStakes) * 100);
+		selfStakeReward = reward * (1 - commission) * ((selfStakes / totalStakes) * 100);
 	}
 
 	return selfStakeReward;

--- a/services/gateway/apis/http-version3/swagger/definitions/events.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/events.json
@@ -34,7 +34,10 @@
 						"type": "string",
 						"example": "100000000"
 					},
-					"reduction": 0
+					"reduction": {
+						"type": "integer",
+						"example": 0
+					}
 				}
 			},
 			"topics": {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1380 

### How was it solved?

- [x] The indexing process applies each block sequentially, one at a time
- [x] Indexing process starts indexing blocks in chronological order, starting with the genesis block (Already implemented, verified.)
- [x] The commissions table is updated with validator information for the genesis block at init (available in pos assets - data.validators)
- [x] The stakes table is updated at init with relevant information from the block assets (pos - data.stakers)
- [x] The block indexing process should compute the following values for the block generator and index them in the validators table only if reward !== BigInt('0'):
  - [x] totalCommission
  - [x] totalSelfStakeRewards

### How was it tested?
Local