### PR TITLE
Connector crashes on request timeouts

### DIFF
--- a/services/blockchain-connector/shared/sdk/client.js
+++ b/services/blockchain-connector/shared/sdk/client.js
@@ -97,8 +97,11 @@ const invokeEndpoint = async (endpoint, params = {}, numRetries = NUM_REQUEST_RE
 			const response = await apiClient._channel.invoke(endpoint, params);
 			return response;
 		} catch (err) {
-			if (retries && err instanceof TimeoutException) await delay(10);
-			else throw err;
+			if (retries && err.message.includes(timeoutMessage)) {
+				await delay(10);
+			} else {
+				throw err;
+			}
 		}
 		/* eslint-enable no-await-in-loop */
 	} while (retries--);

--- a/services/blockchain-connector/shared/sdk/client.js
+++ b/services/blockchain-connector/shared/sdk/client.js
@@ -13,7 +13,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { Logger, Exceptions: { TimeoutException }, Signals } = require('lisk-service-framework');
+const { Logger, Signals } = require('lisk-service-framework');
 const {
 	createWSClient,
 	createIPCClient,

--- a/services/blockchain-connector/shared/sdk/events.js
+++ b/services/blockchain-connector/shared/sdk/events.js
@@ -38,15 +38,6 @@ const events = [
 	EVENT_TX_POOL_TRANSACTION_NEW,
 ];
 
-const catchAndRetry = async (err, fn, ...params) => {
-	const RETRY_MS = 1000;
-	logger.warn(`Invocation for ${fn.name} failed with error: ${err.message}. Retrying in ${RETRY_MS}ms.`);
-	setTimeout(
-		() => fn(params).catch((_err) => logger.warn(`Retry for ${fn.name} failed with error: ${_err.message}.`)),
-		RETRY_MS,
-	);
-};
-
 const subscribeToAllRegisteredEvents = async () => {
 	const apiClient = await getApiClient();
 	const registeredEvents = await getRegisteredEvents();
@@ -58,9 +49,9 @@ const subscribeToAllRegisteredEvents = async () => {
 				// Force update necessary caches on new chain events
 				if (event.startsWith('chain_')) {
 					await getNodeInfo(true)
-						.catch((err) => catchAndRetry(err, getNodeInfo, true));
+						.catch(err => logger.warn(`Invocation for 'getNodeInfo' failed with error: ${err.message}.`));
 					await getEscrowedAmounts(true)
-						.catch((err) => catchAndRetry(err, getEscrowedAmounts, true));
+						.catch(err => logger.warn(`Invocation for 'getEscrowedAmounts' failed with error: ${err.message}.`));
 				}
 
 				logger.debug(`Received event: ${event} with payload:\n${util.inspect(payload)}`);

--- a/services/blockchain-connector/shared/sdk/events.js
+++ b/services/blockchain-connector/shared/sdk/events.js
@@ -41,7 +41,10 @@ const events = [
 const catchAndRetry = async (err, fn, ...params) => {
 	const RETRY_MS = 1000;
 	logger.warn(`Invocation for ${fn.name} failed with error: ${err.message}. Retrying in ${RETRY_MS}ms.`);
-	setTimeout(() => fn(params).catch((_err) => logger.warn(`Retry for ${fn.name} failed with error: ${_err.message}.`)), RETRY_MS);
+	setTimeout(
+		() => fn(params).catch((_err) => logger.warn(`Retry for ${fn.name} failed with error: ${_err.message}.`)),
+		RETRY_MS,
+	);
 };
 
 const subscribeToAllRegisteredEvents = async () => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1758 

### How was it solved?
- [x] Fix request is not retried multiple times on time out error from node
- [x] Fix Internal node call errors are not handled properly
 
### How was it tested?
- [x] Local. Throw random timeout errors from here or deeper within the calls. The connector should not crash in such cases.