### PR TITLE
Unable to index the registerMainchain transaction

### DIFF
--- a/services/blockchain-connector/methods/interoperability.js
+++ b/services/blockchain-connector/methods/interoperability.js
@@ -30,7 +30,7 @@ module.exports = [
 	},
 	{
 		name: 'getMainchainID',
-		controller: async ({ chainID }) => getMainchainID(chainID),
+		controller: async () => getMainchainID(),
 		params: {
 			chainID: { optional: false, type: 'string', pattern: regex.CHAIN_ID },
 		},

--- a/services/blockchain-connector/methods/interoperability.js
+++ b/services/blockchain-connector/methods/interoperability.js
@@ -15,6 +15,7 @@
  */
 const {
 	getChainAccount,
+	getMainchainID,
 } = require('../shared/sdk');
 
 const regex = require('../shared/utils/regex');
@@ -23,6 +24,13 @@ module.exports = [
 	{
 		name: 'getChainAccount',
 		controller: async ({ chainID }) => getChainAccount(chainID),
+		params: {
+			chainID: { optional: false, type: 'string', pattern: regex.CHAIN_ID },
+		},
+	},
+	{
+		name: 'getMainchainID',
+		controller: async ({ chainID }) => getMainchainID(chainID),
 		params: {
 			chainID: { optional: false, type: 'string', pattern: regex.CHAIN_ID },
 		},

--- a/services/blockchain-connector/methods/interoperability.js
+++ b/services/blockchain-connector/methods/interoperability.js
@@ -31,8 +31,6 @@ module.exports = [
 	{
 		name: 'getMainchainID',
 		controller: async () => getMainchainID(),
-		params: {
-			chainID: { optional: false, type: 'string', pattern: regex.CHAIN_ID },
-		},
+		params: {},
 	},
 ];

--- a/services/blockchain-connector/shared/sdk/index.js
+++ b/services/blockchain-connector/shared/sdk/index.js
@@ -98,6 +98,7 @@ const {
 
 const {
 	getChainAccount,
+	getMainchainID,
 } = require('./interoperability');
 
 const { getLegacyAccount } = require('./legacy');
@@ -198,6 +199,7 @@ module.exports = {
 
 	// Interoperability
 	getChainAccount,
+	getMainchainID,
 
 	// Legacy
 	getLegacyAccount,

--- a/services/blockchain-connector/shared/sdk/interoperability.js
+++ b/services/blockchain-connector/shared/sdk/interoperability.js
@@ -50,7 +50,7 @@ const getMainchainID = async () => {
 		if (err.message.includes(timeoutMessage)) {
 			throw new TimeoutException('Request timed out when calling \'getMainchainID\'.');
 		}
-		logger.warn(`Error returned when invoking 'interoperability_getMainchainID' with chainID: ${chainID}.\n${err.stack}`);
+		logger.warn(`Error returned when invoking 'interoperability_getMainchainID'.\n${err.stack}`);
 		throw err;
 	}
 };

--- a/services/blockchain-connector/shared/sdk/interoperability.js
+++ b/services/blockchain-connector/shared/sdk/interoperability.js
@@ -46,6 +46,24 @@ const getChainAccount = async (chainID) => {
 	}
 };
 
+const getMainchainID = async (chainID) => {
+	try {
+		// TODO: Remove this and use SDK endpoint once following issue is closed: https://github.com/LiskHQ/lisk-sdk/issues/8309
+		const LENGTH_CHAIN_ID = 4 * 2; // Each byte is represented with 2 nibbles
+		const mainchainID = chainID.substring(0, 2).padEnd(LENGTH_CHAIN_ID, '0');
+
+		// const mainchainID = await invokeEndpoint('interoperability_getMainchainID', { chainID });
+		return mainchainID;
+	} catch (err) {
+		if (err.message.includes(timeoutMessage)) {
+			throw new TimeoutException('Request timed out when calling \'getMainchainID\'.');
+		}
+		logger.warn(`Error returned when invoking 'interoperability_getMainchainID' with chainID: ${chainID}.\n${err.stack}`);
+		throw err;
+	}
+};
+
 module.exports = {
 	getChainAccount,
+	getMainchainID,
 };

--- a/services/blockchain-connector/shared/sdk/interoperability.js
+++ b/services/blockchain-connector/shared/sdk/interoperability.js
@@ -19,23 +19,12 @@ const {
 } = require('lisk-service-framework');
 
 const { timeoutMessage, invokeEndpoint } = require('./client');
-const regex = require('../utils/regex');
 
 const logger = Logger();
 
 const getChainAccount = async (chainID) => {
 	try {
 		const chainAccount = await invokeEndpoint('interoperability_getChainAccount', { chainID });
-
-		if (chainAccount.error
-			&& regex.KEY_NOT_EXIST.test(chainAccount.error.message)) {
-			return {
-				lastCertificate: {},
-				name: null,
-				status: null,
-			};
-		}
-
 		return chainAccount;
 	} catch (err) {
 		if (err.message.includes(timeoutMessage)) {

--- a/services/blockchain-connector/shared/sdk/interoperability.js
+++ b/services/blockchain-connector/shared/sdk/interoperability.js
@@ -23,6 +23,8 @@ const { getNodeInfo } = require('./endpoints_1');
 
 const logger = Logger();
 
+let mainchainID;
+
 const getChainAccount = async (chainID) => {
 	try {
 		const chainAccount = await invokeEndpoint('interoperability_getChainAccount', { chainID });
@@ -38,12 +40,14 @@ const getChainAccount = async (chainID) => {
 
 const getMainchainID = async () => {
 	try {
-		// const mainchainID = await invokeEndpoint('interoperability_getMainchainID', { chainID });
+		if (!mainchainID) {
+			// const mainchainID = await invokeEndpoint('interoperability_getMainchainID', { chainID });
 
-		// TODO: Remove this and use SDK endpoint once following issue is closed: https://github.com/LiskHQ/lisk-sdk/issues/8309
-		const { chainID } = await getNodeInfo();
-		const LENGTH_CHAIN_ID = 4 * 2; // Each byte is represented with 2 nibbles
-		const mainchainID = chainID.substring(0, 2).padEnd(LENGTH_CHAIN_ID, '0');
+			// TODO: Remove this and use SDK endpoint once following issue is closed: https://github.com/LiskHQ/lisk-sdk/issues/8309
+			const { chainID } = await getNodeInfo();
+			const LENGTH_CHAIN_ID = 4 * 2; // Each byte is represented with 2 nibbles
+			mainchainID = chainID.substring(0, 2).padEnd(LENGTH_CHAIN_ID, '0');
+		}
 
 		return mainchainID;
 	} catch (err) {

--- a/services/blockchain-connector/shared/sdk/interoperability.js
+++ b/services/blockchain-connector/shared/sdk/interoperability.js
@@ -19,6 +19,7 @@ const {
 } = require('lisk-service-framework');
 
 const { timeoutMessage, invokeEndpoint } = require('./client');
+const { getNodeInfo } = require('./endpoints_1');
 
 const logger = Logger();
 
@@ -35,13 +36,15 @@ const getChainAccount = async (chainID) => {
 	}
 };
 
-const getMainchainID = async (chainID) => {
+const getMainchainID = async () => {
 	try {
+		// const mainchainID = await invokeEndpoint('interoperability_getMainchainID', { chainID });
+
 		// TODO: Remove this and use SDK endpoint once following issue is closed: https://github.com/LiskHQ/lisk-sdk/issues/8309
+		const { chainID } = await getNodeInfo();
 		const LENGTH_CHAIN_ID = 4 * 2; // Each byte is represented with 2 nibbles
 		const mainchainID = chainID.substring(0, 2).padEnd(LENGTH_CHAIN_ID, '0');
 
-		// const mainchainID = await invokeEndpoint('interoperability_getMainchainID', { chainID });
 		return mainchainID;
 	} catch (err) {
 		if (err.message.includes(timeoutMessage)) {

--- a/services/blockchain-connector/shared/sdk/interoperability.js
+++ b/services/blockchain-connector/shared/sdk/interoperability.js
@@ -41,7 +41,7 @@ const getChainAccount = async (chainID) => {
 const getMainchainID = async () => {
 	try {
 		if (!mainchainID) {
-			// const mainchainID = await invokeEndpoint('interoperability_getMainchainID', { chainID });
+			// const mainchainID = await invokeEndpoint('interoperability_getMainchainID');
 
 			// TODO: Remove this and use SDK endpoint once following issue is closed: https://github.com/LiskHQ/lisk-sdk/issues/8309
 			const { chainID } = await getNodeInfo();

--- a/services/blockchain-connector/shared/sdk/pos.js
+++ b/services/blockchain-connector/shared/sdk/pos.js
@@ -21,6 +21,7 @@ const {
 const { timeoutMessage, invokeEndpoint } = require('./client');
 const { MODULE_NAME_POS } = require('./constants/names');
 const { getBlockByHeight } = require('./endpoints');
+const regex = require('../utils/regex');
 
 const logger = Logger();
 
@@ -93,6 +94,14 @@ const getPosPendingUnlocks = async (address) => {
 const getStaker = async (address) => {
 	try {
 		const staker = await invokeEndpoint('pos_getStaker', { address });
+
+		if (staker.error && regex.KEY_NOT_EXIST.test(staker.error.message)) {
+			return {
+				stakes: [],
+				pendingUnlocks: [],
+			};
+		}
+
 		return staker;
 	} catch (err) {
 		if (err.message.includes(timeoutMessage)) {

--- a/services/blockchain-connector/shared/sdk/pos.js
+++ b/services/blockchain-connector/shared/sdk/pos.js
@@ -21,7 +21,6 @@ const {
 const { timeoutMessage, invokeEndpoint } = require('./client');
 const { MODULE_NAME_POS } = require('./constants/names');
 const { getBlockByHeight } = require('./endpoints');
-const regex = require('../utils/regex');
 
 const logger = Logger();
 
@@ -94,14 +93,6 @@ const getPosPendingUnlocks = async (address) => {
 const getStaker = async (address) => {
 	try {
 		const staker = await invokeEndpoint('pos_getStaker', { address });
-
-		if (staker.error && regex.KEY_NOT_EXIST.test(staker.error.message)) {
-			return {
-				stakes: [],
-				pendingUnlocks: [],
-			};
-		}
-
 		return staker;
 	} catch (err) {
 		if (err.message.includes(timeoutMessage)) {

--- a/services/blockchain-connector/shared/utils/regex.js
+++ b/services/blockchain-connector/shared/utils/regex.js
@@ -16,9 +16,11 @@
 const BLS_KEY = /^\b[a-fA-F0-9]{96}\b$/;
 const CHAIN_ID = /^\b[a-fA-F0-9]{8}\b$/;
 const PROOF_OF_POSSESSION = /^\b[a-fA-F0-9]{192}\b$/;
+const KEY_NOT_EXIST = /^Key [a-f0-9]+ does not exist\.$/;
 
 module.exports = {
 	BLS_KEY,
 	CHAIN_ID,
 	PROOF_OF_POSSESSION,
+	KEY_NOT_EXIST,
 };

--- a/services/blockchain-connector/shared/utils/regex.js
+++ b/services/blockchain-connector/shared/utils/regex.js
@@ -16,11 +16,9 @@
 const BLS_KEY = /^\b[a-fA-F0-9]{96}\b$/;
 const CHAIN_ID = /^\b[a-fA-F0-9]{8}\b$/;
 const PROOF_OF_POSSESSION = /^\b[a-fA-F0-9]{192}\b$/;
-const KEY_NOT_EXIST = /^Key [a-f0-9]+ does not exist\.$/;
 
 module.exports = {
 	BLS_KEY,
 	CHAIN_ID,
 	PROOF_OF_POSSESSION,
-	KEY_NOT_EXIST,
 };

--- a/services/blockchain-indexer/shared/dataService/business/index.js
+++ b/services/blockchain-indexer/shared/dataService/business/index.js
@@ -50,6 +50,7 @@ const {
 	getBlockchainApps,
 	getBlockchainAppsStatistics,
 	getChainAccount,
+	getMainchainID,
 	reloadBlockchainAppsStats,
 } = require('./interoperability');
 
@@ -125,6 +126,7 @@ module.exports = {
 	// Interoperability
 	getBlockchainApps,
 	getChainAccount,
+	getMainchainID,
 	getBlockchainAppsStatistics,
 	reloadBlockchainAppsStats,
 

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/index.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/index.js
@@ -15,11 +15,13 @@
  */
 const { getBlockchainApps } = require('./blockchainApps');
 const { getChainAccount } = require('./chainAccount');
+const { getMainchainID } = require('./mainchain');
 const { getBlockchainAppsStatistics, reloadBlockchainAppsStats } = require('./blockchainAppsStats');
 
 module.exports = {
 	getBlockchainApps,
 	getChainAccount,
+	getMainchainID,
 	getBlockchainAppsStatistics,
 	reloadBlockchainAppsStats,
 };

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/mainchain.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/mainchain.js
@@ -1,6 +1,6 @@
 /*
  * LiskHQ/lisk-service
- * Copyright © 2022 Lisk Foundation
+ * Copyright © 2023 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -13,15 +13,14 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { getBlockchainApps } = require('./blockchainApps');
-const { getChainAccount } = require('./chainAccount');
-const { getMainchainID } = require('./mainchain');
-const { getBlockchainAppsStatistics, reloadBlockchainAppsStats } = require('./blockchainAppsStats');
+
+const { requestConnector } = require('../../../utils/request');
+
+const getMainchainID = async params => {
+	const response = await requestConnector('getMainchainID', { chainID: params.chainID });
+	return response;
+};
 
 module.exports = {
-	getBlockchainApps,
-	getBlockchainAppsStatistics,
-	getChainAccount,
 	getMainchainID,
-	reloadBlockchainAppsStats,
 };

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/mainchain.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/mainchain.js
@@ -16,8 +16,8 @@
 
 const { requestConnector } = require('../../../utils/request');
 
-const getMainchainID = async params => {
-	const response = await requestConnector('getMainchainID', { chainID: params.chainID });
+const getMainchainID = async () => {
+	const response = await requestConnector('getMainchainID');
 	return response;
 };
 

--- a/services/blockchain-indexer/shared/dataService/index.js
+++ b/services/blockchain-indexer/shared/dataService/index.js
@@ -82,6 +82,7 @@ const {
 	getBlockchainApps,
 	getBlockchainAppsStatistics,
 	getChainAccount,
+	getMainchainID,
 	reloadBlockchainAppsStats,
 } = require('./interoperability');
 
@@ -136,6 +137,7 @@ module.exports = {
 	getBlockchainApps,
 	getBlockchainAppsStatistics,
 	getChainAccount,
+	getMainchainID,
 	reloadBlockchainAppsStats,
 
 	// Events

--- a/services/blockchain-indexer/shared/dataService/interoperability/mainchain.js
+++ b/services/blockchain-indexer/shared/dataService/interoperability/mainchain.js
@@ -1,6 +1,6 @@
 /*
  * LiskHQ/lisk-service
- * Copyright © 2022 Lisk Foundation
+ * Copyright © 2023 Lisk Foundation
  *
  * See the LICENSE file at the top-level directory of this distribution
  * for licensing information.
@@ -13,15 +13,13 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { getBlockchainApps } = require('./blockchainApps');
-const { getChainAccount } = require('./chainAccount');
-const { getMainchainID } = require('./mainchain');
-const { getBlockchainAppsStatistics, reloadBlockchainAppsStats } = require('./blockchainAppsStats');
+const business = require('../business');
+
+const getMainchainID = async params => {
+	const response = await business.getMainchainID(params);
+	return response;
+};
 
 module.exports = {
-	getBlockchainApps,
-	getBlockchainAppsStatistics,
-	getChainAccount,
 	getMainchainID,
-	reloadBlockchainAppsStats,
 };

--- a/services/blockchain-indexer/shared/dataService/interoperability/mainchain.js
+++ b/services/blockchain-indexer/shared/dataService/interoperability/mainchain.js
@@ -15,8 +15,8 @@
  */
 const business = require('../business');
 
-const getMainchainID = async params => {
-	const response = await business.getMainchainID(params);
+const getMainchainID = async () => {
+	const response = await business.getMainchainID();
 	return response;
 };
 

--- a/services/blockchain-indexer/shared/dataService/interoperability/mainchain.js
+++ b/services/blockchain-indexer/shared/dataService/interoperability/mainchain.js
@@ -15,10 +15,7 @@
  */
 const business = require('../business');
 
-const getMainchainID = async () => {
-	const response = await business.getMainchainID();
-	return response;
-};
+const getMainchainID = async () => business.getMainchainID();
 
 module.exports = {
 	getMainchainID,

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerMainchain.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerMainchain.js
@@ -44,8 +44,8 @@ const getChainInfo = async chainID => {
 	const chainStatusInt = chainAccount.status;
 	const chainStatus = CHAIN_STATUS[chainStatusInt];
 	return {
-		chainName: chainAccount.name,
-		chainStatus,
+		name: chainAccount.name,
+		status: chainStatus,
 	};
 };
 
@@ -53,14 +53,14 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 	if (tx.executionStatus !== TRANSACTION_STATUS.SUCCESS) return;
 
 	const blockchainAppsTable = await getBlockchainAppsTable();
-	const mainchainID = await getMainchainID({ chainID: tx.params.ownChainID });
-	const { chainName, chainStatus } = await getChainInfo(mainchainID);
+	const mainchainID = await getMainchainID();
+	const mainchainInfo = await getChainInfo(mainchainID);
 
 	logger.trace(`Indexing mainchain (${mainchainID}) registration information.`);
 	const appInfo = {
 		chainID: mainchainID,
-		name: chainName,
-		status: chainStatus,
+		name: mainchainInfo.name,
+		status: mainchainInfo.status,
 		address: getLisk32AddressFromPublicKey(tx.senderPublicKey),
 		lastUpdated: blockHeader.timestamp,
 		lastCertificateHeight: blockHeader.height,
@@ -75,7 +75,7 @@ const revertTransaction = async (blockHeader, tx, events, dbTrx) => {
 	if (tx.executionStatus !== TRANSACTION_STATUS.SUCCESS) return;
 
 	const blockchainAppsTable = await getBlockchainAppsTable();
-	const mainchainID = await getMainchainID({ chainID: tx.params.ownChainID });
+	const mainchainID = await getMainchainID();
 
 	logger.trace(`Reverting mainchain (${mainchainID}) registration information.`);
 	await blockchainAppsTable.deleteByPrimaryKey(mainchainID, dbTrx);

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerSidechain.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerSidechain.js
@@ -42,13 +42,13 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 	if (tx.executionStatus !== TRANSACTION_STATUS.SUCCESS) return;
 
 	const blockchainAppsTable = await getBlockchainAppsTable();
-	const { chainStatus } = await getChainInfo(tx.params.chainID);
+	const chainInfo = await getChainInfo(tx.params.chainID);
 
 	logger.trace(`Indexing sidechain (${tx.params.chainID}) registration information.`);
 	const appInfo = {
 		chainID: tx.params.chainID,
 		name: tx.params.name,
-		status: chainStatus,
+		status: chainInfo.status,
 		address: getLisk32AddressFromPublicKey(tx.senderPublicKey),
 		lastUpdated: blockHeader.timestamp,
 		lastCertificateHeight: blockHeader.height,

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerSidechain.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerSidechain.js
@@ -27,7 +27,7 @@ const logger = Logger();
 const MYSQL_ENDPOINT = config.endpoints.mysql;
 const blockchainAppsTableSchema = require('../../../database/schema/blockchainApps');
 const { TRANSACTION_STATUS } = require('../../../constants');
-const { getChainStatus } = require('./registerMainchain');
+const { getChainInfo } = require('./registerMainchain');
 
 const getBlockchainAppsTable = () => getTableInstance(
 	blockchainAppsTableSchema.tableName,
@@ -42,7 +42,7 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 	if (tx.executionStatus !== TRANSACTION_STATUS.SUCCESS) return;
 
 	const blockchainAppsTable = await getBlockchainAppsTable();
-	const chainStatus = await getChainStatus(tx.params.chainID);
+	const { chainStatus } = await getChainInfo(tx.params.chainID);
 
 	logger.trace(`Indexing sidechain (${tx.params.chainID}) registration information.`);
 	const appInfo = {

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/submitSidechainCrossChainUpdate.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/submitSidechainCrossChainUpdate.js
@@ -40,13 +40,13 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 	if (tx.executionStatus !== TRANSACTION_STATUS.SUCCESS) return;
 
 	const blockchainAppsTable = await getBlockchainAppsTable();
-	const { chainStatus } = await getChainInfo(tx.params.sendingChainID);
+	const chainInfo = await getChainInfo(tx.params.sendingChainID);
 
 	logger.trace(`Indexing cross chain update transaction ${tx.id} contained in block at height ${tx.height}.`);
 
 	const appInfo = {
 		chainID: tx.params.sendingChainID,
-		status: chainStatus,
+		status: chainInfo.status,
 		address: '',
 		lastUpdated: blockHeader.timestamp,
 		lastCertificateHeight: blockHeader.height,
@@ -63,10 +63,10 @@ const revertTransaction = async (blockHeader, tx, events, dbTrx) => {
 
 	logger.trace(`Reverting cross chain update transaction ${tx.id} contained in block at height ${tx.height}.`);
 
-	const { chainStatus } = await getChainInfo(tx.params.sendingChainID);
+	const chainInfo = await getChainInfo(tx.params.sendingChainID);
 	const appInfo = {
 		chainID: tx.params.sendingChainID,
-		status: chainStatus,
+		status: chainInfo.status,
 		address: '',
 		lastUpdated: blockHeader.timestamp,
 		lastCertificateHeight: blockHeader.height,

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/submitSidechainCrossChainUpdate.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/submitSidechainCrossChainUpdate.js
@@ -25,7 +25,7 @@ const logger = Logger();
 
 const MYSQL_ENDPOINT = config.endpoints.mysql;
 const blockchainAppsTableSchema = require('../../../database/schema/blockchainApps');
-const { getChainStatus } = require('./registerMainchain');
+const { getChainInfo } = require('./registerMainchain');
 
 const getBlockchainAppsTable = () => getTableInstance(
 	blockchainAppsTableSchema.tableName,
@@ -40,7 +40,7 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 	if (tx.executionStatus !== TRANSACTION_STATUS.SUCCESS) return;
 
 	const blockchainAppsTable = await getBlockchainAppsTable();
-	const chainStatus = await getChainStatus(tx.params.sendingChainID);
+	const { chainStatus } = await getChainInfo(tx.params.sendingChainID);
 
 	logger.trace(`Indexing cross chain update transaction ${tx.id} contained in block at height ${tx.height}.`);
 
@@ -63,7 +63,7 @@ const revertTransaction = async (blockHeader, tx, events, dbTrx) => {
 
 	logger.trace(`Reverting cross chain update transaction ${tx.id} contained in block at height ${tx.height}.`);
 
-	const chainStatus = await getChainStatus(tx.params.sendingChainID);
+	const { chainStatus } = await getChainInfo(tx.params.sendingChainID);
 	const appInfo = {
 		chainID: tx.params.sendingChainID,
 		status: chainStatus,

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/terminateSidechainForLiveness.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/terminateSidechainForLiveness.js
@@ -40,12 +40,12 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 	if (tx.executionStatus !== TRANSACTION_STATUS.SUCCESS) return;
 
 	const blockchainAppsTable = await getBlockchainAppsTable();
-	const { chainStatus } = await getChainInfo(tx.params.chainID);
+	const chainInfo = await getChainInfo(tx.params.chainID);
 
 	const { chainID } = tx.params;
 	const appInfo = {
 		chainID,
-		status: chainStatus,
+		status: chainInfo.status,
 	};
 
 	logger.trace(`Updating chain ${chainID} state.`);
@@ -60,10 +60,10 @@ const revertTransaction = async (blockHeader, tx, events, dbTrx) => {
 	const blockchainAppsTable = await getBlockchainAppsTable();
 
 	const { chainID } = tx.params;
-	const { chainStatus } = await getChainInfo(chainID);
+	const chainInfo = await getChainInfo(chainID);
 	const appInfo = {
 		chainID,
-		status: chainStatus,
+		status: chainInfo.status,
 	};
 
 	logger.trace(`Reverting chain ${chainID} state.`);

--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/terminateSidechainForLiveness.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/terminateSidechainForLiveness.js
@@ -24,7 +24,7 @@ const logger = Logger();
 
 const MYSQL_ENDPOINT = config.endpoints.mysql;
 const blockchainAppsTableSchema = require('../../../database/schema/blockchainApps');
-const { getChainStatus } = require('./registerMainchain');
+const { getChainInfo } = require('./registerMainchain');
 
 const getBlockchainAppsTable = () => getTableInstance(
 	blockchainAppsTableSchema.tableName,
@@ -40,7 +40,7 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 	if (tx.executionStatus !== TRANSACTION_STATUS.SUCCESS) return;
 
 	const blockchainAppsTable = await getBlockchainAppsTable();
-	const chainStatus = await getChainStatus(tx.params.chainID);
+	const { chainStatus } = await getChainInfo(tx.params.chainID);
 
 	const { chainID } = tx.params;
 	const appInfo = {
@@ -60,7 +60,7 @@ const revertTransaction = async (blockHeader, tx, events, dbTrx) => {
 	const blockchainAppsTable = await getBlockchainAppsTable();
 
 	const { chainID } = tx.params;
-	const chainStatus = await getChainStatus(chainID);
+	const { chainStatus } = await getChainInfo(chainID);
 	const appInfo = {
 		chainID,
 		status: chainStatus,


### PR DESCRIPTION
### What was the problem?
This PR resolves #1554

### How was it solved?
- [x] Revert the endpoint related changes made in https://github.com/LiskHQ/lisk-service/issues/1535.
- [x] Fetch the mainchainID from the SDK via connector. Temporarily implement a similar logic (https://github.com/LiskHQ/lisk-sdk/blob/v6.0.0-alpha.16/framework/src/modules/interoperability/utils.ts#L386-L390)
- [x] Update the indexing logic for services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/registerMainchain.js
- [x] Fetch the chainAccount by mainchainID and use the status and name to index
- [x] Use a similar approach for the revertTransaction hook as well
### How was it tested?
- [x] Local