### PR TITLE
Remove rank calculation logic

### DIFF
--- a/services/blockchain-indexer/jobs/dataService/validators.js
+++ b/services/blockchain-indexer/jobs/dataService/validators.js
@@ -22,9 +22,8 @@ const {
 
 module.exports = [
 	{
-		name: 'reload.validators',
-		description: 'Keep the validators list up-to-date',
-		schedule: '*/5 * * * *', // Every 5 min
+		name: 'init.validators',
+		description: 'Initialize validators cache',
 		init: async () => {
 			if (await isPosModuleRegistered()) {
 				logger.debug('Initializing validators cache...');
@@ -33,16 +32,6 @@ module.exports = [
 					logger.info('Successfully initialized validators cache.');
 				} catch (err) {
 					logger.warn(`Initializing validators cache failed due to: ${err.stack}`);
-				}
-			}
-		},
-		controller: async () => {
-			if (await isPosModuleRegistered()) {
-				logger.debug('Reloading validators cache...');
-				try {
-					await reloadValidatorCache();
-				} catch (err) {
-					logger.warn(`Reloading validators cache failed due to: ${err.message}`);
 				}
 			}
 		},

--- a/services/blockchain-indexer/shared/dataService/business/pos/validators.js
+++ b/services/blockchain-indexer/shared/dataService/business/pos/validators.js
@@ -62,10 +62,11 @@ const getPosValidators = async (params) => {
 };
 
 const getAllPosValidators = async () => {
-	const { validators: rawValidators } = await requestConnector('getAllPosValidators');
+	const { validators: rawValidators } = await requestConnector('getPosValidatorsByStake', { limit: -1 });
 	const validators = await BluebirdPromise.map(
 		rawValidators,
-		async validator => {
+		async (validator, index) => {
+			validator.rank = index + 1;
 			// TODO: Get validatorWeight from SDK directly when available
 			if (validator.isBanned || await verifyIfPunished(validator)) {
 				validator.validatorWeight = BigInt('0');

--- a/services/blockchain-indexer/shared/dataService/business/pos/validators.js
+++ b/services/blockchain-indexer/shared/dataService/business/pos/validators.js
@@ -61,6 +61,7 @@ const getPosValidators = async (params) => {
 	return validators;
 };
 
+// TODO: Test the implementation after the issue https://github.com/LiskHQ/lisk-sdk/issues/8057 is fixed
 const getAllPosValidators = async () => {
 	const { validators: rawValidators } = await requestConnector('getPosValidatorsByStake', { limit: -1 });
 	const validators = await BluebirdPromise.map(


### PR DESCRIPTION
### What was the problem?
This PR resolves #1439 

### How was it solved?
- [x] Use the `pos_getValidatorsByStake` endpoint from SDK to retrieve all validators
- [x] Validator rank is assigned based on their index in the response from `pos_getValidatorsByStake`
- [x] The rank computation logic is removed

### How was it tested?
Test is blocked by the issue https://github.com/LiskHQ/lisk-sdk/issues/8057