### PR TITLE
Update totalLocked on block delete

### DIFF
--- a/services/blockchain-connector/shared/sdk/network.js
+++ b/services/blockchain-connector/shared/sdk/network.js
@@ -39,6 +39,11 @@ const refreshNetworkStatus = async () => {
 			logger.warn(`Error occurred while refreshing network status:\n${err.stack}`);
 		}
 	};
+
+	if (!networkStatus) {
+		await refreshNetworkStatusListener();
+	}
+
 	Signals.get('chainNewBlock').add(refreshNetworkStatusListener);
 };
 

--- a/services/blockchain-indexer/shared/constants.js
+++ b/services/blockchain-indexer/shared/constants.js
@@ -23,7 +23,7 @@ let systemMetadata;
 let finalizedHeight;
 
 const updateFinalizedHeight = async () => {
-	const { finalizedHeight: latestFinalizedHeight = {} } = await requestConnector('getNetworkStatus');
+	const { finalizedHeight: latestFinalizedHeight } = await requestConnector('getNetworkStatus') || {};
 	finalizedHeight = latestFinalizedHeight;
 };
 

--- a/services/blockchain-indexer/shared/constants.js
+++ b/services/blockchain-indexer/shared/constants.js
@@ -23,7 +23,7 @@ let systemMetadata;
 let finalizedHeight;
 
 const updateFinalizedHeight = async () => {
-	const { finalizedHeight: latestFinalizedHeight } = await requestConnector('getNetworkStatus') || {};
+	const { finalizedHeight: latestFinalizedHeight } = await requestConnector('getNetworkStatus');
 	finalizedHeight = latestFinalizedHeight;
 };
 

--- a/services/blockchain-indexer/shared/constants.js
+++ b/services/blockchain-indexer/shared/constants.js
@@ -23,7 +23,7 @@ let systemMetadata;
 let finalizedHeight;
 
 const updateFinalizedHeight = async () => {
-	const { finalizedHeight: latestFinalizedHeight } = await requestConnector('getNetworkStatus');
+	const { finalizedHeight: latestFinalizedHeight = {} } = await requestConnector('getNetworkStatus');
 	finalizedHeight = latestFinalizedHeight;
 };
 

--- a/services/blockchain-indexer/shared/dataService/business/events.js
+++ b/services/blockchain-indexer/shared/dataService/business/events.js
@@ -79,6 +79,8 @@ const getEventsByHeight = async (height) => {
 	return eventsFromNode;
 };
 
