### PR TITLE
Add endpoint to fetch NFT history

### DIFF
--- a/services/blockchain-indexer/methods/dataService/controllers/nft.js
+++ b/services/blockchain-indexer/methods/dataService/controllers/nft.js
@@ -55,7 +55,21 @@ const getNFTConstants = async () => {
 	return constants;
 };
 
+const getNFTHistory = async () => {
+	const history = {
+		data: [],
+		meta: {},
+	};
+
+	const response = await dataService.getNFTHistory();
+	if (response.data) history.data = response.data;
+	if (response.meta) history.meta = response.meta;
+
+	return history;
+};
+
 module.exports = {
 	getNFTs,
 	getNFTConstants,
+	getNFTHistory,
 };

--- a/services/blockchain-indexer/methods/dataService/modules/nft.js
+++ b/services/blockchain-indexer/methods/dataService/modules/nft.js
@@ -16,6 +16,7 @@
 const {
 	getNFTs,
 	getNFTConstants,
+	getNFTHistory,
 } = require('../controllers/nft');
 
 module.exports = [
@@ -37,5 +38,15 @@ module.exports = [
 		name: 'nft.constants',
 		controller: getNFTConstants,
 		params: {},
+	},
+	{
+		name: 'nft.history',
+		controller: getNFTHistory,
+		params: {
+			nftID: { optional: false, type: 'string' },
+			type: { optional: false, type: 'string' },
+			limit: { optional: true, type: 'number' },
+			offset: { optional: true, type: 'number' },
+		},
 	},
 ];

