### PR TITLE
Add endpoint to fetch NFT module constants

### DIFF
--- a/services/blockchain-connector/methods/nft.js
+++ b/services/blockchain-connector/methods/nft.js
@@ -1,0 +1,24 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const { getNFTConstants } = require('../shared/sdk');
+
+module.exports = [
+	{
+		name: 'getNFTConstants',
+		controller: async () => getNFTConstants(),
+		params: {},
+	},
+];

--- a/services/blockchain-connector/shared/sdk/index.js
+++ b/services/blockchain-connector/shared/sdk/index.js
@@ -115,6 +115,7 @@ const {
 const { cacheCleanup } = require('./cache');
 const { formatTransaction } = require('./formatter');
 const { encodeCCM } = require('./encoder');
+const { getNFTConstants } = require('./nft');
 
 const init = async () => {
 	// Initialize the local cache
@@ -238,4 +239,7 @@ module.exports = {
 
 	// Cache
 	cacheCleanup,
+
+	// NFT
+	getNFTConstants,
 };

--- a/services/blockchain-connector/shared/sdk/nft.js
+++ b/services/blockchain-connector/shared/sdk/nft.js
@@ -1,0 +1,37 @@
+/*
+* LiskHQ/lisk-service
+* Copyright © 2023 Lisk Foundation
+*
+* See the LICENSE file at the top-level directory of this distribution
+* for licensing information.
+*
+* Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+* no part of this software, including this file, may be copied, modified,
+* propagated, or distributed except according to the terms contained in the
+* LICENSE file.
+*
+* Removal or modification of this copyright notice is prohibited.
+*
+*/
+const { Exceptions: { TimeoutException }, Logger } = require('lisk-service-framework');
+const { timeoutMessage, invokeEndpoint } = require('./client');
+
+const logger = Logger();
+
+const getNFTConstants = async () => {
+	try {
+		const response = await invokeEndpoint('nft_getNFTConstants');
+		if (response.error) throw new Error(response.error);
+		return response;
+	} catch (err) {
+		if (err.message.includes(timeoutMessage)) {
+			throw new TimeoutException('Request timed out when calling \'getNFTConstants\'.');
+		}
+		logger.warn(`Error returned when invoking 'nft_getNFTConstants'.\n${err.stack}`);
+		throw err;
+	}
+};
+
+module.exports = {
+	getNFTConstants,
+};

--- a/services/blockchain-indexer/methods/dataService/controllers/nft.js
+++ b/services/blockchain-indexer/methods/dataService/controllers/nft.js
@@ -1,0 +1,33 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const dataService = require('../../../shared/dataService');
+
+const getNFTConstants = async () => {
+	const constants = {
+		data: {},
+		meta: {},
+	};
+
+	const response = await dataService.getNFTConstants();
+	if (response.data) constants.data = response.data;
+	if (response.meta) constants.meta = response.meta;
+
+	return constants;
+};
+
+module.exports = {
+	getNFTConstants,
+};

--- a/services/blockchain-indexer/methods/dataService/modules/nft.js
+++ b/services/blockchain-indexer/methods/dataService/modules/nft.js
@@ -1,0 +1,24 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const { getNFTConstants } = require('../controllers/nft');
+
+module.exports = [
+	{
+		name: 'nft.constants',
+		controller: getNFTConstants,
+		params: {},
+	},
+];

--- a/services/blockchain-indexer/shared/dataService/business/nft/constants.js
+++ b/services/blockchain-indexer/shared/dataService/business/nft/constants.js
@@ -1,0 +1,41 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const { Logger } = require('lisk-service-framework');
+const { requestConnector } = require('../../../utils/request');
+
+const logger = Logger();
+
+let moduleConstants;
+
+const getNFTConstants = async () => {
+	try {
+		if (typeof moduleConstants === 'undefined') moduleConstants = await requestConnector('getNFTConstants');
+	} catch (err) {
+		const errMessage = `Unable to fetch the NFT constants from connector due to: ${err.message}.`;
+		logger.warn(errMessage);
+		logger.trace(err.stack);
+		throw new Error(errMessage);
+	}
+
+	return {
+		data: moduleConstants,
+		meta: {},
+	};
+};
+
+module.exports = {
+	getNFTConstants,
+};

--- a/services/blockchain-indexer/shared/dataService/business/nft/index.js
+++ b/services/blockchain-indexer/shared/dataService/business/nft/index.js
@@ -1,0 +1,20 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const { getNFTConstants } = require('./constants');
+
+module.exports = {
+	getNFTConstants,
+};

--- a/services/blockchain-indexer/shared/dataService/index.js
+++ b/services/blockchain-indexer/shared/dataService/index.js
@@ -103,6 +103,10 @@ const { getValidator, validateBLSKey } = require('./validator');
 const { getGenerators } = require('./generators');
 const { invokeEndpoint } = require('./invoke');
 
+const {
+	getNFTConstants,
+} = require('./nft');
+
 module.exports = {
 	// Blocks
 	getBlocks,
@@ -200,4 +204,7 @@ module.exports = {
 	resolveMainchainServiceURL,
 
 	invokeEndpoint,
+
+	// NFT
+	getNFTConstants,
 };

--- a/services/blockchain-indexer/shared/dataService/nft/constants.js
+++ b/services/blockchain-indexer/shared/dataService/nft/constants.js
@@ -1,0 +1,22 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const business = require('../business');
+
+const getNFTConstants = async () => business.getNFTConstants();
+
+module.exports = {
+	getNFTConstants,
+};

--- a/services/blockchain-indexer/shared/dataService/nft/index.js
+++ b/services/blockchain-indexer/shared/dataService/nft/index.js
@@ -1,0 +1,20 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const { getNFTConstants } = require('./constants');
+
+module.exports = {
+	getNFTConstants,
+};

--- a/services/gateway/apis/http-version3/methods/modules/nft/constants.js
+++ b/services/gateway/apis/http-version3/methods/modules/nft/constants.js
@@ -1,0 +1,48 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+const nftConstantsSource = require('../../../../../sources/version3/nftConstants');
+const envelope = require('../../../../../sources/version3/mappings/stdEnvelope');
+const { response, getSwaggerDescription } = require('../../../../../shared/utils');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/nft/constants',
+	rpcMethod: 'get.nft.constants',
+	tags: ['NFT'],
+	get schema() {
+		const constantsSchema = {};
+		constantsSchema[this.swaggerApiPath] = { get: {} };
+		constantsSchema[this.swaggerApiPath].get.tags = this.tags;
+		constantsSchema[this.swaggerApiPath].get.summary = 'Requests NFT module constants.';
+		constantsSchema[this.swaggerApiPath].get.description = getSwaggerDescription({
+			rpcMethod: this.rpcMethod,
+			description: 'Requests all the configured constants for the NFT module.',
+		});
+		constantsSchema[this.swaggerApiPath].get.responses = {
+			200: {
+				description: 'Returns all the configured constants for the NFT module.',
+				schema: {
+					$ref: '#/definitions/nftConstantsWithEnvelope',
+				},
+			},
+		};
+		Object.assign(constantsSchema[this.swaggerApiPath].get.responses, response);
+		return constantsSchema;
+	},
+	source: nftConstantsSource,
+	envelope,
+};

--- a/services/gateway/apis/http-version3/swagger/definitions/nft.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/nft.json
@@ -1,0 +1,28 @@
+{
+    "nftConstantsWithEnvelope": {
+        "type": "object",
+        "required": [
+            "data",
+            "meta"
+        ],
+        "properties": {
+            "data": {
+                "description": "NFT module constants.",
+                "type": "object",
+                "required": [
+                    "feeCreateNFT"
+                ],
+                "properties": {
+                    "feeCreateNFT": {
+                        "type": "string",
+                        "example": "5000000",
+                        "description": "The extra fee to be supplied for creating NFT."
+                    }
+                }
+            },
+            "meta": {
+                "type": "object"
+            }
+        }
+    }
+}

--- a/services/gateway/sources/version3/nftConstants.js
+++ b/services/gateway/sources/version3/nftConstants.js
@@ -1,0 +1,26 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+module.exports = {
+	type: 'moleculer',
+	method: 'indexer.nft.constants',
+	params: {},
+	definition: {
+		data: {
+			feeCreateNFT: '=,string',
+		},
+		meta: {},
+	},
+};


### PR DESCRIPTION
### What was the problem?
This PR resolves #1789 

### How was it solved?

- [ ] The endpoints are implemented as expected above:
  - [ ] HTTP GET /api/v3/nft/constants
  - [ ] RPC  get.nft.constants
- [ ] The response body is up-to-date
- [ ] Implement methods in indexer to fetch this information from the node
- [ ] Cache “feeCreateNFT” in connector
- [ ] Add swagger specification
- [ ] Update documentation
- [ ] Add integration tests
- [ ] Add unit tests if applicable

### How was it tested?
Local