### PR TITLE
Transaction estimate fees throws error for cross chain transfer transaction

### DIFF
--- a/services/blockchain-indexer/shared/dataService/business/transactionsEstimateFees.js
+++ b/services/blockchain-indexer/shared/dataService/business/transactionsEstimateFees.js
@@ -284,8 +284,9 @@ const estimateTransactionFees = async params => {
 		const channelInfo = await resolveChannelInfo(params.transaction.params.receivingChainID);
 
 		const ccmByteFee = BigInt(ccmLength) * BigInt(channelInfo.minReturnFeePerByte);
-		const totalMessageFee = ccmByteFee
-			+ BigInt(additionalFees.params.messageFee.userAccountInitializationFee || 0);
+		const totalMessageFee = additionalFees.params.messageFee
+			? ccmByteFee + BigInt(additionalFees.params.messageFee.userAccountInitializationFee)
+			: ccmByteFee;
 
 		estimateTransactionFeesRes.data.transaction.params = {
 			messageFee: {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1804 

### How was it solved?
- [x] Update `totalMessageFee` calculation

### How was it tested?
Local against devnet