--- a/services/blockchain-indexer/shared/dataService/business/index.js
+++ b/services/blockchain-indexer/shared/dataService/business/index.js
@@ -62,6 +62,7 @@ const {
 const {
 	getNFTs,
 	getNFTConstants,
+	getNFTHistory,
 } = require('./nft');
 
 const {
@@ -161,6 +162,7 @@ module.exports = {
 	// NFTs
 	getNFTs,
 	getNFTConstants,
+	getNFTHistory,
 
 	// PoS
 	getPosValidators,

--- a/services/blockchain-indexer/shared/dataService/business/nft/history.js
+++ b/services/blockchain-indexer/shared/dataService/business/nft/history.js
@@ -13,12 +13,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { getNFTs } = require('./nft');
-const { getNFTConstants } = require('./constants');
-const { getNFTHistory } = require('./history');
+const getNFTHistory = async () => { };
 
 module.exports = {
-	getNFTs,
-	getNFTConstants,
 	getNFTHistory,
 };

--- a/services/blockchain-indexer/shared/dataService/business/nft/index.js
+++ b/services/blockchain-indexer/shared/dataService/business/nft/index.js
@@ -15,8 +15,10 @@
  */
 const { getNFTs } = require('./nft');
 const { getNFTConstants } = require('./constants');
+const { getNFTHistory } = require('./history');
 
 module.exports = {
 	getNFTs,
 	getNFTConstants,
+	getNFTHistory,
 };

--- a/services/blockchain-indexer/shared/dataService/index.js
+++ b/services/blockchain-indexer/shared/dataService/index.js
@@ -71,6 +71,8 @@ const {
 
 const {
 	getNFTs,
+	getNFTConstants,
+	getNFTHistory,
 } = require('./nft');
 
 const {
@@ -107,10 +109,6 @@ const { getValidator, validateBLSKey } = require('./validator');
 const { getGenerators } = require('./generators');
 const { invokeEndpoint } = require('./invoke');
 
-const {
-	getNFTConstants,
-} = require('./nft');
-
 module.exports = {
 	// Blocks
 	getBlocks,
@@ -129,9 +127,6 @@ module.exports = {
 	getStakes,
 	getStakers,
 	getPosClaimableRewards,
-
-	// NFTs
-	getNFTs,
 
 	// Token
 	tokenHasUserAccount,
@@ -214,5 +209,7 @@ module.exports = {
 	invokeEndpoint,
 
 	// NFT
+	getNFTs,
 	getNFTConstants,
+	getNFTHistory,
 };

--- a/services/blockchain-indexer/shared/dataService/nft/history.js
+++ b/services/blockchain-indexer/shared/dataService/nft/history.js
@@ -13,12 +13,10 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { getNFTs } = require('./nft');
-const { getNFTConstants } = require('./constants');
-const { getNFTHistory } = require('./history');
+const business = require('../business');
+
+const getNFTHistory = async (params) => business.getNFTHistory(params);
 
 module.exports = {
-	getNFTs,
-	getNFTConstants,
 	getNFTHistory,
 };

--- a/services/gateway/apis/http-version3/methods/modules/nft/history.js
+++ b/services/gateway/apis/http-version3/methods/modules/nft/history.js
@@ -1,0 +1,55 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const nftHistorySource = require('../../../../../sources/version3/nftHistory');
+const envelope = require('../../../../../sources/version3/mappings/stdEnvelope');
+const regex = require('../../../../../shared/regex');
+const { transformParams, response, getSwaggerDescription } = require('../../../../../shared/utils');
+
+module.exports = {
+	version: '2.0',
+	swaggerApiPath: '/nft/history',
+	rpcMethod: 'get.nft.history',
+	tags: ['NFT'],
+	params: {
+		nftID: { optional: false, type: 'string', pattern: regex.NFT_ID },
+		type: { optional: false, type: 'string', pattern: regex.TYPE },
+		limit: { optional: true, type: 'number', min: 1, max: 100, default: 10 },
+		offset: { optional: true, type: 'number', min: 0, default: 0 },
+	},
+	get schema() {
+		const nftSchema = {};
+		nftSchema[this.swaggerApiPath] = { get: {} };
+		nftSchema[this.swaggerApiPath].get.tags = this.tags;
+		nftSchema[this.swaggerApiPath].get.summary = 'Requests NFT history.';
+		nftSchema[this.swaggerApiPath].get.description = getSwaggerDescription({
+			rpcMethod: this.rpcMethod,
+			description: 'Returns NFT history.',
+		});
+		nftSchema[this.swaggerApiPath].get.parameters = transformParams('nft', this.params);
+		nftSchema[this.swaggerApiPath].get.responses = {
+			200: {
+				description: 'Returns history of NFT by type.',
+				schema: {
+					$ref: '#/definitions/NFTHistoryWithEnvelope',
+				},
+			},
+		};
+		Object.assign(nftSchema[this.swaggerApiPath].get.responses, response);
+		return nftSchema;
+	},
+	source: nftHistorySource,
+	envelope,
+};

--- a/services/gateway/apis/http-version3/swagger/definitions/nft.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/nft.json
@@ -124,5 +124,113 @@
                 "type": "object"
             }
         }
+    },
+    "NFTHistory": {
+        "type": "object",
+        "required": [
+            "transactionID",
+            "block"
+        ],
+        "properties": {
+            "transactionID": {
+                "type": "string",
+                "description": "Unique identifier of the transaction.\nDerived from the transaction signature.",
+                "example": "f9593f101c4acafc3ede650ab4c10fa2ecb59b225813eddbbb17b47e96932e9b"
+            },
+            "owner": {
+                "type": "object",
+                "required": [
+                    "new",
+                    "old"
+                ],
+                "properties": {
+                    "new": {
+                        "type": "string",
+                        "description": "New owner of the NFT.",
+                        "example": "lskyvvam5rxyvbvofxbdfcupxetzmqxu22phm4yuo"
+                    },
+                    "old": {
+                        "type": "string",
+                        "description": "Old owner of the NFT.",
+                        "example": "lskguo9kqnea2zsfo3a6qppozsxsg92nuuma3p7ad"
+                    }
+                },
+                "block": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "format": "id",
+                            "minLength": 1,
+                            "maxLength": 64,
+                            "example": "01967dba384998026fe028119bd099ecf073c05c045381500a93d1a7c7307e5b",
+                            "description": "Unique identifier of the block.\nDerived from the block signature."
+                        },
+                        "height": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "example": 8350681,
+                            "description": "The height of the network, at the moment where this transaction was included in the blockchain."
+                        },
+                        "timestamp": {
+                            "type": "integer",
+                            "example": 1613323667,
+                            "description": "UNIX Timestamp"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "NFTHistoryWithEnvelope": {
+        "type": "object",
+        "required": [
+            "data",
+            "meta"
+        ],
+        "properties": {
+            "data": {
+                "description": "NFT history by type. Based on type, only one of 'transfer' or 'attribute' entries will be present in the response",
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/NFTHistory"
+                }
+            },
+            "meta": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Universal identifier of the NFT.",
+                        "example": "00000000100000001"
+                    },
+                    "nft": {
+                        "type": "object",
+                        "required": [
+                            "chainID",
+                            "collectionID",
+                            "index"
+                        ],
+                        "properties": {
+                            "chainID": {
+                                "type": "string",
+                                "description": "Chain ID on which the NFT was created.",
+                                "example": "00000000"
+                            },
+                            "collectionID": {
+                                "type": "string",
+                                "description": "Collection ID of the NFT.",
+                                "example": "10000000"
+                            },
+                            "index": {
+                                "type": "number",
+                                "description": "Index of NFT within the collection.",
+                                "example": 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/services/gateway/apis/http-version3/swagger/parameters/nft.json
+++ b/services/gateway/apis/http-version3/swagger/parameters/nft.json
@@ -55,5 +55,13 @@
         "minLength": 8,
         "maxLength": 8,
         "pattern": "^[a-fA-F0-9]{8}$"
+    },
+    "type": {
+        "name": "type",
+        "in": "query",
+        "description": "Query NFT history by type. \nAccepted values: transfer, attribute.",
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^\b(?:transfer|attribute|,)\b$"
     }
 }

--- a/services/gateway/shared/regex.js
+++ b/services/gateway/shared/regex.js
@@ -57,6 +57,7 @@ const EVENT_NAME = /^[\w!@$&. ]{1,32}$/;
 const NFT_ID = /^\b(?:[A-Fa-f0-9]){32}\b$/;
 const NFT_COLLECTION_ID = /^\b[a-fA-F0-9]{8}\b$/;
 const NFT_OWNER = /^(lsk[a-hjkm-z2-9]{38})$|^(?:\b[a-fA-F0-9]{8}\b)$/;
+const TYPE = /^\b(?:transfer|attribute|,)\b$/;
 
 module.exports = {
 	PUBLIC_KEY,
@@ -103,4 +104,5 @@ module.exports = {
 	NFT_ID,
 	NFT_COLLECTION_ID,
 	NFT_OWNER,
+	TYPE,
 };

--- a/services/gateway/sources/version3/mappings/nftHistory.js
+++ b/services/gateway/sources/version3/mappings/nftHistory.js
@@ -1,0 +1,32 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+module.exports = {
+	owner: {
+		old: '=,string',
+		new: '=,string',
+	},
+	attribute: {
+		module: '=,string',
+		old: '=,string',
+		new: '=,string',
+	},
+	transactionID: '=,string',
+	block: {
+		id: '=,string',
+		height: '=,number',
+		timestamp: '=,number',
+	},
+};

--- a/services/gateway/sources/version3/nftHistory.js
+++ b/services/gateway/sources/version3/nftHistory.js
@@ -1,0 +1,38 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+const nftHistory = require('./mappings/nft');
+
+module.exports = {
+	type: 'moleculer',
+	method: 'indexer.nft.history',
+	params: {
+		nftID: '=,string',
+		type: '=,string',
+		limit: '=,number',
+		offset: '=,number',
+	},
+	definition: {
+		data: ['data', nftHistory],
+		meta: {
+			id: '=,string',
+			nft: {
+				chainID: '=,string',
+				collectionID: '=,string',
+				index: '=,number',
+			},
+		},
+	},
+};


### PR DESCRIPTION
### What was the problem?
This PR resolves #1798 

### How was it solved?

- [ ] The endpoints are implemented as expected above
  - [ ] HTTP GET /api/v3/nft/history
  - [ ] RPC  get.nft.history
- [ ] The response body is up-to-date
- [ ] Add business logic
- [ ] Add swagger specification
- [ ] Add integration tests
- [ ] Add unit tests if applicable

### How was it tested?
Local