### PR TITLE
Extend the blockchain apps endpoint

### DIFF
--- a/services/blockchain-connector/shared/sdk/events.js
+++ b/services/blockchain-connector/shared/sdk/events.js
@@ -20,6 +20,7 @@ const { Logger, Signals } = require('lisk-service-framework');
 const { getApiClient } = require('./client');
 const { formatEvent } = require('./formatter');
 const { getRegisteredEvents, getEventsByHeight, getNodeInfo } = require('./endpoints');
+const { getEscrowedAmounts } = require('./tokens');
 
 const logger = Logger();
 
@@ -46,7 +47,10 @@ const subscribeToAllRegisteredEvents = async () => {
 			event,
 			async payload => {
 				// Force update nodeInfo cache on new chain events
-				if (event.startsWith('chain_')) await getNodeInfo(true);
+				if (event.startsWith('chain_')) {
+					await getNodeInfo(true);
+					await getEscrowedAmounts(true);
+				}
 
 				logger.debug(`Received event: ${event} with payload:\n${util.inspect(payload)}`);
 				Signals.get(event).dispatch(payload);

--- a/services/blockchain-connector/shared/sdk/tokens.js
+++ b/services/blockchain-connector/shared/sdk/tokens.js
@@ -18,6 +18,8 @@ const { timeoutMessage, invokeEndpoint } = require('./client');
 
 const logger = Logger();
 
+let escrowedAmounts;
+
 const getTokenBalances = async (address) => {
 	try {
 		const balances = await invokeEndpoint('token_getBalances', { address });
@@ -44,9 +46,12 @@ const getTokenBalance = async ({ address, tokenID }) => {
 	}
 };
 
-const getEscrowedAmounts = async () => {
+const getEscrowedAmounts = async (isForceUpdate = false) => {
 	try {
-		return invokeEndpoint('token_getEscrowedAmounts');
+		if (isForceUpdate || !escrowedAmounts) {
+			escrowedAmounts = await invokeEndpoint('token_getEscrowedAmounts');
+		}
+		return escrowedAmounts;
 	} catch (err) {
 		if (err.message.includes(timeoutMessage)) {
 			throw new TimeoutException('Request timed out when calling \'getEscrowedAmounts\'.');

--- a/services/gateway/apis/http-version3/swagger/definitions/blockchainApps.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/blockchainApps.json
@@ -41,6 +41,28 @@
 				"type": "integer",
 				"example": 1616008148,
 				"description": "timestamp"
+			},
+			"escrow": {
+				"type": "array",
+				"required": [
+					"tokenID",
+					"amount"
+				],
+				"items": {
+					"type": "object",
+					"properties": {
+						"tokenID": {
+							"type": "string",
+							"example": "0000000010000000",
+							"description": "The universal token identifier for the escrowed tokens within the Lisk ecosystem."
+						},
+						"amount": {
+							"type": "string",
+							"example": "50000000000",
+							"description": "The escrowed amount."
+						}
+					}
+				}
 			}
 		}
 	},

--- a/services/gateway/sources/version3/mappings/blockchainApp.js
+++ b/services/gateway/sources/version3/mappings/blockchainApp.js
@@ -20,4 +20,8 @@ module.exports = {
 	address: '=,string',
 	lastCertificateHeight: '=,number',
 	lastUpdated: '=,number',
+	escrow: ['escrow', {
+		tokenID: '=,string',
+		amount: '=,string',
+	}],
 };

--- a/tests/schemas/api_v3/blockchainAppsSchema.schema.js
+++ b/tests/schemas/api_v3/blockchainAppsSchema.schema.js
@@ -34,6 +34,11 @@ const blockchainAppsStatsSchema = {
 	currentAnnualInflationRate: Joi.string().required(),
 };
 
+const escrow = {
+	tokenID: Joi.string().pattern(regex.TOKEN_ID).required(),
+	amount: Joi.string().pattern(regex.DIGITS).required(),
+};
+
 const blockchainAppSchema = {
 	name: Joi.string().pattern(regex.NAME).required(),
 	chainID: Joi.number().integer().min(1).required(),
@@ -45,6 +50,7 @@ const blockchainAppSchema = {
 		.positive()
 		.max(getCurrentTimestamp())
 		.required(),
+	escrow: Joi.array().items(escrow).required(),
 };
 
 module.exports = {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1567 

### How was it solved?

- [ ] Extend the blockchain apps endpoint response to include escrow 
  - [ ] The escrow amount is fetched from the token_getEscrowedAmounts endpoint in SDK
  - [ ] The information is cached in the connector and updated with every chain_* event emitted from the node
- [ ] Update gateway
- [ ] Update swagger specs
- [ ] Update integration tests schema

### How was it tested?
Local