### PR TITLE
Add skipDecode support for transaction dryrun endpoint

### DIFF
--- a/services/blockchain-connector/methods/transactions.js
+++ b/services/blockchain-connector/methods/transactions.js
@@ -53,10 +53,12 @@ module.exports = [
 		controller: async ({
 			transaction,
 			skipVerify,
-		}) => dryRunTransaction({ transaction, skipVerify }),
+			skipDecode,
+		}) => dryRunTransaction({ transaction, skipVerify, skipDecode }),
 		params: {
 			transaction: { optional: false, type: 'any' },
 			skipVerify: { optional: true, type: 'boolean', default: false },
+			skipDecode: { optional: true, type: 'boolean', default: false },
 		},
 	},
 ];

--- a/services/blockchain-connector/shared/sdk/transactions.js
+++ b/services/blockchain-connector/shared/sdk/transactions.js
@@ -42,12 +42,14 @@ const getTransactionsFromPoolFormatted = async () => {
 };
 
 const dryRunTransactionWrapper = async (params) => {
-	const { transaction, skipVerify } = params;
+	const { transaction, skipVerify, skipDecode } = params;
 	const encodedTransaction = typeof transaction === 'object'
 		? encodeTransaction(transaction)
 		: transaction;
 
 	const response = await dryRunTransaction({ transaction: encodedTransaction, skipVerify });
+	if (skipDecode) return response;
+
 	response.events = response.events.map(event => formatEvent(event));
 	return response;
 };

--- a/services/blockchain-connector/shared/sdk/transactions.js
+++ b/services/blockchain-connector/shared/sdk/transactions.js
@@ -48,6 +48,7 @@ const dryRunTransactionWrapper = async (params) => {
 		: transaction;
 
 	const response = await dryRunTransaction({ transaction: encodedTransaction, skipVerify });
+
 	if (skipDecode) return response;
 
 	response.events = response.events.map(event => formatEvent(event));

--- a/services/blockchain-indexer/methods/dataService/transactions.js
+++ b/services/blockchain-indexer/methods/dataService/transactions.js
@@ -67,6 +67,7 @@ module.exports = [
 		params: {
 			transaction: { optional: false, type: 'any' },
 			skipVerify: { optional: true, type: 'boolean', default: false },
+			skipDecode: { optional: true, type: 'boolean', default: false },
 		},
 	},
 ];

--- a/services/blockchain-indexer/shared/dataService/business/transactionsDryRun.js
+++ b/services/blockchain-indexer/shared/dataService/business/transactionsDryRun.js
@@ -21,9 +21,9 @@ const dryRunTransactions = async params => {
 		data: [],
 		meta: {},
 	};
-	const { transaction, skipVerify } = params;
+	const { transaction, skipVerify, skipDecode } = params;
 
-	const response = await requestConnector('dryRunTransaction', { transaction, skipVerify });
+	const response = await requestConnector('dryRunTransaction', { transaction, skipVerify, skipDecode });
 
 	dryRunTransactionsRes.data = {
 		...response,

--- a/services/gateway/apis/http-version3/methods/transactionsDryRun.js
+++ b/services/gateway/apis/http-version3/methods/transactionsDryRun.js
@@ -41,6 +41,7 @@ module.exports = {
 			},
 		],
 		skipVerify: { optional: true, type: 'boolean', default: false },
