### PR TITLE
Fix apk package pinning on Dockerfile

### DIFF
--- a/services/blockchain-connector/Dockerfile
+++ b/services/blockchain-connector/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM node:16-alpine AS builder
 
-RUN apk add --no-cache alpine-sdk=~1.0-r1 python3=~3.10.10-r0 cmake=~3.24.4-r0 && \
+RUN apk add --no-cache alpine-sdk=~1.0 python3=~3.10 cmake=~3.24 && \
     adduser -D builder && \
     mkdir /home/builder/build && \
     chown -R builder:builder /home/builder/

--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -19,7 +19,7 @@ RUN npm ci && \
 
 FROM node:16-alpine
 
-RUN apk add --no-cache curl=~7.88.1-r1 && \
+RUN apk add --no-cache curl=~8.0 && \
     adduser -D lisk
 
 USER lisk


### PR DESCRIPTION
### What was the problem?
This PR resolves #1580 

### How was it solved?
- [x] Updates apk package versions to use fuzzy versioning only against the major/minor versions
- [x] Updates `curl` package version to latest in gateway microservice

### How was it tested?
- make build
- Run against Lisk Core v4.0.0-alpha.19