+const deleteEventsFromCache = async (height) => eventCache.delete(height);
+
 const getEvents = async (params) => {
 	const blocksTable = await getBlocksTable();
 	const eventsTable = await getEventsTable();
@@ -186,4 +188,5 @@ const getEvents = async (params) => {
 module.exports = {
 	getEvents,
 	getEventsByHeight,
+	deleteEventsFromCache,
 };

--- a/services/blockchain-indexer/shared/dataService/business/events.js
+++ b/services/blockchain-indexer/shared/dataService/business/events.js
@@ -53,12 +53,12 @@ const getEventTopicsTable = () => getTableInstance(
 
 const eventCache = CacheLRU('events');
 
-const getEventsByHeight = async (height) => {
+const getEventsByHeightFromNode = async (height) => {
 	const events = await requestConnector('getEventsByHeight', { height });
 	return parseToJSONCompatObj(events);
 };
 
-const getEventsFromCache = async (height) => {
+const getEventsByHeight = async (height) => {
 	// Get from cache
 	const cachedEvents = await eventCache.get(height);
 	if (cachedEvents) return JSON.parse(cachedEvents);
@@ -74,7 +74,7 @@ const getEventsFromCache = async (height) => {
 	}
 
 	// Get from node
-	const eventsFromNode = await getEventsByHeight(height);
+	const eventsFromNode = await getEventsByHeightFromNode(height);
 	await eventCache.set(height, JSON.stringify(eventsFromNode));
 	return eventsFromNode;
 };
@@ -158,7 +158,7 @@ const getEvents = async (params) => {
 				if (eventStr) event = JSON.parse(eventStr);
 			}
 			if (!event) {
-				const eventsFromCache = await getEventsFromCache(height);
+				const eventsFromCache = await getEventsByHeight(height);
 				event = eventsFromCache.find(entry => entry.index === index);
 			}
 
@@ -186,5 +186,4 @@ const getEvents = async (params) => {
 module.exports = {
 	getEvents,
 	getEventsByHeight,
-	getEventsFromCache,
 };

--- a/services/blockchain-indexer/shared/dataService/business/events.js
+++ b/services/blockchain-indexer/shared/dataService/business/events.js
@@ -60,10 +60,10 @@ const getEventsByHeight = async (height) => {
 
 const getEventsFromCache = async (height) => {
 	// Get from cache
-	const cacheEvents = await eventCache.get(height);
-	if (cacheEvents) return JSON.parse(cacheEvents);
+	const cachedEvents = await eventCache.get(height);
+	if (cachedEvents) return JSON.parse(cachedEvents);
 
-	// Get from db
+	// Get from DB
 	const eventsTable = await getEventsTable();
 	const dbEventStrs = await eventsTable.find({ height }, ['eventStr']);
 

--- a/services/blockchain-indexer/shared/dataService/business/index.js
+++ b/services/blockchain-indexer/shared/dataService/business/index.js
@@ -82,7 +82,11 @@ const { getSchemas } = require('./schemas');
 const { getAuthAccountInfo } = require('./auth');
 const { getLegacyAccountInfo } = require('./legacy');
 const { postTransactions } = require('./postTransactions');
-const { getEvents, getEventsByHeight } = require('./events');
+const {
+	getEvents,
+	getEventsByHeight,
+	deleteEventsFromCache,
+} = require('./events');
 const { dryRunTransactions } = require('./transactionsDryRun');
 const { getValidator, validateBLSKey } = require('./validator');
 
@@ -115,6 +119,7 @@ module.exports = {
 	// Events
 	getEvents,
 	getEventsByHeight,
+	deleteEventsFromCache,
 
 	// Interoperability
 	getBlockchainApps,

--- a/services/blockchain-indexer/shared/dataService/index.js
+++ b/services/blockchain-indexer/shared/dataService/index.js
@@ -26,6 +26,7 @@ const {
 	getTransactionsByIDs,
 	normalizeTransaction,
 	getEventsByHeight,
+	deleteEventsFromCache,
 } = require('./business');
 
 const {
@@ -173,6 +174,7 @@ module.exports = {
 	normalizeTransaction,
 	getPosLockedRewards,
 	getEventsByHeight,
+	deleteEventsFromCache,
 
 	getAnnualInflation,
 	getDefaultRewardAtHeight,

--- a/services/blockchain-indexer/shared/database/schema/eventTopics.js
+++ b/services/blockchain-indexer/shared/database/schema/eventTopics.js
@@ -26,6 +26,7 @@ module.exports = {
 	},
 	indexes: {
 		topic: { type: 'key' },
+		height: {},
 	},
 	purge: {},
 };

--- a/services/blockchain-indexer/shared/database/schema/events.js
+++ b/services/blockchain-indexer/shared/database/schema/events.js
@@ -24,6 +24,8 @@ module.exports = {
 		index: { type: 'integer' },
 		eventStr: { type: 'text' },
 	},
-	indexes: {},
+	indexes: {
+		height: {},
+	},
 	purge: {},
 };

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -44,7 +44,7 @@ const {
 
 const { getLisk32AddressFromPublicKey, updateAccountPublicKey } = require('../utils/accountUtils');
 const { normalizeTransaction } = require('../utils/transactionsUtils');
-const { getEventsInfoToIndex, deleteEventsTillBlockHeight } = require('../utils/eventsUtils');
+const { getEventsInfoToIndex, deleteEventsTillHeight } = require('../utils/eventsUtils');
 const { calcCommission, calcSelfStakeReward } = require('../utils/validatorUtils');
 
 const {
@@ -238,10 +238,10 @@ const indexBlock = async job => {
 			await updateTotalLockedAmounts(tokenIDLockedAmountChangeMap, dbTrx);
 		}
 
-		// Delete events of finalized blocks unless required to persist
+		// Delete events of finalized blocks when persistence is disabled
 		if (!config.db.isPersistEvents) {
 			const finalizedBlockHeight = await getFinalizedHeight();
-			await deleteEventsTillBlockHeight(finalizedBlockHeight, dbTrx);
+			await deleteEventsTillHeight(finalizedBlockHeight, dbTrx);
 		}
 
 		const blockToIndex = {
@@ -329,7 +329,7 @@ const deleteIndexedBlocks = async job => {
 						const { data: eventData } = event;
 						// Initialize map entry with BigInt
 						if ([EVENT_NAME.LOCK, EVENT_NAME.UNLOCK].includes(event.name)
-						&& !(eventData.tokenID in tokenIDLockedAmountChangeMap)) {
+							&& !(eventData.tokenID in tokenIDLockedAmountChangeMap)) {
 							tokenIDLockedAmountChangeMap[eventData.tokenID] = BigInt(0);
 						}
 

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -122,8 +122,6 @@ const getTransactionExecutionStatus = (tx, events) => {
 const updateTotalLockedAmounts = (tokenIDLockedAmountChangeMap, dbTrx) => BluebirdPromise.map(
 	Object.entries(tokenIDLockedAmountChangeMap),
 	async ([tokenID, lockedAmountChange]) => {
-		if (lockedAmountChange === BigInt(0)) return;
-
 		const tokenKey = KV_STORE_KEY.PREFIX.TOTAL_LOCKED.concat(tokenID);
 		const curLockedAmount = BigInt(await keyValueTable.get(tokenKey) || 0);
 		const newLockedAmount = curLockedAmount + lockedAmountChange;
@@ -335,7 +333,7 @@ const deleteIndexedBlocks = async job => {
 							tokenIDLockedAmountChangeMap[eventData.tokenID] = BigInt(0);
 						}
 
-						// Negate amount to reverse the affect
+						// Negate amount to reverse the effect
 						if (event.name === EVENT_NAME.LOCK) {
 							tokenIDLockedAmountChangeMap[eventData.tokenID] -= BigInt(eventData.amount);
 						} else if (event.name === EVENT_NAME.UNLOCK) {

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -35,6 +35,7 @@ const {
 	getTransactionIDsByBlockID,
 	getTransactions,
 	getEventsByHeight,
+	deleteEventsFromCache,
 } = require('../dataService');
 
 const {
@@ -319,6 +320,9 @@ const deleteIndexedBlocks = async job => {
 				}
 				await transactionsTable.deleteByPrimaryKey(forkedTransactionIDs, dbTrx);
 				Signals.get('deleteTransactions').dispatch({ data: forkedTransactions });
+
+				// Invalidate cached events of this block
+				await deleteEventsFromCache(block.height);
 
 				const events = await getEventsByHeight(block.height);
 				if (events.length) {

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -221,7 +221,6 @@ const indexBlock = async job => {
 				}
 			}
 
-			// TODO: Verify and enable it once pos:validatorStaked schema is exposed from SDK
 			// Calculate locked amount change and update in key_value_store table for affected tokens
 			const tokenIDLockedAmountChangeMap = {};
 			events.forEach(event => {

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -97,7 +97,6 @@ const getValidatorsTable = () => getTableInstance(
 );
 
 const { KV_STORE_KEY } = require('../constants');
-const { getEventsFromCache } = require('../dataService/business/events');
 
 const EVENT_NAME = Object.freeze({
 	LOCK: 'lock',
@@ -321,7 +320,7 @@ const deleteIndexedBlocks = async job => {
 				await transactionsTable.deleteByPrimaryKey(forkedTransactionIDs, dbTrx);
 				Signals.get('deleteTransactions').dispatch({ data: forkedTransactions });
 
-				const events = await getEventsFromCache(block.height);
+				const events = await getEventsByHeight(block.height);
 				if (events.length) {
 				// Calculate locked amount change and update in key_value_store table for affected tokens
 					const tokenIDLockedAmountChangeMap = {};

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -384,6 +384,8 @@ const indexNewBlock = async block => {
 	logger.info(`Indexing new block: ${block.id} at height ${block.height}`);
 
 	const [blockInfo] = await blocksTable.find({ height: block.height, limit: 1 }, ['id', 'isFinal']);
+	// Schedule indexing of incoming block if it is not indexed before
+	// Or the indexed block is not final yet (chain fork)
 	if (!blockInfo || !blockInfo.isFinal) {
 		// Index if doesn't exist, or update if it isn't set to final
 		await indexBlocksQueue.add({ block });

--- a/services/blockchain-indexer/shared/utils/eventsUtils.js
+++ b/services/blockchain-indexer/shared/utils/eventsUtils.js
@@ -75,7 +75,7 @@ const getEventsInfoToIndex = async (block, events) => {
 };
 
 const deleteEventsTillBlockHeight = async (blockHeight, dbTrx) => {
-	if (blockHeight === undefined || Number.isNaN(blockHeight)) return;
+	if (Number.isNaN(Number(blockHeight))) return;
 
 	const eventsTable = await getEventsTable();
 	const eventTopicsTable = await getEventTopicsTable();

--- a/services/blockchain-indexer/shared/utils/eventsUtils.js
+++ b/services/blockchain-indexer/shared/utils/eventsUtils.js
@@ -75,8 +75,6 @@ const getEventsInfoToIndex = async (block, events) => {
 };
 
 const deleteEventsTillBlockHeight = async (blockHeight, dbTrx) => {
-	if (Number.isNaN(Number(blockHeight))) return;
-
 	const eventsTable = await getEventsTable();
 	const eventTopicsTable = await getEventTopicsTable();
 	const queryParams = {

--- a/services/blockchain-indexer/shared/utils/eventsUtils.js
+++ b/services/blockchain-indexer/shared/utils/eventsUtils.js
@@ -52,6 +52,8 @@ const getEventsInfoToIndex = async (block, events) => {
 			index: event.index,
 		};
 
+		// Store whole event when persistence is enabled or block is not finalized yet
+		// Storing events of non-finalized blocks is required to fetch events of dropped blocks
 		if (!block.isFinal || config.db.isPersistEvents) {
 			eventInfo.eventStr = JSON.stringify(event);
 		}

--- a/services/blockchain-indexer/shared/utils/eventsUtils.js
+++ b/services/blockchain-indexer/shared/utils/eventsUtils.js
@@ -84,7 +84,6 @@ const deleteEventsTillBlockHeight = async (blockHeight, dbTrx) => {
 			property: 'height',
 			lowerThan: blockHeight + 1,
 		}],
-		limit: 1000,
 	};
 	await eventTopicsTable.delete(queryParams, dbTrx);
 	await eventsTable.delete(queryParams, dbTrx);

--- a/services/blockchain-indexer/shared/utils/eventsUtils.js
+++ b/services/blockchain-indexer/shared/utils/eventsUtils.js
@@ -53,7 +53,7 @@ const getEventsInfoToIndex = async (block, events) => {
 		};
 
 		// Store whole event when persistence is enabled or block is not finalized yet
-		// Storing events of non-finalized blocks is required to fetch events of dropped blocks
+		// Storing event of non-finalized block is required to fetch events of a dropped block
 		if (!block.isFinal || config.db.isPersistEvents) {
 			eventInfo.eventStr = JSON.stringify(event);
 		}

--- a/services/blockchain-indexer/shared/utils/eventsUtils.js
+++ b/services/blockchain-indexer/shared/utils/eventsUtils.js
@@ -74,7 +74,7 @@ const getEventsInfoToIndex = async (block, events) => {
 	return eventsInfoToIndex;
 };
 
-const deleteEventsTillBlockHeight = async (blockHeight, dbTrx) => {
+const deleteEventsTillHeight = async (blockHeight, dbTrx) => {
 	const eventsTable = await getEventsTable();
 	const eventTopicsTable = await getEventTopicsTable();
 	const queryParams = {
@@ -90,5 +90,5 @@ const deleteEventsTillBlockHeight = async (blockHeight, dbTrx) => {
 
 module.exports = {
 	getEventsInfoToIndex,
-	deleteEventsTillBlockHeight,
+	deleteEventsTillHeight,
 };

--- a/services/blockchain-indexer/shared/utils/eventsUtils.js
+++ b/services/blockchain-indexer/shared/utils/eventsUtils.js
@@ -82,7 +82,7 @@ const deleteEventsTillBlockHeight = async (blockHeight, dbTrx) => {
 	const queryParams = {
 		propBetweens: [{
 			property: 'height',
-			lowerThan: blockHeight + 1,
+			to: blockHeight,
 		}],
 		limit: 10000,
 	};

--- a/services/blockchain-indexer/shared/utils/eventsUtils.js
+++ b/services/blockchain-indexer/shared/utils/eventsUtils.js
@@ -84,6 +84,7 @@ const deleteEventsTillBlockHeight = async (blockHeight, dbTrx) => {
 			property: 'height',
 			lowerThan: blockHeight + 1,
 		}],
+		limit: 10000,
 	};
 	await eventTopicsTable.delete(queryParams, dbTrx);
 	await eventsTable.delete(queryParams, dbTrx);

--- a/services/blockchain-indexer/shared/utils/eventsUtils.js
+++ b/services/blockchain-indexer/shared/utils/eventsUtils.js
@@ -75,6 +75,8 @@ const getEventsInfoToIndex = async (block, events) => {
 };
 
 const deleteEventsTillBlockHeight = async (blockHeight, dbTrx) => {
+	if (blockHeight === undefined || Number.isNaN(blockHeight)) return;
+
 	const eventsTable = await getEventsTable();
 	const eventTopicsTable = await getEventTopicsTable();
 	const queryParams = {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1440 

### How was it solved?

- [x] Cache events corresponding the non-final blocks within the indexer
- [x] Consider storing all the events for the non-final blocks in MySQL (no matter the value for config.db.isPersistEvents) and delete them once the blocks are finalized based on the config.db.isPersistEvents value
- [x] Introduce a new method: getCachedEventsByBlockID that reads and serves the information from the cache in indexer
- [x] Implement the necessary changes for totalLocked within the delete block event handler in indexer

### How was it tested?
- [x] Local