+		skipDecode: { optional: true, type: 'boolean', default: false },
 	},
 	get schema() {
 		const dryRunTransactionSchema = {};

--- a/services/gateway/apis/http-version3/swagger/definitions/transactions.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/transactions.json
@@ -357,6 +357,12 @@
 	"dryrunTransactionParamEnvelope": {
 		"type": "object",
 		"properties": {
+			"skipDecode": {
+				"type": "boolean",
+				"description": "A boolean indicator to skip decoding event data.",
+				"example": "false",
+				"default": false
+			},
 			"skipVerify": {
 				"type": "boolean",
 				"description": "A boolean indicator to skip transaction verification.",

--- a/services/gateway/sources/version3/transactionsDryRun.js
+++ b/services/gateway/sources/version3/transactionsDryRun.js
@@ -19,6 +19,7 @@ module.exports = {
 	params: {
 		transaction: '=',
 		skipVerify: '=,boolean',
+		skipDecode: '=,boolean',
 	},
 	definition: {
 		data: {

--- a/tests/integration/api_v3/http/transactionsDryRun.test.js
+++ b/tests/integration/api_v3/http/transactionsDryRun.test.js
@@ -35,6 +35,7 @@ const {
 
 const {
 	dryrunTransactionSuccessResponseSchema,
+	dryrunTxSuccessSchemaWithSkipDecode,
 	dryrunTransactionInvalidResponseSchema,
 	dryrunTransactionPendingResponseSchema,
 	metaSchema,
@@ -82,6 +83,16 @@ describe('Post dryrun transactions API', () => {
 		expect(response).toMap(goodRequestSchema);
 		expect(response.data).toMap(dryrunTransactionSuccessResponseSchema);
 		expect(response.data.events.length).toBeGreaterThan(0);
+		expect(response.meta).toMap(metaSchema);
+	});
+
+	it('Post dryrun transaction succesfully with skipDecode: true', async () => {
+		const response = await api.post(
+			endpoint,
+			{ transaction: TRANSACTION_ENCODED_VALID, skipDecode: true },
+		);
+		expect(response).toMap(goodRequestSchema);
+		expect(response.data).toMap(dryrunTxSuccessSchemaWithSkipDecode);
 		expect(response.meta).toMap(metaSchema);
 	});
 

--- a/tests/integration/api_v3/rpc/transactionsDryRun.test.js
+++ b/tests/integration/api_v3/rpc/transactionsDryRun.test.js
@@ -38,6 +38,7 @@ const {
 
 const {
 	dryrunTransactionSuccessResponseSchema,
+	dryrunTxSuccessSchemaWithSkipDecode,
 	dryrunTransactionInvalidResponseSchema,
 	dryrunTransactionPendingResponseSchema,
 	metaSchema,
@@ -107,6 +108,21 @@ describe('Method post.transactions.dryrun', () => {
 		expect(result).toMap(goodRequestSchema);
 		expect(result.data).toBeInstanceOf(Object);
 		expect(result.data).toMap(dryrunTransactionSuccessResponseSchema);
+		expect(result.meta).toMap(metaSchema);
+	});
+
+	it('Post dryrun transaction succesfully with skipDecode: true', async () => {
+		const response = await postDryrunTransaction(
+			{
+				transaction: TRANSACTION_ENCODED_VALID, skipDecode: true,
+			},
+		);
+		expect(response).toMap(jsonRpcEnvelopeSchema);
+
+		const { result } = response;
+		expect(result).toMap(goodRequestSchema);
+		expect(result.data).toBeInstanceOf(Object);
+		expect(result.data).toMap(dryrunTxSuccessSchemaWithSkipDecode);
 		expect(result.meta).toMap(metaSchema);
 	});
 

--- a/tests/schemas/api_v3/transactionsDryRun.schema.js
+++ b/tests/schemas/api_v3/transactionsDryRun.schema.js
@@ -35,10 +35,20 @@ const event = {
 	id: Joi.string().pattern(regex.HEX).required(),
 };
 
+const eventSchemaWithSkipDecode = {
+	...event,
+	data: Joi.string().required(),
+};
+
 const dryrunTransactionSuccessResponseSchema = {
 	result: Joi.number().integer().valid(TRANSACTION_VERIFY_RESULT.OK).required(),
 	status: Joi.string().valid(...TRANSACTION_VERIFY_STATUSES).required(),
 	events: Joi.array().items(Joi.object(event).required()).min(1).required(),
+};
+const dryrunTxSuccessSchemaWithSkipDecode = {
+	result: Joi.number().integer().valid(TRANSACTION_VERIFY_RESULT.OK).required(),
+	status: Joi.string().valid(...TRANSACTION_VERIFY_STATUSES).required(),
+	events: Joi.array().items(Joi.object(eventSchemaWithSkipDecode).required()).min(1).required(),
 };
 const dryrunTransactionPendingResponseSchema = {
 	result: Joi.number().integer().valid(TRANSACTION_VERIFY_RESULT.PENDING).required(),
@@ -55,6 +65,9 @@ const dryrunTransactionInvalidResponseSchema = {
 module.exports = {
 	dryrunTransactionSuccessResponseSchema: Joi.object(
 		dryrunTransactionSuccessResponseSchema,
+	).required(),
+	dryrunTxSuccessSchemaWithSkipDecode: Joi.object(
+		dryrunTxSuccessSchemaWithSkipDecode,
 	).required(),
 	dryrunTransactionPendingResponseSchema: Joi.object(
 		dryrunTransactionPendingResponseSchema,

--- a/tests/schemas/api_v3/transactionsDryRun.schema.js
+++ b/tests/schemas/api_v3/transactionsDryRun.schema.js
@@ -45,11 +45,13 @@ const dryrunTransactionSuccessResponseSchema = {
 	status: Joi.string().valid(...TRANSACTION_VERIFY_STATUSES).required(),
 	events: Joi.array().items(Joi.object(event).required()).min(1).required(),
 };
+
 const dryrunTxSuccessSchemaWithSkipDecode = {
 	result: Joi.number().integer().valid(TRANSACTION_VERIFY_RESULT.OK).required(),
 	status: Joi.string().valid(...TRANSACTION_VERIFY_STATUSES).required(),
 	events: Joi.array().items(Joi.object(eventSchemaWithSkipDecode).required()).min(1).required(),
 };
+
 const dryrunTransactionPendingResponseSchema = {
 	result: Joi.number().integer().valid(TRANSACTION_VERIFY_RESULT.PENDING).required(),
 	status: Joi.string().valid(...TRANSACTION_VERIFY_STATUSES).required(),


### PR DESCRIPTION
### What was the problem?
This PR resolves #1572 

### How was it solved?

- [x] The following endpoint is extended to support the skipDecode flag in the request query:
  - [x] HTTP: `POST /transactions/dryrun`
  - [x] RPC: `post.transactions.dryrun`
- [x] Added integration tests
- [x] Update Swagger specs

### How was it tested?
Local