### PR TITLE
Remove globalTokenID logic from transaction-statistics

### DIFF
--- a/services/blockchain-app-registry/shared/database/schema/token_metadata.js
+++ b/services/blockchain-app-registry/shared/database/schema/token_metadata.js
@@ -17,14 +17,12 @@ module.exports = {
 	tableName: 'token_metadata',
 	primaryKey: ['tokenID'],
 	schema: {
-		chainID: { type: 'string' },
 		chainName: { type: 'string' },
 		network: { type: 'string' },
 		tokenName: { type: 'string' },
 		tokenID: { type: 'string' },
 	},
 	indexes: {
-		chainID: { type: 'key' },
 		chainName: { type: 'key' },
 		tokenName: { type: 'key' },
 		network: { type: 'key' },

--- a/services/blockchain-app-registry/shared/database/schema/token_metadata.js
+++ b/services/blockchain-app-registry/shared/database/schema/token_metadata.js
@@ -15,22 +15,19 @@
  */
 module.exports = {
 	tableName: 'token_metadata',
-	primaryKey: ['network', 'chainName', 'localID'],
+	primaryKey: ['tokenID'],
 	schema: {
 		chainID: { type: 'string' },
 		chainName: { type: 'string' },
 		network: { type: 'string' },
-		localID: { type: 'string' },
 		tokenName: { type: 'string' },
 		tokenID: { type: 'string' },
 	},
 	indexes: {
 		chainID: { type: 'key' },
 		chainName: { type: 'key' },
-		localID: { type: 'key' },
 		tokenName: { type: 'key' },
 		network: { type: 'key' },
-		tokenID: { type: 'key' },
 	},
 	purge: {},
 };

--- a/services/blockchain-app-registry/shared/metadata.js
+++ b/services/blockchain-app-registry/shared/metadata.js
@@ -267,29 +267,11 @@ const getBlockchainAppsTokenMetadata = async (params) => {
 	if (params.tokenID) {
 		const { tokenID, ...remParams } = params;
 		params = remParams;
-		const networkSet = new Set();
-
-		const chainIDlocalIDPairs = tokenID.split(',').map(_tokenID => {
-			const chainID = _tokenID.substring(0, LENGTH_CHAIN_ID).toLowerCase();
-			const localID = _tokenID.substring(LENGTH_CHAIN_ID).toLowerCase();
-
-			if (!('network' in params)) {
-				const network = config.CHAIN_ID_PREFIX_NETWORK_MAP[chainID.substring(0, 2)];
-				networkSet.add(network);
-			}
-
-			return [chainID, localID];
-		});
 
 		params.whereIn.push({
-			property: ['chainID', 'localID'],
-			values: chainIDlocalIDPairs,
+			property: 'tokenID',
+			values: tokenID.split(','),
 		});
-
-		// Set network if not already specified in the request params
-		if (!('network' in params)) {
-			params.network = Array.from(networkSet).join(',');
-		}
 	}
 
 	// Resolve network from chainID if present

--- a/services/blockchain-app-registry/shared/metadata.js
+++ b/services/blockchain-app-registry/shared/metadata.js
@@ -274,7 +274,6 @@ const getBlockchainAppsTokenMetadata = async (params) => {
 		});
 	}
 
-	// Resolve network from chainID if present
 	if (params.chainID) {
 		const { chainID, ...remParams } = params;
 		params = remParams;

--- a/services/blockchain-app-registry/shared/metadata.js
+++ b/services/blockchain-app-registry/shared/metadata.js
@@ -275,8 +275,13 @@ const getBlockchainAppsTokenMetadata = async (params) => {
 	}
 
 	// Resolve network from chainID if present
-	if (params.chainID && !('network' in params)) {
-		params.network = config.CHAIN_ID_PREFIX_NETWORK_MAP[params.chainID.substring(0, 2)];
+	if (params.chainID) {
+		const { chainID, ...remParams } = params;
+		params = remParams;
+		params.search = {
+			property: 'tokenID',
+			startsWith: chainID,
+		};
 	}
 
 	if (params.network) {
@@ -289,17 +294,25 @@ const getBlockchainAppsTokenMetadata = async (params) => {
 		});
 	}
 
-	const tokensResultSet = await tokenMetadataTable.find(params, ['network', 'chainID', 'chainName']);
+	const tokensResultSet = await tokenMetadataTable.find(params, ['network', 'tokenID', 'chainName']);
 
+	// Used to avoid reading same token metadata json file multiple times
 	const uniqueChainMap = {};
-	tokensResultSet.forEach(item => uniqueChainMap[item.chainID] = item);
+	// Used to only return the filtered token details in response
+	const resultTokenIDSet = new Set();
+	tokensResultSet.forEach(tokenMeta => {
+		const chainID = tokenMeta.tokenID.substring(0, LENGTH_CHAIN_ID);
+		uniqueChainMap[chainID] = tokenMeta;
+		resultTokenIDSet.add(tokenMeta.tokenID);
+	});
 	const uniqueChainList = Object.values(uniqueChainMap);
 
 	await BluebirdPromise.map(
 		uniqueChainList,
 		async (tokenMeta) => {
+			const chainID = tokenMeta.tokenID.substring(0, LENGTH_CHAIN_ID);
 			const [{ appDirName }] = await applicationMetadataTable.find(
-				{ network: tokenMeta.network, chainID: tokenMeta.chainID },
+				{ network: tokenMeta.network, chainID },
 				['appDirName'],
 			);
 
@@ -309,12 +322,14 @@ const getBlockchainAppsTokenMetadata = async (params) => {
 				config.FILENAME.NATIVETOKENS_JSON,
 			);
 			parsedTokenMeta.tokens.forEach(token => {
-				blockchainAppsTokenMetadata.data.push({
-					...token,
-					chainID: tokenMeta.chainID,
-					chainName: tokenMeta.chainName,
-					network: tokenMeta.network,
-				});
+				if (resultTokenIDSet.has(token.tokenID)) {
+					blockchainAppsTokenMetadata.data.push({
+						...token,
+						chainID,
+						chainName: tokenMeta.chainName,
+						network: tokenMeta.network,
+					});
+				}
 			});
 		},
 		{ concurrency: uniqueChainList.length },
@@ -333,23 +348,38 @@ const getBlockchainAppsTokenMetadata = async (params) => {
 
 const resolveTokenMetaInfo = async (tokenInfoFromDB) => {
 	const tokensMeta = [];
+	const processedChainIDs = new Set();
+	const resultTokenIDsSet = tokenInfoFromDB.reduce(
+		(accSet, tokenInfo) => accSet.add(tokenInfo.tokenID),
+		new Set(),
+	);
 
 	await BluebirdPromise.map(
 		tokenInfoFromDB,
 		async (entry) => {
+			const chainID = entry.tokenID.substring(0, LENGTH_CHAIN_ID);
+
+			// Avoid reading same token metadata file multiple times
+			if (processedChainIDs.has(chainID)) return;
+			processedChainIDs.add(chainID);
+
 			const parsedTokenMeta = await readMetadataFromClonedRepo(
 				entry.network,
 				entry.chainName,
 				config.FILENAME.NATIVETOKENS_JSON,
 			);
 
+			// Loop over all tokens in the token metadata file
 			parsedTokenMeta.tokens.forEach(async token => {
-				tokensMeta.push({
-					...token,
-					chainID: entry.chainID,
-					chainName: entry.chainName,
-					network: entry.network,
-				});
+				// Only add filtered tokens info to the response
+				if (resultTokenIDsSet.has(token.tokenID)) {
+					tokensMeta.push({
+						...token,
+						chainID,
+						chainName: entry.chainName,
+						network: entry.network,
+					});
+				}
 			});
 		},
 		{ concurrency: tokenInfoFromDB.length },
@@ -382,8 +412,8 @@ const getAllTokensMetaInNetworkByChainID = async (chainID, limit, offset, sort) 
 		offset,
 		sort,
 	};
-	const tokensResultSet = await tokenMetadataTable.find(searchParams, ['network', 'chainID', 'chainName']);
-	const total = await tokenMetadataTable.count(searchParams, ['network', 'chainID', 'chainName']);
+	const tokensResultSet = await tokenMetadataTable.find(searchParams, ['network', 'tokenID', 'chainName']);
+	const total = await tokenMetadataTable.count(searchParams, ['network', 'tokenID', 'chainName']);
 	const tokensMeta = await resolveTokenMetaInfo(tokensResultSet);
 	// Fetch the data
 	return { tokensMeta, total };
@@ -408,8 +438,8 @@ const getTokensMetaByTokenIDs = async (patternTokenIDs, exactTokenIDs, limit, of
 		sort,
 	};
 
-	const tokensResultSet = await tokenMetadataTable.find(searchParams, ['network', 'chainID', 'chainName']);
-	const total = await tokenMetadataTable.count(searchParams, ['network', 'chainID', 'chainName']);
+	const tokensResultSet = await tokenMetadataTable.find(searchParams, ['network', 'tokenID', 'chainName']);
+	const total = await tokenMetadataTable.count(searchParams, ['network', 'tokenID', 'chainName']);
 
 	// Fetch the data
 	const tokensMeta = await resolveTokenMetaInfo(tokensResultSet);

--- a/services/blockchain-app-registry/shared/metadataIndex.js
+++ b/services/blockchain-app-registry/shared/metadataIndex.js
@@ -60,11 +60,10 @@ const indexTokensMeta = async (tokenMeta, dbTrx) => {
 		tokenMeta.tokens,
 		async (token) => {
 			const result = {
-				chainID: tokenMeta.chainID.toLowerCase(),
 				chainName: tokenMeta.chainName,
 				network: tokenMeta.network,
 				tokenName: token.tokenName,
-				tokenID: token.tokenID,
+				tokenID: token.tokenID.toLowerCase(),
 			};
 			return result;
 		},
@@ -120,7 +119,6 @@ const indexMetadataFromFile = async (filePath, dbTrx) => {
 		const tokenMeta = {
 			...JSON.parse(tokenMetaString),
 			chainName: appMeta.chainName,
-			chainID: appMeta.chainID,
 			network,
 		};
 
@@ -147,7 +145,7 @@ const deleteTokensMeta = async (tokenMeta, dbTrx) => {
 		tokenMeta.tokenIDs,
 		async (tokenID) => {
 			const queryParams = {
-				tokenID,
+				tokenID: tokenID.toLowerCase(),
 			};
 			await tokenMetadataTable.delete(queryParams, dbTrx);
 		},

--- a/services/blockchain-app-registry/shared/metadataIndex.js
+++ b/services/blockchain-app-registry/shared/metadataIndex.js
@@ -33,7 +33,6 @@ const tokenMetadataIndexSchema = require('./database/schema/token_metadata');
 const { getDirectories, read, getFiles, exists } = require('./utils/fs');
 
 const config = require('../config');
-const constants = require('./constants');
 
 const MYSQL_ENDPOINT = config.endpoints.mysql;
 

--- a/services/blockchain-app-registry/shared/metadataIndex.js
+++ b/services/blockchain-app-registry/shared/metadataIndex.js
@@ -64,7 +64,6 @@ const indexTokensMeta = async (tokenMeta, dbTrx) => {
 				chainID: tokenMeta.chainID.toLowerCase(),
 				chainName: tokenMeta.chainName,
 				network: tokenMeta.network,
-				localID: token.tokenID.substring(constants.LENGTH_CHAIN_ID).toLowerCase(),
 				tokenName: token.tokenName,
 				tokenID: token.tokenID,
 			};
@@ -146,16 +145,14 @@ const deleteAppMeta = async (appMeta, dbTrx) => {
 const deleteTokensMeta = async (tokenMeta, dbTrx) => {
 	const tokenMetadataTable = await getTokenMetadataIndex();
 	await BluebirdPromise.map(
-		tokenMeta.localIDs,
-		async (localID) => {
+		tokenMeta.tokenIDs,
+		async (tokenID) => {
 			const queryParams = {
-				network: tokenMeta.network,
-				chainName: tokenMeta.chainName,
-				localID,
+				tokenID,
 			};
 			await tokenMetadataTable.delete(queryParams, dbTrx);
 		},
-		{ concurrency: tokenMeta.localIDs.length },
+		{ concurrency: tokenMeta.tokenIDs.length },
 	);
 };
 
@@ -180,13 +177,9 @@ const deleteIndexedMetadataFromFile = async (filePath, dbTrx) => {
 		logger.trace('Reading tokens information.');
 		const tokenMetaString = await read(filePath);
 		const { tokens } = JSON.parse(tokenMetaString);
-		const localIDs = tokens.map(
-			token => token.tokenID.substring(constants.LENGTH_CHAIN_ID).toLowerCase(),
-		);
+		const tokenIDs = tokens.map(token => token.tokenID);
 		const tokenMeta = {
-			localIDs,
-			chainName: appMeta.chainName,
-			network,
+			tokenIDs,
 		};
 
 		logger.debug(`Deleting tokens information for the app: ${app} (${network}).`);

--- a/services/blockchain-app-registry/shared/utils/downloadRepository.js
+++ b/services/blockchain-app-registry/shared/utils/downloadRepository.js
@@ -199,7 +199,8 @@ const buildEventPayload = async (allFilesModified) => {
 };
 
 const isMetadataFile = (filePath) => (
-	filePath.endsWith(FILENAME.APP_JSON) || filePath.endsWith(FILENAME.NATIVETOKENS_JSON)
+	filePath !== undefined
+	&& (filePath.endsWith(FILENAME.APP_JSON) || filePath.endsWith(FILENAME.NATIVETOKENS_JSON))
 );
 
 /* Sorts the passed array and groups files by the network and app. Returns following structure:
@@ -223,7 +224,7 @@ const groupFilesByNetworkAndApp = (fileInfos) => {
 		const [network, appName, fileName] = fileInfo.filename.split('/').slice(-3);
 
 		// Only process metadata files
-		if (!isMetadataFile(fileName)) return;
+		if (!config.supportedNetworks.includes(network) || !isMetadataFile(fileName)) return;
 
 		if (!(network in groupedFiles)) groupedFiles[network] = {};
 		if (!(appName in groupedFiles[network])) groupedFiles[network][appName] = [];

--- a/services/blockchain-app-registry/shared/utils/downloadRepository.js
+++ b/services/blockchain-app-registry/shared/utils/downloadRepository.js
@@ -199,8 +199,8 @@ const buildEventPayload = async (allFilesModified) => {
 };
 
 const isMetadataFile = (filePath) => (
-	filePath !== undefined
-	&& (filePath.endsWith(FILENAME.APP_JSON) || filePath.endsWith(FILENAME.NATIVETOKENS_JSON))
+	!!(filePath
+	&& (filePath.endsWith(FILENAME.APP_JSON) || filePath.endsWith(FILENAME.NATIVETOKENS_JSON)))
 );
 
 /* Sorts the passed array and groups files by the network and app. Returns following structure:

--- a/services/blockchain-app-registry/tests/functional/shared/metadataIndex.test.js
+++ b/services/blockchain-app-registry/tests/functional/shared/metadataIndex.test.js
@@ -75,8 +75,8 @@ const appMetaQueryParams = {
 const tokenMetaQueryParams = {
 	...appMetaQueryParams,
 	whereIn: {
-		property: 'localID',
-		values: tokenMetaObj.tokens.map(token => token.tokenID.substring(LENGTH_CHAIN_ID)),
+		property: 'tokenID',
+		values: tokenMetaObj.tokens.map(token => token.tokenID),
 	},
 };
 
@@ -262,9 +262,7 @@ describe('Test deleteAppMeta method', () => {
 });
 
 describe('Test deleteTokenMeta method', () => {
-	const localIDs = tokenMetaObj.tokens.map(
-		token => token.tokenID.substring(LENGTH_CHAIN_ID),
-	);
+	const tokenIDs = tokenMetaObj.tokens.map(token => token.tokenID);
 
 	beforeEach(async () => indexTokensMeta({
 		chainID: appMetaObj.chainID,
@@ -281,10 +279,7 @@ describe('Test deleteTokenMeta method', () => {
 		expect(dbResponseBefore.length).toEqual(1);
 
 		await deleteTokensMeta({
-			...tokenMetaObj,
-			network: appMetaObj.networkType,
-			chainName: appMetaObj.chainName,
-			localIDs,
+			tokenIDs,
 		});
 
 		const dbResponse = await tokenMetadataTable.find(tokenMetaQueryParams, ['chainID']);
@@ -299,10 +294,7 @@ describe('Test deleteTokenMeta method', () => {
 		const dbTrx = await startDbTransaction(connection);
 		await deleteTokensMeta(
 			{
-				...tokenMetaObj,
-				network: appMetaObj.networkType,
-				chainName: appMetaObj.chainName,
-				localIDs,
+				tokenIDs,
 			},
 			dbTrx,
 		);

--- a/services/blockchain-app-registry/tests/functional/shared/metadataIndex.test.js
+++ b/services/blockchain-app-registry/tests/functional/shared/metadataIndex.test.js
@@ -41,7 +41,6 @@ const {
 	tokenMetaObj,
 } = require('../../constants/metadataIndex');
 
-const { LENGTH_CHAIN_ID } = require('../../../shared/constants');
 const config = require('../../../config');
 
 const applicationMetadataIndexSchema = require('../../../shared/database/schema/application_metadata');

--- a/services/blockchain-app-registry/tests/unit/shared/metadataIndex.test.js
+++ b/services/blockchain-app-registry/tests/unit/shared/metadataIndex.test.js
@@ -1,0 +1,373 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+/* eslint-disable mocha/max-top-level-suites */
+const {
+	appMetaObj: mockAppMetaObj,
+	tokenMetaObj: mockTokenMetaObj,
+} = require('../../constants/metadataIndex');
+
+const tempDir = `${__dirname}/temp/${mockAppMetaObj.networkType}/${mockAppMetaObj.chainName}`;
+const mockAppMetaPath = `${tempDir}/${require('../../../config').FILENAME.APP_JSON}`;
+const mockTokenMetaPath = `${tempDir}/${require('../../../config').FILENAME.NATIVETOKENS_JSON}`;
+
+beforeEach(() => jest.resetModules());
+
+describe('Test indexTokensMeta method', () => {
+	it('should index token meta in db when called with valid metadata object', async () => {
+		jest.mock('lisk-service-framework', () => {
+			const actual = jest.requireActual('lisk-service-framework');
+			return {
+				...actual,
+				CacheRedis: jest.fn(),
+				CacheLRU: jest.fn(),
+				MySQL: {
+					getTableInstance: () => ({
+						upsert: (dataArray) => expect(dataArray[0].tokenID)
+							.toEqual(mockTokenMetaObj.tokens[0].tokenID),
+					}),
+					getDbConnection: jest.fn(),
+					startDbTransaction: jest.fn(),
+					commitDbTransaction: jest.fn(),
+					rollbackDbTransaction: jest.fn(),
+				},
+			};
+		});
+		const { indexTokensMeta } = require('../../../shared/metadataIndex');
+		await indexTokensMeta(mockTokenMetaObj);
+	});
+
+	it('should throw error when called with null or undefined tokenMeta', async () => {
+		const { indexTokensMeta } = require('../../../shared/metadataIndex');
+		expect(() => indexTokensMeta(null)).rejects.toThrow();
+		expect(() => indexTokensMeta(undefined)).rejects.toThrow();
+	});
+});
+
+describe('Test indexAppMeta method', () => {
+	it('should index app meta in db when called with valid metadata object', async () => {
+		jest.mock('lisk-service-framework', () => {
+			const actual = jest.requireActual('lisk-service-framework');
+			return {
+				...actual,
+				CacheRedis: jest.fn(),
+				CacheLRU: jest.fn(),
+				MySQL: {
+					getTableInstance: () => ({
+						upsert: (data) => expect(data.chainID).toEqual(mockAppMetaObj.chainID),
+					}),
+					getDbConnection: jest.fn(),
+					startDbTransaction: jest.fn(),
+					commitDbTransaction: jest.fn(),
+					rollbackDbTransaction: jest.fn(),
+				},
+			};
+		});
+		const { indexAppMeta } = require('../../../shared/metadataIndex');
+		await indexAppMeta(mockAppMetaObj);
+	});
+
+	it('should throw error when called with null or undefined appMeta', async () => {
+		const { indexAppMeta } = require('../../../shared/metadataIndex');
+		expect(() => indexAppMeta(null)).rejects.toThrow();
+		expect(() => indexAppMeta(undefined)).rejects.toThrow();
+	});
+});
+
+describe('Test indexMetadataFromFile method', () => {
+	it('should index app meta in db when called with valid app meta path', async () => {
+		jest.mock('../../../shared/utils/fs', () => {
+			const actual = jest.requireActual('../../../shared/utils/fs');
+			return {
+				...actual,
+				read: (filePath) => {
+					expect(filePath).toEqual(mockAppMetaPath);
+					return JSON.stringify(mockAppMetaObj);
+				},
+				exists: () => true,
+			};
+		});
+		jest.mock('lisk-service-framework', () => {
+			const actual = jest.requireActual('lisk-service-framework');
+			return {
+				...actual,
+				MySQL: {
+					getTableInstance: () => ({
+						upsert: (data) => expect(data.chainID).toEqual(mockAppMetaObj.chainID),
+					}),
+					getDbConnection: jest.fn(),
+					startDbTransaction: jest.fn(),
+					commitDbTransaction: jest.fn(),
+					rollbackDbTransaction: jest.fn(),
+				},
+			};
+		});
+
+		const { indexMetadataFromFile } = require('../../../shared/metadataIndex');
+		await indexMetadataFromFile(mockAppMetaPath);
+	});
+
+	it('should index token meta in db when called with valid token meta path', async () => {
+		jest.mock('../../../shared/utils/fs', () => {
+			const actual = jest.requireActual('../../../shared/utils/fs');
+			return {
+				...actual,
+				read: (filePath) => {
+					if (filePath === mockAppMetaPath) return JSON.stringify(mockAppMetaObj);
+					if (filePath === mockTokenMetaPath) return JSON.stringify(mockTokenMetaObj);
+
+					throw new Error(`Invalid file path passed to fs.read. filePath:${filePath}`);
+				},
+				exists: () => true,
+			};
+		});
+		jest.mock('lisk-service-framework', () => {
+			const actual = jest.requireActual('lisk-service-framework');
+			return {
+				...actual,
+				MySQL: {
+					getTableInstance: () => ({
+						upsert: (data) => expect(data[0].tokenID).toEqual(mockTokenMetaObj.tokens[0].tokenID),
+					}),
+					getDbConnection: jest.fn(),
+					startDbTransaction: jest.fn(),
+					commitDbTransaction: jest.fn(),
+					rollbackDbTransaction: jest.fn(),
+				},
+			};
+		});
+
+		const { indexMetadataFromFile } = require('../../../shared/metadataIndex');
+		await indexMetadataFromFile(mockTokenMetaPath);
+	});
+
+	it('should throw error when called with null or undefined filePath', async () => {
+		const { indexMetadataFromFile } = require('../../../shared/metadataIndex');
+		expect(() => indexMetadataFromFile(null)).rejects.toThrow();
+		expect(() => indexMetadataFromFile(undefined)).rejects.toThrow();
+	});
+});
+
+describe('Test deleteAppMeta method', () => {
+	it('should delete app meta in db when called with valid metadata object', async () => {
+		jest.mock('lisk-service-framework', () => {
+			const actual = jest.requireActual('lisk-service-framework');
+			return {
+				...actual,
+				CacheRedis: jest.fn(),
+				CacheLRU: jest.fn(),
+				MySQL: {
+					getTableInstance: () => ({
+						delete: (data) => expect(data).toEqual({
+							network: mockAppMetaObj.networkType,
+							chainName: mockAppMetaObj.chainName,
+						}),
+					}),
+				},
+			};
+		});
+		const { deleteAppMeta } = require('../../../shared/metadataIndex');
+		await deleteAppMeta(mockAppMetaObj);
+	});
+
+	it('should throw error when called with null or undefined appMeta', async () => {
+		const { deleteAppMeta } = require('../../../shared/metadataIndex');
+		expect(() => deleteAppMeta(null)).rejects.toThrow();
+		expect(() => deleteAppMeta(undefined)).rejects.toThrow();
+	});
+});
+
+describe('Test deleteTokensMeta method', () => {
+	it('should delete token meta in db when called with valid metadata object', async () => {
+		const tokenIDs = mockTokenMetaObj.tokens.map(token => token.tokenID);
+		jest.mock('lisk-service-framework', () => {
+			const actual = jest.requireActual('lisk-service-framework');
+			return {
+				...actual,
+				CacheRedis: jest.fn(),
+				CacheLRU: jest.fn(),
+				MySQL: {
+					getTableInstance: () => ({
+						delete: (data) => expect(data.tokenID).toEqual(mockTokenMetaObj.tokens[0].tokenID),
+					}),
+					getDbConnection: jest.fn(),
+					startDbTransaction: jest.fn(),
+					commitDbTransaction: jest.fn(),
+					rollbackDbTransaction: jest.fn(),
+				},
+			};
+		});
+		const { deleteTokensMeta } = require('../../../shared/metadataIndex');
+		await deleteTokensMeta({ tokenIDs });
+	});
+
+	it('should throw error when called with null or undefined tokenMeta', async () => {
+		const { deleteTokensMeta } = require('../../../shared/metadataIndex');
+		expect(() => deleteTokensMeta(null)).rejects.toThrow();
+		expect(() => deleteTokensMeta(undefined)).rejects.toThrow();
+	});
+});
+
+describe('Test deleteIndexedMetadataFromFile method', () => {
+	it('should delete app meta in db when called with valid app meta path', async () => {
+		jest.mock('../../../shared/utils/fs', () => {
+			const actual = jest.requireActual('../../../shared/utils/fs');
+			return {
+				...actual,
+				read: (filePath) => {
+					expect(filePath).toEqual(mockAppMetaPath);
+					return JSON.stringify(mockAppMetaObj);
+				},
+				exists: () => true,
+			};
+		});
+		jest.mock('lisk-service-framework', () => {
+			const actual = jest.requireActual('lisk-service-framework');
+			return {
+				...actual,
+				MySQL: {
+					getTableInstance: () => ({
+						delete: (data) => expect(data).toEqual({
+							network: mockAppMetaObj.networkType,
+							chainName: mockAppMetaObj.chainName,
+						}),
+					}),
+					getDbConnection: jest.fn(),
+					startDbTransaction: jest.fn(),
+					commitDbTransaction: jest.fn(),
+					rollbackDbTransaction: jest.fn(),
+				},
+			};
+		});
+
+		const { deleteIndexedMetadataFromFile } = require('../../../shared/metadataIndex');
+		await deleteIndexedMetadataFromFile(mockAppMetaPath);
+	});
+
+	it('should delete token meta in db when called with valid token meta path', async () => {
+		jest.mock('../../../shared/utils/fs', () => {
+			const actual = jest.requireActual('../../../shared/utils/fs');
+			return {
+				...actual,
+				read: (filePath) => {
+					if (filePath === mockAppMetaPath) return JSON.stringify(mockAppMetaObj);
+					if (filePath === mockTokenMetaPath) return JSON.stringify(mockTokenMetaObj);
+
+					throw new Error(`Invalid file path passed to fs.read. filePath:${filePath}`);
+				},
+				exists: () => true,
+			};
+		});
+		jest.mock('lisk-service-framework', () => {
+			const actual = jest.requireActual('lisk-service-framework');
+			return {
+				...actual,
+				MySQL: {
+					getTableInstance: () => ({
+						delete: (data) => expect(data.tokenID).toEqual(mockTokenMetaObj.tokens[0].tokenID),
+					}),
+					getDbConnection: jest.fn(),
+					startDbTransaction: jest.fn(),
+					commitDbTransaction: jest.fn(),
+					rollbackDbTransaction: jest.fn(),
+				},
+			};
+		});
+
+		const { deleteIndexedMetadataFromFile } = require('../../../shared/metadataIndex');
+		await deleteIndexedMetadataFromFile(mockTokenMetaPath);
+	});
+
+	it('should throw error when called with null or undefined filePath', async () => {
+		const { deleteIndexedMetadataFromFile } = require('../../../shared/metadataIndex');
+		expect(() => deleteIndexedMetadataFromFile(null)).rejects.toThrow();
+		expect(() => deleteIndexedMetadataFromFile(undefined)).rejects.toThrow();
+	});
+});
+
+describe('Test indexAllBlockchainAppsMeta method', () => {
+	it('should index token meta in db when called with valid metadata object', async () => {
+		jest.mock('lisk-service-framework', () => {
+			const actual = jest.requireActual('lisk-service-framework');
+			return {
+				...actual,
+				CacheRedis: jest.fn(),
+				CacheLRU: jest.fn(),
+				MySQL: {
+					getTableInstance: () => ({
+						upsert: (dataArray) => expect(dataArray[0].tokenID)
+							.toEqual(mockTokenMetaObj.tokens[0].tokenID),
+					}),
+					getDbConnection: jest.fn(),
+					startDbTransaction: jest.fn(),
+					commitDbTransaction: jest.fn(),
+					rollbackDbTransaction: jest.fn(),
+				},
+			};
+		});
+
+		jest.mock('../../../config', () => {
+			const actual = jest.requireActual('../../../config');
+			return {
+				...actual,
+				supportedNetworks: ['betanet'],
+			};
+		});
+
+		jest.mock('../../../shared/utils/fs', () => {
+			const actual = jest.requireActual('../../../shared/utils/fs');
+			return {
+				...actual,
+				getDirectories: () => ['Lisk'],
+				getFiles: () => [
+					mockAppMetaPath,
+					mockTokenMetaPath,
+				],
+				read: (filePath) => {
+					if (filePath === mockAppMetaPath) return JSON.stringify(mockAppMetaObj);
+					if (filePath === mockTokenMetaPath) return JSON.stringify(mockTokenMetaObj);
+
+					throw new Error(`Invalid file path passed to fs.read. filePath:${filePath}`);
+				},
+				exists: () => true,
+			};
+		});
+
+		jest.mock('lisk-service-framework', () => {
+			const actual = jest.requireActual('lisk-service-framework');
+			return {
+				...actual,
+				MySQL: {
+					getTableInstance: () => ({
+						delete: (data) => {
+							if (data.chainID) {
+								expect(data.chainID).toEqual(mockAppMetaObj.chainID);
+							} else {
+								expect(data[0].tokenID).toEqual(mockTokenMetaObj.tokens[0].tokenID);
+							}
+						},
+					}),
+					getDbConnection: jest.fn(),
+					startDbTransaction: jest.fn(),
+					commitDbTransaction: jest.fn(),
+					rollbackDbTransaction: jest.fn(),
+				},
+			};
+		});
+
+		const { indexAllBlockchainAppsMeta } = require('../../../shared/metadataIndex');
+		await indexAllBlockchainAppsMeta(mockTokenMetaObj);
+	});
+});

--- a/services/blockchain-app-registry/tests/unit/shared/metadataIndex.test.js
+++ b/services/blockchain-app-registry/tests/unit/shared/metadataIndex.test.js
@@ -32,6 +32,7 @@ describe('Test indexTokensMeta method', () => {
 			return {
 				...actual,
 				MySQL: {
+					...actual.MySQL,
 					getTableInstance: () => ({
 						upsert: (dataArray) => expect(dataArray[0].tokenID)
 							.toEqual(mockTokenMetaObj.tokens[0].tokenID),
@@ -57,6 +58,7 @@ describe('Test indexAppMeta method', () => {
 			return {
 				...actual,
 				MySQL: {
+					...actual.MySQL,
 					getTableInstance: () => ({
 						upsert: (data) => expect(data.chainID).toEqual(mockAppMetaObj.chainID),
 					}),
@@ -95,6 +97,7 @@ describe('Test indexMetadataFromFile method', () => {
 			return {
 				...actual,
 				MySQL: {
+					...actual.MySQL,
 					getTableInstance: () => ({
 						upsert: (data) => expect(data.chainID).toEqual(mockAppMetaObj.chainID),
 					}),
@@ -112,6 +115,7 @@ describe('Test indexMetadataFromFile method', () => {
 			return {
 				...actual,
 				MySQL: {
+					...actual.MySQL,
 					getTableInstance: () => ({
 						upsert: (data) => expect(data[0].tokenID).toEqual(mockTokenMetaObj.tokens[0].tokenID),
 					}),
@@ -141,6 +145,7 @@ describe('Test deleteAppMeta method', () => {
 			return {
 				...actual,
 				MySQL: {
+					...actual.MySQL,
 					getTableInstance: () => ({
 						delete: (data) => expect(data).toEqual({
 							network: mockAppMetaObj.networkType,
@@ -169,6 +174,7 @@ describe('Test deleteTokensMeta method', () => {
 			return {
 				...actual,
 				MySQL: {
+					...actual.MySQL,
 					getTableInstance: () => ({
 						delete: (data) => expect(data.tokenID).toEqual(mockTokenMetaObj.tokens[0].tokenID),
 					}),
@@ -207,6 +213,7 @@ describe('Test deleteIndexedMetadataFromFile method', () => {
 			return {
 				...actual,
 				MySQL: {
+					...actual.MySQL,
 					getTableInstance: () => ({
 						delete: (data) => expect(data).toEqual({
 							network: mockAppMetaObj.networkType,
@@ -227,6 +234,7 @@ describe('Test deleteIndexedMetadataFromFile method', () => {
 			return {
 				...actual,
 				MySQL: {
+					...actual.MySQL,
 					getTableInstance: () => ({
 						delete: (data) => expect(data.tokenID).toEqual(mockTokenMetaObj.tokens[0].tokenID),
 					}),

--- a/services/blockchain-app-registry/tests/unit/shared/metadataIndex.test.js
+++ b/services/blockchain-app-registry/tests/unit/shared/metadataIndex.test.js
@@ -31,17 +31,11 @@ describe('Test indexTokensMeta method', () => {
 			const actual = jest.requireActual('lisk-service-framework');
 			return {
 				...actual,
-				CacheRedis: jest.fn(),
-				CacheLRU: jest.fn(),
 				MySQL: {
 					getTableInstance: () => ({
 						upsert: (dataArray) => expect(dataArray[0].tokenID)
 							.toEqual(mockTokenMetaObj.tokens[0].tokenID),
 					}),
-					getDbConnection: jest.fn(),
-					startDbTransaction: jest.fn(),
-					commitDbTransaction: jest.fn(),
-					rollbackDbTransaction: jest.fn(),
 				},
 			};
 		});
@@ -62,16 +56,10 @@ describe('Test indexAppMeta method', () => {
 			const actual = jest.requireActual('lisk-service-framework');
 			return {
 				...actual,
-				CacheRedis: jest.fn(),
-				CacheLRU: jest.fn(),
 				MySQL: {
 					getTableInstance: () => ({
 						upsert: (data) => expect(data.chainID).toEqual(mockAppMetaObj.chainID),
 					}),
-					getDbConnection: jest.fn(),
-					startDbTransaction: jest.fn(),
-					commitDbTransaction: jest.fn(),
-					rollbackDbTransaction: jest.fn(),
 				},
 			};
 		});
@@ -87,18 +75,21 @@ describe('Test indexAppMeta method', () => {
 });
 
 describe('Test indexMetadataFromFile method', () => {
+	beforeEach(() => jest.mock('../../../shared/utils/fs', () => {
+		const actual = jest.requireActual('../../../shared/utils/fs');
+		return {
+			...actual,
+			read: (filePath) => {
+				if (filePath === mockAppMetaPath) return JSON.stringify(mockAppMetaObj);
+				if (filePath === mockTokenMetaPath) return JSON.stringify(mockTokenMetaObj);
+
+				throw new Error(`Invalid file path passed to fs.read. filePath:${filePath}`);
+			},
+			exists: () => true,
+		};
+	}));
+
 	it('should index app meta in db when called with valid app meta path', async () => {
-		jest.mock('../../../shared/utils/fs', () => {
-			const actual = jest.requireActual('../../../shared/utils/fs');
-			return {
-				...actual,
-				read: (filePath) => {
-					expect(filePath).toEqual(mockAppMetaPath);
-					return JSON.stringify(mockAppMetaObj);
-				},
-				exists: () => true,
-			};
-		});
 		jest.mock('lisk-service-framework', () => {
 			const actual = jest.requireActual('lisk-service-framework');
 			return {
@@ -107,10 +98,6 @@ describe('Test indexMetadataFromFile method', () => {
 					getTableInstance: () => ({
 						upsert: (data) => expect(data.chainID).toEqual(mockAppMetaObj.chainID),
 					}),
-					getDbConnection: jest.fn(),
-					startDbTransaction: jest.fn(),
-					commitDbTransaction: jest.fn(),
-					rollbackDbTransaction: jest.fn(),
 				},
 			};
 		});
@@ -120,19 +107,6 @@ describe('Test indexMetadataFromFile method', () => {
 	});
 
 	it('should index token meta in db when called with valid token meta path', async () => {
-		jest.mock('../../../shared/utils/fs', () => {
-			const actual = jest.requireActual('../../../shared/utils/fs');
-			return {
-				...actual,
-				read: (filePath) => {
-					if (filePath === mockAppMetaPath) return JSON.stringify(mockAppMetaObj);
-					if (filePath === mockTokenMetaPath) return JSON.stringify(mockTokenMetaObj);
-
-					throw new Error(`Invalid file path passed to fs.read. filePath:${filePath}`);
-				},
-				exists: () => true,
-			};
-		});
 		jest.mock('lisk-service-framework', () => {
 			const actual = jest.requireActual('lisk-service-framework');
 			return {
@@ -166,8 +140,6 @@ describe('Test deleteAppMeta method', () => {
 			const actual = jest.requireActual('lisk-service-framework');
 			return {
 				...actual,
-				CacheRedis: jest.fn(),
-				CacheLRU: jest.fn(),
 				MySQL: {
 					getTableInstance: () => ({
 						delete: (data) => expect(data).toEqual({
@@ -196,16 +168,10 @@ describe('Test deleteTokensMeta method', () => {
 			const actual = jest.requireActual('lisk-service-framework');
 			return {
 				...actual,
-				CacheRedis: jest.fn(),
-				CacheLRU: jest.fn(),
 				MySQL: {
 					getTableInstance: () => ({
 						delete: (data) => expect(data.tokenID).toEqual(mockTokenMetaObj.tokens[0].tokenID),
 					}),
-					getDbConnection: jest.fn(),
-					startDbTransaction: jest.fn(),
-					commitDbTransaction: jest.fn(),
-					rollbackDbTransaction: jest.fn(),
 				},
 			};
 		});
@@ -221,18 +187,21 @@ describe('Test deleteTokensMeta method', () => {
 });
 
 describe('Test deleteIndexedMetadataFromFile method', () => {
+	beforeEach(() => jest.mock('../../../shared/utils/fs', () => {
+		const actual = jest.requireActual('../../../shared/utils/fs');
+		return {
+			...actual,
+			read: (filePath) => {
+				if (filePath === mockAppMetaPath) return JSON.stringify(mockAppMetaObj);
+				if (filePath === mockTokenMetaPath) return JSON.stringify(mockTokenMetaObj);
+
+				throw new Error(`Invalid file path passed to fs.read. filePath:${filePath}`);
+			},
+			exists: () => true,
+		};
+	}));
+
 	it('should delete app meta in db when called with valid app meta path', async () => {
-		jest.mock('../../../shared/utils/fs', () => {
-			const actual = jest.requireActual('../../../shared/utils/fs');
-			return {
-				...actual,
-				read: (filePath) => {
-					expect(filePath).toEqual(mockAppMetaPath);
-					return JSON.stringify(mockAppMetaObj);
-				},
-				exists: () => true,
-			};
-		});
 		jest.mock('lisk-service-framework', () => {
 			const actual = jest.requireActual('lisk-service-framework');
 			return {
@@ -244,10 +213,6 @@ describe('Test deleteIndexedMetadataFromFile method', () => {
 							chainName: mockAppMetaObj.chainName,
 						}),
 					}),
-					getDbConnection: jest.fn(),
-					startDbTransaction: jest.fn(),
-					commitDbTransaction: jest.fn(),
-					rollbackDbTransaction: jest.fn(),
 				},
 			};
 		});
@@ -257,19 +222,6 @@ describe('Test deleteIndexedMetadataFromFile method', () => {
 	});
 
 	it('should delete token meta in db when called with valid token meta path', async () => {
-		jest.mock('../../../shared/utils/fs', () => {
-			const actual = jest.requireActual('../../../shared/utils/fs');
-			return {
-				...actual,
-				read: (filePath) => {
-					if (filePath === mockAppMetaPath) return JSON.stringify(mockAppMetaObj);
-					if (filePath === mockTokenMetaPath) return JSON.stringify(mockTokenMetaObj);
-
-					throw new Error(`Invalid file path passed to fs.read. filePath:${filePath}`);
-				},
-				exists: () => true,
-			};
-		});
 		jest.mock('lisk-service-framework', () => {
 			const actual = jest.requireActual('lisk-service-framework');
 			return {
@@ -298,26 +250,7 @@ describe('Test deleteIndexedMetadataFromFile method', () => {
 });
 
 describe('Test indexAllBlockchainAppsMeta method', () => {
-	it('should index token meta in db when called with valid metadata object', async () => {
-		jest.mock('lisk-service-framework', () => {
-			const actual = jest.requireActual('lisk-service-framework');
-			return {
-				...actual,
-				CacheRedis: jest.fn(),
-				CacheLRU: jest.fn(),
-				MySQL: {
-					getTableInstance: () => ({
-						upsert: (dataArray) => expect(dataArray[0].tokenID)
-							.toEqual(mockTokenMetaObj.tokens[0].tokenID),
-					}),
-					getDbConnection: jest.fn(),
-					startDbTransaction: jest.fn(),
-					commitDbTransaction: jest.fn(),
-					rollbackDbTransaction: jest.fn(),
-				},
-			};
-		});
-
+	it('should index all metadata in db', async () => {
 		jest.mock('../../../config', () => {
 			const actual = jest.requireActual('../../../config');
 			return {
@@ -345,29 +278,7 @@ describe('Test indexAllBlockchainAppsMeta method', () => {
 			};
 		});
 
-		jest.mock('lisk-service-framework', () => {
-			const actual = jest.requireActual('lisk-service-framework');
-			return {
-				...actual,
-				MySQL: {
-					getTableInstance: () => ({
-						delete: (data) => {
-							if (data.chainID) {
-								expect(data.chainID).toEqual(mockAppMetaObj.chainID);
-							} else {
-								expect(data[0].tokenID).toEqual(mockTokenMetaObj.tokens[0].tokenID);
-							}
-						},
-					}),
-					getDbConnection: jest.fn(),
-					startDbTransaction: jest.fn(),
-					commitDbTransaction: jest.fn(),
-					rollbackDbTransaction: jest.fn(),
-				},
-			};
-		});
-
 		const { indexAllBlockchainAppsMeta } = require('../../../shared/metadataIndex');
-		await indexAllBlockchainAppsMeta(mockTokenMetaObj);
+		await indexAllBlockchainAppsMeta();
 	});
 });

--- a/services/blockchain-app-registry/tests/unit/shared/utils/downloadRepository.test.js
+++ b/services/blockchain-app-registry/tests/unit/shared/utils/downloadRepository.test.js
@@ -204,7 +204,7 @@ describe('Test isMetadataFile method', () => {
 		expect(response).toEqual(true);
 	});
 
-	it('should return true when called with app.json', async () => {
+	it('should return true when called with nativetokens.json', async () => {
 		const response = isMetadataFile(config.FILENAME.NATIVETOKENS_JSON);
 		expect(response).toEqual(true);
 	});

--- a/services/blockchain-app-registry/tests/unit/shared/utils/downloadRepository.test.js
+++ b/services/blockchain-app-registry/tests/unit/shared/utils/downloadRepository.test.js
@@ -13,13 +13,18 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { getRepoInfoFromURL, getUniqueNetworkAppDirPairs, filterMetaConfigFilesByNetwork, getModifiedFileNames, isMetadataFile } = require('../../../../shared/utils/downloadRepository');
 const config = require('../../../../config');
+const {
+	getRepoInfoFromURL,
+	getUniqueNetworkAppDirPairs,
+	filterMetaConfigFilesByNetwork,
+	getModifiedFileNames,
+	isMetadataFile,
+} = require('../../../../shared/utils/downloadRepository');
 const {
 	getModifiedFileNamesInput,
 	getModifiedFileNamesExpectedResponse,
 } = require('../../../constants/downloadRepository');
-const { FILENAME } = require('../../../../config');
 
 describe('Test getRepoInfoFromURL method', () => {
 	it('should return proper response when url is valid', async () => {
@@ -195,12 +200,12 @@ describe('Test getModifiedFileNames method', () => {
 
 describe('Test isMetadataFile method', () => {
 	it('should return true when called with app.json', async () => {
-		const response = isMetadataFile(FILENAME.APP_JSON);
+		const response = isMetadataFile(config.FILENAME.APP_JSON);
 		expect(response).toEqual(true);
 	});
 
 	it('should return true when called with app.json', async () => {
-		const response = isMetadataFile(FILENAME.NATIVETOKENS_JSON);
+		const response = isMetadataFile(config.FILENAME.NATIVETOKENS_JSON);
 		expect(response).toEqual(true);
 	});
 

--- a/services/blockchain-app-registry/tests/unit/shared/utils/downloadRepository.test.js
+++ b/services/blockchain-app-registry/tests/unit/shared/utils/downloadRepository.test.js
@@ -13,12 +13,13 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { getRepoInfoFromURL, getUniqueNetworkAppDirPairs, filterMetaConfigFilesByNetwork, getModifiedFileNames } = require('../../../../shared/utils/downloadRepository');
+const { getRepoInfoFromURL, getUniqueNetworkAppDirPairs, filterMetaConfigFilesByNetwork, getModifiedFileNames, isMetadataFile } = require('../../../../shared/utils/downloadRepository');
 const config = require('../../../../config');
 const {
 	getModifiedFileNamesInput,
 	getModifiedFileNamesExpectedResponse,
 } = require('../../../constants/downloadRepository');
+const { FILENAME } = require('../../../../config');
 
 describe('Test getRepoInfoFromURL method', () => {
 	it('should return proper response when url is valid', async () => {
@@ -189,5 +190,32 @@ describe('Test getModifiedFileNames method', () => {
 	it('should throw error when called with null or undefined groupedFiles', async () => {
 		expect(() => getModifiedFileNames(null)).toThrow();
 		expect(() => getModifiedFileNames(undefined)).toThrow();
+	});
+});
+
+describe('Test isMetadataFile method', () => {
+	it('should return true when called with app.json', async () => {
+		const response = isMetadataFile(FILENAME.APP_JSON);
+		expect(response).toEqual(true);
+	});
+
+	it('should return true when called with app.json', async () => {
+		const response = isMetadataFile(FILENAME.NATIVETOKENS_JSON);
+		expect(response).toEqual(true);
+	});
+
+	it('should return false when called with random.json', async () => {
+		const response = isMetadataFile('random.json');
+		expect(response).toEqual(false);
+	});
+
+	it('should return false when called with null', async () => {
+		const response = isMetadataFile(null);
+		expect(response).toEqual(false);
+	});
+
+	it('should return false when called with undefined', async () => {
+		const response = isMetadataFile(undefined);
+		expect(response).toEqual(false);
 	});
 });

--- a/services/transaction-statistics/shared/buildTransactionStatistics.js
+++ b/services/transaction-statistics/shared/buildTransactionStatistics.js
@@ -31,7 +31,7 @@ const {
 } = require('lisk-service-framework');
 
 const { getDistributionByType } = require('./transactionStatistics');
-const { resolveGlobalTokenID, DB_CONSTANT, DATE_FORMAT } = require('./utils/constants');
+const { DB_CONSTANT, DATE_FORMAT } = require('./utils/constants');
 const { requestIndexer } = require('./utils/request');
 const requestAll = require('./utils/requestAll');
 
@@ -105,7 +105,7 @@ const computeTransactionStats = transactions => transactions.reduce(
 				[getRange(tx)]: {
 					count: txStatsWithFallback.count + 1,
 					volume: BigNumber(txStatsWithFallback.volume).add(getTxValue(tx)),
-					tokenID: resolveGlobalTokenID(tx.params.tokenID),
+					tokenID: tx.params.tokenID,
 				},
 			},
 		};

--- a/services/transaction-statistics/shared/utils/constants.js
+++ b/services/transaction-statistics/shared/utils/constants.js
@@ -13,10 +13,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { requestIndexer } = require('./request');
-
-let chainID;
-
 const DB_CONSTANT = {
 	ANY: 'any',
 	UNAVAILABLE: 'na',
@@ -27,28 +23,7 @@ const DATE_FORMAT = {
 	MONTH: 'YYYY-MM',
 };
 
-const getChainID = async () => {
-	if (typeof chainID === 'undefined') {
-		const networkStatus = await requestIndexer('network.status');
-		chainID = networkStatus.data.chainID;
-	}
-
-	return chainID;
-};
-
-const resolveGlobalTokenID = (tokenID) => {
-	if (!tokenID) return DB_CONSTANT.UNAVAILABLE;
-	if (!chainID) return tokenID;
-
-	const localID = tokenID.slice(8);
-	const globalTokenID = `${chainID}${localID}`;
-	return globalTokenID;
-};
-
 module.exports = {
-	getChainID,
-	resolveGlobalTokenID,
-
 	DB_CONSTANT,
 	DATE_FORMAT,
 };


### PR DESCRIPTION
### What was the problem?
This PR resolves #1473

### How was it solved?
- [x] Remove localID related logic from transaction statistics
- [x] Remove localID and chainID related logic from blockchain app registry
- [x] Refactor blockchain-app-registry to use `tokenID` instead of chainID
- [x] Fix `blockchain/apps/token/meta` does not respect tokenID filter
- [x] Fix `/blockchain/apps/meta/tokens/supported` returns duplicate token infos when a chain has multiple supported tokens
- Add unit test coverage forblockchain-app-registry/shared/metadataIndex.js
    - [x] indexTokensMeta
    - [x] indexAppMeta
    - [x] indexMetadataFromFile
    - [x] deleteAppMeta
    - [x] deleteTokensMeta
    - [x] deleteIndexedMetadataFromFile
    - [x] indexAllBlockchainAppsMeta
- [x] Add unit test coverage for isMetadataFile in downloadRepository

### How was it tested?
- [x] Local