### PR TITLE
Unable to query pending transactions by address

### DIFF
--- a/services/blockchain-indexer/shared/constants.js
+++ b/services/blockchain-indexer/shared/constants.js
@@ -136,6 +136,7 @@ const MODULE_SUB_STORE = Object.freeze({
 const COMMAND = Object.freeze({
 	REGISTER_VALIDATOR: 'registerValidator',
 	STAKE: 'stake',
+	CHANGE_COMMISSION: 'changeCommission',
 	TRANSFER: 'transfer',
 	TRANSFER_CROSS_CHAIN: 'transferCrossChain',
 });

--- a/services/blockchain-indexer/shared/dataService/business/pendingTransactions.js
+++ b/services/blockchain-indexer/shared/dataService/business/pendingTransactions.js
@@ -86,10 +86,7 @@ const validateParams = async params => {
 	}
 
 	if (params.id) validatedParams.id = params.id;
-	if (params.address) {
-		validatedParams.senderAddress = params.address;
-		validatedParams.recipientAddress = params.address;
-	}
+	if (params.address) validatedParams.address = params.address;
 	if (params.senderAddress) validatedParams.senderAddress = params.senderAddress;
 	if (params.recipientAddress) validatedParams.recipientAddress = params.recipientAddress;
 	if (params.moduleCommand) validatedParams.moduleCommand = params.moduleCommand;
@@ -107,7 +104,7 @@ const getPendingTransactions = async params => {
 	const offset = Number(params.offset) || 0;
 	const limit = Number(params.limit) || 10;
 
-	params = await validateParams(params);
+	const validatedParams = await validateParams(params);
 
 	const sortComparator = (sortParam) => {
 		const sortProp = sortParam.split(':')[0];
@@ -122,18 +119,21 @@ const getPendingTransactions = async params => {
 	if (pendingTransactionsList.length) {
 		// Filter according to the request params
 		const filteredPendingTxs = pendingTransactionsList.filter(transaction => (
-			(!params.id
-				|| transaction.id === params.id)
-			&& (!params.senderAddress
-				|| transaction.sender.address === params.senderAddress)
-			&& (!params.recipientAddress
-				|| transaction.params.recipientAddress === params.recipientAddress)
-			&& (!params.moduleCommand
-				|| transaction.moduleCommand === params.moduleCommand)
+			(!validatedParams.id
+				|| transaction.id === validatedParams.id)
+			&& (!validatedParams.senderAddress
+				|| transaction.sender.address === validatedParams.senderAddress)
+			&& (!validatedParams.recipientAddress
+				|| transaction.params.recipientAddress === validatedParams.recipientAddress)
+			&& (!validatedParams.address
+				|| transaction.sender.address === validatedParams.address
+				|| transaction.params.recipientAddress === validatedParams.address)
+			&& (!validatedParams.moduleCommand
+				|| transaction.moduleCommand === validatedParams.moduleCommand)
 		));
 
 		pendingTransactions.data = filteredPendingTxs
-			.sort(sortComparator(params.sort))
+			.sort(sortComparator(validatedParams.sort))
 			.slice(offset, offset + limit)
 			.map(transaction => {
 				// Set the 'executionStatus'

--- a/services/blockchain-indexer/shared/dataService/business/pendingTransactions.js
+++ b/services/blockchain-indexer/shared/dataService/business/pendingTransactions.js
@@ -153,4 +153,7 @@ const getPendingTransactions = async params => {
 module.exports = {
 	getPendingTransactions,
 	loadAllPendingTransactions,
+
+	// For unit test
+	validateParams,
 };

--- a/services/blockchain-indexer/shared/dataService/pos/validators.js
+++ b/services/blockchain-indexer/shared/dataService/pos/validators.js
@@ -261,8 +261,7 @@ const updateValidatorListEveryBlock = () => {
 			if (block && block.transactions && Array.isArray(block.transactions)) {
 				block.transactions.forEach(tx => {
 					if (tx.module === MODULE.POS) {
-						if (tx.command === COMMAND.REGISTER_VALIDATOR
-							|| tx.command === COMMAND.CHANGE_COMMISSION) {
+						if ([COMMAND.REGISTER_VALIDATOR, COMMAND.CHANGE_COMMISSION].includes(tx.command)) {
 							updatedValidatorAddresses
 								.push(getLisk32AddressFromPublicKey(tx.senderPublicKey));
 						} else if (tx.command === COMMAND.STAKE) {

--- a/services/blockchain-indexer/shared/dataService/pos/validators.js
+++ b/services/blockchain-indexer/shared/dataService/pos/validators.js
@@ -261,7 +261,8 @@ const updateValidatorListEveryBlock = () => {
 			if (block && block.transactions && Array.isArray(block.transactions)) {
 				block.transactions.forEach(tx => {
 					if (tx.module === MODULE.POS) {
-						if (tx.command === COMMAND.REGISTER_VALIDATOR) {
+						if (tx.command === COMMAND.REGISTER_VALIDATOR
+							|| tx.command === COMMAND.CHANGE_COMMISSION) {
 							updatedValidatorAddresses
 								.push(getLisk32AddressFromPublicKey(tx.senderPublicKey));
 						} else if (tx.command === COMMAND.STAKE) {

--- a/services/blockchain-indexer/tests/unit/shared/dataservice/business/pendingTransactions.test.js
+++ b/services/blockchain-indexer/tests/unit/shared/dataservice/business/pendingTransactions.test.js
@@ -1,0 +1,58 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const { validateParams } = require('../../../../../shared/dataService/business/pendingTransactions');
+
+jest.mock('lisk-service-framework', () => {
+	const actual = jest.requireActual('lisk-service-framework');
+	return {
+		...actual,
+		MySQL: {
+			...actual.MySQL,
+			KVStore: {
+				...actual.KVStore,
+				getKeyValueTable: jest.fn(),
+			},
+		},
+		CacheRedis: jest.fn(),
+		CacheLRU: jest.fn(),
+	};
+});
+
+describe('Test validateParams method', () => {
+	it('should return validated params when called with valid params', async () => {
+		const params = {
+			moduleCommand: 'token:transfer',
+			address: 'lskyvvam5rxyvbvofxbdfcupxetzmqxu22phm4yuo',
+			sort: 'timestamp:desc',
+		};
+
+		const result = await validateParams(params);
+		expect(result).toEqual(params);
+	});
+
+	it('should throw error when called with nonce without senderAddress', async () => {
+		const params = { nonce: 1 };
+		expect(() => validateParams(params)).rejects.toThrow();
+	});
+
+	it('should throw error when called with undefined', async () => {
+		expect(() => validateParams(undefined)).rejects.toThrow();
+	});
+
+	it('should throw error when called with null', async () => {
+		expect(() => validateParams(null)).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
### What was the problem?
This PR resolves #1712 #1713 

### How was it solved?

- [x] Fix logic to query pending transactions by address
- [x] Refresh validators cache on every change commission transaction

### How was it tested?
Local
- docker
- debugger