### PR TITLE
Dryrun does not validate properly with an invalid transaction

### DIFF
--- a/services/blockchain-connector/methods/transactions.js
+++ b/services/blockchain-connector/methods/transactions.js
@@ -54,11 +54,13 @@ module.exports = [
 			transaction,
 			skipVerify,
 			skipDecode,
-		}) => dryRunTransaction({ transaction, skipVerify, skipDecode }),
+			strict,
+		}) => dryRunTransaction({ transaction, skipVerify, skipDecode, strict }),
 		params: {
 			transaction: { optional: false, type: 'any' },
 			skipVerify: { optional: true, type: 'boolean', default: false },
 			skipDecode: { optional: true, type: 'boolean', default: false },
+			strict: { optional: true, type: 'boolean', default: false },
 		},
 	},
 ];

--- a/services/blockchain-connector/shared/sdk/endpoints.js
+++ b/services/blockchain-connector/shared/sdk/endpoints.js
@@ -263,9 +263,9 @@ const postTransaction = async (transaction) => {
 	}
 };
 
-const dryRunTransaction = async ({ transaction, skipVerify }) => {
+const dryRunTransaction = async ({ transaction, skipVerify, strict }) => {
 	try {
-		const response = await invokeEndpoint('txpool_dryRunTransaction', { transaction, skipVerify });
+		const response = await invokeEndpoint('txpool_dryRunTransaction', { transaction, skipVerify, strict });
 		return response;
 	} catch (err) {
 		if (err.message.includes(timeoutMessage)) {

--- a/services/blockchain-connector/shared/sdk/transactions.js
+++ b/services/blockchain-connector/shared/sdk/transactions.js
@@ -42,12 +42,12 @@ const getTransactionsFromPoolFormatted = async () => {
 };
 
 const dryRunTransactionWrapper = async (params) => {
-	const { transaction, skipVerify, skipDecode } = params;
+	const { transaction, skipVerify, skipDecode, strict } = params;
 	const encodedTransaction = typeof transaction === 'object'
 		? encodeTransaction(transaction)
 		: transaction;
 
-	const response = await dryRunTransaction({ transaction: encodedTransaction, skipVerify });
+	const response = await dryRunTransaction({ transaction: encodedTransaction, skipVerify, strict });
 	response.events = response.events.map(event => formatEvent(event, skipDecode));
 	return response;
 };

--- a/services/blockchain-indexer/methods/dataService/transactions.js
+++ b/services/blockchain-indexer/methods/dataService/transactions.js
@@ -69,6 +69,7 @@ module.exports = [
 			transaction: { optional: false, type: 'any' },
 			skipVerify: { optional: true, type: 'boolean', default: false },
 			skipDecode: { optional: true, type: 'boolean', default: false },
+			strict: { optional: true, type: 'boolean', default: false },
 		},
 	},
 	{

--- a/services/blockchain-indexer/shared/dataService/business/transactionsDryRun.js
+++ b/services/blockchain-indexer/shared/dataService/business/transactionsDryRun.js
@@ -21,9 +21,9 @@ const dryRunTransactions = async params => {
 		data: [],
 		meta: {},
 	};
-	const { transaction, skipVerify, skipDecode } = params;
+	const { transaction, skipVerify, skipDecode, strict } = params;
 
-	const response = await requestConnector('dryRunTransaction', { transaction, skipVerify, skipDecode });
+	const response = await requestConnector('dryRunTransaction', { transaction, skipVerify, skipDecode, strict });
 
 	dryRunTransactionsRes.data = {
 		...response,

--- a/services/gateway/apis/http-version3/methods/transactionsDryRun.js
+++ b/services/gateway/apis/http-version3/methods/transactionsDryRun.js
@@ -43,6 +43,7 @@ module.exports = {
 		],
 		skipVerify: { optional: true, type: 'boolean', default: false },
 		skipDecode: { optional: true, type: 'boolean', default: false },
+		strict: { optional: true, type: 'boolean', default: false },
 	},
 	get schema() {
 		const dryRunTransactionSchema = {};

--- a/services/gateway/apis/http-version3/swagger/definitions/transactions.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/transactions.json
@@ -382,6 +382,12 @@
 				"example": "false",
 				"default": false
 			},
+			"strict": {
+				"type": "boolean",
+				"description": "A boolean indicator to enable strict mode. By default it is set to false which skips nonce and signature check",
+				"example": "false",
+				"default": false
+			},
 			"transaction": {
 				"type": "object",
 				"description": "Binary payload or the transaction object.",
@@ -707,7 +713,6 @@
 											}
 										}
 									}
-									
 								}
 							},
 							"params": {

--- a/services/gateway/sources/version3/transactionsDryRun.js
+++ b/services/gateway/sources/version3/transactionsDryRun.js
@@ -20,6 +20,7 @@ module.exports = {
 		transaction: '=',
 		skipVerify: '=,boolean',
 		skipDecode: '=,boolean',
+		strict: '=,boolean',
 	},
 	definition: {
 		data: {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1763 

### How was it solved?

- [ ] Add support for `strict` flag for dryrun transaction endpoint
- [ ] Add integration tests

### How was it tested?
Local + Integration tests