### PR TITLE
Fix `getDefaultRewardAtHeight` method in connector

### DIFF
--- a/services/blockchain-connector/shared/sdk/dynamicReward.js
+++ b/services/blockchain-connector/shared/sdk/dynamicReward.js
@@ -68,9 +68,7 @@ const getInflationRate = async () => {
 
 const getDefaultRewardAtHeight = async height => {
 	try {
-		// TODO: Update endpoint once exposed by SDK
-		// Ref: https://github.com/LiskHQ/lisk-sdk/issues/7865
-		const defaultRewardResponse = await invokeEndpoint(`${registeredRewardModule}_getDefaultRewardAtHeight`);
+		const defaultRewardResponse = await invokeEndpoint(`${registeredRewardModule}_getDefaultRewardAtHeight`, { height });
 		return defaultRewardResponse;
 	} catch (err) {
 		if (err.message.includes(timeoutMessage)) {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1396 

### How was it solved?

- [x] `getDefaultRewardAtHeight` should return default reward
- [x] Endpoint `api/v3/reward/default`should return response as specified

### How was it tested?
Local