### PR TITLE
Transaction statistics crashes

### DIFF
--- a/services/transaction-statistics/shared/buildTransactionStatistics.js
+++ b/services/transaction-statistics/shared/buildTransactionStatistics.js
@@ -234,7 +234,7 @@ const validateTransactionStatistics = async historyLengthDays => {
 			const fromTimestamp = Math.floor((moment.unix(dateFrom).unix()) / 1000);
 			const toTimestamp = Math.floor((moment.unix(dateTo).unix()) / 1000);
 
-			const { meta: { total } } = await requestIndexer('getTransactions', {
+			const { meta: { total } } = await requestIndexer('transactions', {
 				moduleCommand,
 				timestamp: `${fromTimestamp}:${toTimestamp}`,
 				limit: 1,


### PR DESCRIPTION
### What was the problem?
This PR resolves #1527

### How was it solved?
 - [x] Fix validate transaction statistics job fails because of non-existing indexer endpoint invocation
 
### How was it tested?
 - [x] Local