### PR TITLE
`address` unavailable in `/blockchain/apps` endpoint response

### DIFF
--- a/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/submitSidechainCrossChainUpdate.js
+++ b/services/blockchain-indexer/shared/indexer/transactionProcessor/interoperability/submitSidechainCrossChainUpdate.js
@@ -47,7 +47,6 @@ const applyTransaction = async (blockHeader, tx, events, dbTrx) => {
 	const appInfo = {
 		chainID: tx.params.sendingChainID,
 		status: chainInfo.status,
-		address: '',
 		lastUpdated: blockHeader.timestamp,
 		lastCertificateHeight: blockHeader.height,
 	};
@@ -67,7 +66,6 @@ const revertTransaction = async (blockHeader, tx, events, dbTrx) => {
 	const appInfo = {
 		chainID: tx.params.sendingChainID,
 		status: chainInfo.status,
-		address: '',
 		lastUpdated: blockHeader.timestamp,
 		lastCertificateHeight: blockHeader.height,
 	};


### PR DESCRIPTION
### What was the problem?
This PR resolves #1582

### How was it solved?
- [x] Removed empty address allocations for CCU updates from indexer

### How was it tested?
1. Ran a mainchain and 2 sidechains following this [documentation](https://github.com/LiskHQ/lisk-sdk/blob/development/examples/interop/README.md).
2. Ran lisk-service with fresh cleaned db against mainchain node.
3. Submitted a transfer transaction from mainchain to sidechain.
4. After a while queried http://localhost:9901/api/v3/blockchain/apps.
5. Without the changes address was "" but with the PR changes address was appearing correctly.
