### PR TITLE
Extend blockchain apps endpoint response

### DIFF
--- a/docs/api/version3.md
+++ b/docs/api/version3.md
@@ -5658,7 +5658,7 @@ _Supports pagination._
       "address": "lskdwsyfmcko6mcd357446yatromr9vzgu7eb8y99",
       "lastCertificateHeight": 160,
       "lastUpdated": 1616008148,
-      "depositedLsk": "50000000000",
+      "escrowedLsk": "50000000000",
       "escrow": [
         {
           "tokenID": "0000000000000000",

--- a/docs/api/version3.md
+++ b/docs/api/version3.md
@@ -5657,7 +5657,14 @@ _Supports pagination._
       "status": "activated",
       "address": "lskdwsyfmcko6mcd357446yatromr9vzgu7eb8y99",
       "lastCertificateHeight": 160,
-      "lastUpdated": 1616008148
+      "lastUpdated": 1616008148,
+      "depositedLsk": "50000000000",
+      "escrow": [
+        {
+          "tokenID": "0000000000000000",
+          "amount": "50000000000"
+        }
+      ]
     }
   ],
   "meta": {

--- a/docs/api/version3.md
+++ b/docs/api/version3.md
@@ -5658,7 +5658,7 @@ _Supports pagination._
       "address": "lskdwsyfmcko6mcd357446yatromr9vzgu7eb8y99",
       "lastCertificateHeight": 160,
       "lastUpdated": 1616008148,
-      "escrowedLsk": "50000000000",
+      "escrowedLSK": "50000000000",
       "escrow": [
         {
           "tokenID": "0000000000000000",

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
@@ -28,8 +28,7 @@ const { getMainchainID } = require('./mainchain');
 
 const getBlockchainAppsTable = () => getTableInstance(blockchainAppsTableSchema, MYSQL_ENDPOINT);
 
-// use mainchain
-const getTokenIDLSK = async () => {
+const getLSKTokenID = async () => {
 	const mainchainID = await getMainchainID();
 	return mainchainID.substring(0, LENGTH_NETWORK_ID).padEnd(LENGTH_TOKEN_ID, '0');
 };
@@ -86,7 +85,7 @@ const getBlockchainApps = async (params) => {
 	const { data: { chainID } } = await getNetworkStatus();
 	const { escrowedAmounts } = await requestConnector('getEscrowedAmounts');
 
-	const lskTokenID = await getTokenIDLSK();
+	const lskTokenID = await getLSKTokenID();
 
 	blockchainAppsInfo.data = await BluebirdPromise.map(
 		dbBlockchainApps,
@@ -121,5 +120,5 @@ module.exports = {
 	getBlockchainApps,
 
 	// Testing
-	getTokenIDLSK,
+	getLSKTokenID,
 };

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
@@ -91,15 +91,14 @@ const getBlockchainApps = async (params) => {
 	const { data: { chainID } } = await getNetworkStatus();
 	const { escrowedAmounts } = await requestConnector('getEscrowedAmounts');
 
-	lskTokenID = await getLSKTokenID();
-
 	blockchainAppsInfo.data = await BluebirdPromise.map(
 		dbBlockchainApps,
 		async blockchainAppInfo => {
 			const escrow = escrowedAmounts.filter(e => e.escrowChainID === blockchainAppInfo.chainID);
 
-			const escrowedAmountForTokenID = escrow.find(item => item.tokenID === lskTokenID);
-			const escrowedLSK = escrowedAmountForTokenID ? escrowedAmountForTokenID.amount : '0';
+			const escrowEntryForLSKTokenID = escrow
+				.find(async item => item.tokenID === await getLSKTokenID());
+			const escrowedLSK = escrowEntryForLSKTokenID ? escrowEntryForLSKTokenID.amount : '0';
 
 			return {
 				...blockchainAppInfo,

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
@@ -91,13 +91,13 @@ const getBlockchainApps = async (params) => {
 	const { data: { chainID } } = await getNetworkStatus();
 	const { escrowedAmounts } = await requestConnector('getEscrowedAmounts');
 
+	const tokenIdForLSK = await getLSKTokenID();
 	blockchainAppsInfo.data = await BluebirdPromise.map(
 		dbBlockchainApps,
 		async blockchainAppInfo => {
 			const escrow = escrowedAmounts.filter(e => e.escrowChainID === blockchainAppInfo.chainID);
 
-			const escrowEntryForLSKTokenID = escrow
-				.find(async item => item.tokenID === await getLSKTokenID());
+			const escrowEntryForLSKTokenID = escrow.find(item => item.tokenID === tokenIdForLSK);
 			const escrowedLSK = escrowEntryForLSKTokenID ? escrowEntryForLSKTokenID.amount : '0';
 
 			return {

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
@@ -119,4 +119,7 @@ const getBlockchainApps = async (params) => {
 
 module.exports = {
 	getBlockchainApps,
+
+	// Testing
+	getTokenIDLSK,
 };

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
@@ -94,11 +94,11 @@ const getBlockchainApps = async (params) => {
 			const escrow = escrowedAmounts.filter(e => e.escrowChainID === blockchainAppInfo.chainID);
 
 			const escrowedAmountForTokenID = escrow.find(item => item.tokenID === lskTokenID);
-			const depositedLsk = escrowedAmountForTokenID ? escrowedAmountForTokenID.amount : '0';
+			const escrowedLsk = escrowedAmountForTokenID ? escrowedAmountForTokenID.amount : '0';
 
 			return {
 				...blockchainAppInfo,
-				depositedLsk,
+				escrowedLsk,
 				escrow: escrow.length ? escrow : [{
 					tokenID: chainID.substring(0, LENGTH_NETWORK_ID).padEnd(LENGTH_TOKEN_ID, '0'),
 					amount: '0',

--- a/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
+++ b/services/blockchain-indexer/shared/dataService/business/interoperability/blockchainApps.js
@@ -28,9 +28,15 @@ const { getMainchainID } = require('./mainchain');
 
 const getBlockchainAppsTable = () => getTableInstance(blockchainAppsTableSchema, MYSQL_ENDPOINT);
 
+let lskTokenID;
+
 const getLSKTokenID = async () => {
-	const mainchainID = await getMainchainID();
-	return mainchainID.substring(0, LENGTH_NETWORK_ID).padEnd(LENGTH_TOKEN_ID, '0');
+	if (!lskTokenID) {
+		const mainchainID = await getMainchainID();
+		lskTokenID = mainchainID.substring(0, LENGTH_NETWORK_ID).padEnd(LENGTH_TOKEN_ID, '0');
+	}
+
+	return lskTokenID;
 };
 
 const getBlockchainApps = async (params) => {
@@ -85,7 +91,7 @@ const getBlockchainApps = async (params) => {
 	const { data: { chainID } } = await getNetworkStatus();
 	const { escrowedAmounts } = await requestConnector('getEscrowedAmounts');
 
-	const lskTokenID = await getLSKTokenID();
+	lskTokenID = await getLSKTokenID();
 
 	blockchainAppsInfo.data = await BluebirdPromise.map(
 		dbBlockchainApps,
@@ -93,11 +99,11 @@ const getBlockchainApps = async (params) => {
 			const escrow = escrowedAmounts.filter(e => e.escrowChainID === blockchainAppInfo.chainID);
 
 			const escrowedAmountForTokenID = escrow.find(item => item.tokenID === lskTokenID);
-			const escrowedLsk = escrowedAmountForTokenID ? escrowedAmountForTokenID.amount : '0';
+			const escrowedLSK = escrowedAmountForTokenID ? escrowedAmountForTokenID.amount : '0';
 
 			return {
 				...blockchainAppInfo,
-				escrowedLsk,
+				escrowedLSK,
 				escrow: escrow.length ? escrow : [{
 					tokenID: chainID.substring(0, LENGTH_NETWORK_ID).padEnd(LENGTH_TOKEN_ID, '0'),
 					amount: '0',

--- a/services/blockchain-indexer/tests/unit/shared/constants/blockchainApps.js
+++ b/services/blockchain-indexer/tests/unit/shared/constants/blockchainApps.js
@@ -36,7 +36,7 @@ const mockedBlockchainAppsValidResponse = {
 			address: 'lskmh468rxx5kra2xq6x35z9o5haunamm8m3svzup',
 			lastUpdated: '1694184350',
 			lastCertificateHeight: '5377',
-			escrowedLsk: '0',
+			escrowedLSK: '0',
 			escrow: [
 				{
 					escrowChainID: '04000001',

--- a/services/blockchain-indexer/tests/unit/shared/constants/blockchainApps.js
+++ b/services/blockchain-indexer/tests/unit/shared/constants/blockchainApps.js
@@ -1,0 +1,140 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+
+const mockedMainchainID = '04000000';
+
+const mockedBlockchainAppsDatabaseRes = [
+	{
+		chainID: '04000001',
+		chainName: 'enevti',
+		status: 'registered',
+		address: 'lskmh468rxx5kra2xq6x35z9o5haunamm8m3svzup',
+		lastUpdated: '1694184350',
+		lastCertificateHeight: '5377',
+	},
+];
+
+const mockedBlockchainAppsValidResponse = {
+	data: [
+		{
+			chainID: '04000001',
+			chainName: 'enevti',
+			status: 'registered',
+			address: 'lskmh468rxx5kra2xq6x35z9o5haunamm8m3svzup',
+			lastUpdated: '1694184350',
+			lastCertificateHeight: '5377',
+			escrowedLsk: '0',
+			escrow: [
+				{
+					escrowChainID: '04000001',
+					amount: '0',
+					tokenID: '0400000000000000',
+				},
+			],
+		},
+	],
+	meta: {
+		count: 1,
+		offset: 0,
+		total: 1,
+	},
+};
+
+const mockedEscrowedAmounts = {
+	escrowedAmounts: [
+		{
+			escrowChainID: '04000001',
+			amount: '0',
+			tokenID: '0400000000000000',
+		},
+	],
+};
+
+const mockedNetworkStatus = {
+	data: {
+		version: '4.0.0-beta.5',
+		networkVersion: '1.0',
+		chainID: '04000000',
+		lastBlockID: '30abcd4089a4cdc3641de579e2108d22fe03d1cccfddf7c8640507b1624c1e0a',
+		height: 9896,
+		finalizedHeight: 9883,
+		syncing: false,
+		unconfirmedTransactions: 0,
+		genesisHeight: 0,
+		genesis: {
+			block: {
+				fromFile: './config/genesis_block.blob',
+			},
+			blockTime: 10,
+			bftBatchSize: 103,
+			maxTransactionsSize: 15360,
+			minimumCertifyHeight: 1,
+			chainID: '04000000',
+		},
+		network: {
+			version: '1.0',
+			port: 7667,
+			seedPeers: [],
+		},
+		moduleCommands: [
+			'auth:registerMultisignature',
+			'interoperability:submitMainchainCrossChainUpdate',
+			'interoperability:initializeMessageRecovery',
+			'interoperability:recoverMessage',
+			'interoperability:registerSidechain',
+			'interoperability:recoverState',
+			'interoperability:terminateSidechainForLiveness',
+			'legacy:reclaimLSK',
+			'legacy:registerKeys',
+			'pos:registerValidator',
+			'pos:reportMisbehavior',
+			'pos:unlock',
+			'pos:updateGeneratorKey',
+			'pos:stake',
+			'pos:changeCommission',
+			'pos:claimRewards',
+			'token:transfer',
+			'token:transferCrossChain',
+		],
+		registeredModules: [
+			'auth',
+			'dynamicReward',
+			'fee',
+			'interoperability',
+			'legacy',
+			'pos',
+			'random',
+			'token',
+			'validators',
+		],
+		constants: {
+			chainID: '04000000',
+		},
+	},
+	meta: {
+		lastUpdate: 1694526777,
+		lastBlockHeight: 9896,
+		lastBlockID: '30abcd4089a4cdc3641de579e2108d22fe03d1cccfddf7c8640507b1624c1e0a',
+	},
+};
+
+module.exports = {
+	mockedMainchainID,
+	mockedBlockchainAppsValidResponse,
+	mockedEscrowedAmounts,
+	mockedBlockchainAppsDatabaseRes,
+	mockedNetworkStatus,
+};

--- a/services/blockchain-indexer/tests/unit/shared/dataservice/business/interoperability/blockchainApps.test.js
+++ b/services/blockchain-indexer/tests/unit/shared/dataservice/business/interoperability/blockchainApps.test.js
@@ -220,7 +220,7 @@ describe('getBlockchainApps', () => {
 	});
 });
 
-describe('getTokenIDLSK', () => {
+describe('getLSKTokenID', () => {
 	beforeEach(() => {
 		jest.resetModules();
 		jest.clearAllMocks();
@@ -231,8 +231,8 @@ describe('getTokenIDLSK', () => {
 			getMainchainID: jest.fn(() => mockedMainchainID),
 		}));
 
-		const { getTokenIDLSK } = require(mockBlockchainAppsPath);
-		await expect(getTokenIDLSK()).resolves.not.toThrow();
+		const { getLSKTokenID } = require(mockBlockchainAppsPath);
+		await expect(getLSKTokenID()).resolves.not.toThrow();
 	});
 
 	it('should throw an error if MainchainID is not found', async () => {
@@ -242,7 +242,7 @@ describe('getTokenIDLSK', () => {
 			}),
 		}));
 
-		const { getTokenIDLSK } = require(mockBlockchainAppsPath);
-		await expect(getTokenIDLSK()).rejects.toThrow();
+		const { getLSKTokenID } = require(mockBlockchainAppsPath);
+		await expect(getLSKTokenID()).rejects.toThrow();
 	});
 });

--- a/services/blockchain-indexer/tests/unit/shared/dataservice/business/interoperability/blockchainApps.test.js
+++ b/services/blockchain-indexer/tests/unit/shared/dataservice/business/interoperability/blockchainApps.test.js
@@ -181,43 +181,6 @@ describe('getBlockchainApps', () => {
 		const { getBlockchainApps } = require(mockBlockchainAppsPath);
 		await expect(getBlockchainApps(params)).rejects.toThrow();
 	});
-
-	it('should throw an error if MainchainID is not found', async () => {
-		const params = {
-			limit: 10,
-			offset: 0,
-		};
-
-		jest.mock('lisk-service-framework', () => ({
-			DB: {
-				MySQL: {
-					getTableInstance: jest.fn(() => ({
-						find: jest.fn(() => mockedBlockchainAppsDatabaseRes),
-						count: jest.fn(() => mockedBlockchainAppsValidResponse.meta.count),
-					})),
-				},
-			},
-		}));
-
-		jest.mock(mockNetworkPath, () => ({
-			getNetworkStatus: jest.fn(() => (
-				mockedNetworkStatus
-			)),
-		}));
-
-		jest.mock(mockRequestPath, () => ({
-			requestConnector: jest.fn(() => (mockedEscrowedAmounts)),
-		}));
-
-		jest.mock(mockMainchainPath, () => ({
-			getMainchainID: jest.fn(() => {
-				throw Error('MainchainID not found');
-			}),
-		}));
-
-		const { getBlockchainApps } = require(mockBlockchainAppsPath);
-		await expect(getBlockchainApps(params)).rejects.toThrow();
-	});
 });
 
 describe('getLSKTokenID', () => {

--- a/services/blockchain-indexer/tests/unit/shared/dataservice/business/interoperability/blockchainApps.test.js
+++ b/services/blockchain-indexer/tests/unit/shared/dataservice/business/interoperability/blockchainApps.test.js
@@ -1,0 +1,248 @@
+/*
+ * LiskHQ/lisk-service
+ * Copyright © 2023 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+/* eslint-disable import/no-dynamic-require */
+const { resolve } = require('path');
+
+const {
+	mockedMainchainID,
+	mockedBlockchainAppsValidResponse,
+	mockedEscrowedAmounts,
+	mockedBlockchainAppsDatabaseRes,
+	mockedNetworkStatus,
+} = require('../../../constants/blockchainApps');
+
+const mockNetworkPath = resolve(`${__dirname}/../../../../../../shared/dataService/business/network`);
+const mockMainchainPath = resolve(`${__dirname}/../../../../../../shared/dataService/business/interoperability/mainchain`);
+const mockRequestPath = resolve(`${__dirname}/../../../../../../shared/utils/request`);
+const mockBlockchainAppsPath = resolve(`${__dirname}/../../../../../../shared/dataService/business/interoperability/blockchainApps`);
+
+describe('getBlockchainApps', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.clearAllMocks();
+	});
+
+	it('should fetch and process blockchain applications', async () => {
+		const params = {
+			limit: 10,
+			offset: 0,
+		};
+
+		jest.mock('lisk-service-framework', () => ({
+			DB: {
+				MySQL: {
+					getTableInstance: jest.fn(() => ({
+						find: jest.fn(() => mockedBlockchainAppsDatabaseRes),
+						count: jest.fn(() => mockedBlockchainAppsValidResponse.meta.count),
+					})),
+				},
+			},
+		}));
+
+		jest.mock(mockNetworkPath, () => ({
+			getNetworkStatus: jest.fn(() => (
+				mockedNetworkStatus
+			)),
+		}));
+
+		jest.mock(mockRequestPath, () => ({
+			requestConnector: jest.fn(() => (mockedEscrowedAmounts)),
+		}));
+
+		jest.mock(mockMainchainPath, () => ({
+			getMainchainID: jest.fn(() => mockedMainchainID),
+		}));
+
+		const { getBlockchainApps } = require(mockBlockchainAppsPath);
+		const result = await getBlockchainApps(params);
+		expect(result.data).toHaveLength(1);
+		expect(result.meta.count).toBe(1);
+		expect(result).toEqual(mockedBlockchainAppsValidResponse);
+	});
+
+	it('should throw an error if the database is not reachable', async () => {
+		const params = {
+			limit: 10,
+			offset: 0,
+		};
+
+		jest.mock('lisk-service-framework', () => ({
+			DB: {
+				MySQL: {
+					getTableInstance: jest.fn(() => ({
+						find: jest.fn(() => {
+							throw Error('Database not reachable');
+						}),
+						count: jest.fn(() => mockedBlockchainAppsValidResponse.meta.count),
+					})),
+				},
+			},
+		}));
+
+		jest.mock(mockNetworkPath, () => ({
+			getNetworkStatus: jest.fn(() => (
+				mockedNetworkStatus
+			)),
+		}));
+
+		jest.mock(mockRequestPath, () => ({
+			requestConnector: jest.fn(() => (mockedEscrowedAmounts)),
+		}));
+
+		jest.mock(mockMainchainPath, () => ({
+			getMainchainID: jest.fn(() => mockedMainchainID),
+		}));
+
+		const { getBlockchainApps } = require(mockBlockchainAppsPath);
+		await expect(getBlockchainApps(params)).rejects.toThrow();
+	});
+
+	it('should throw an error if network status is not reachable', async () => {
+		const params = {
+			limit: 10,
+			offset: 0,
+		};
+
+		jest.mock('lisk-service-framework', () => ({
+			DB: {
+				MySQL: {
+					getTableInstance: jest.fn(() => ({
+						find: jest.fn(() => mockedBlockchainAppsDatabaseRes),
+						count: jest.fn(() => mockedBlockchainAppsValidResponse.meta.count),
+					})),
+				},
+			},
+		}));
+
+		jest.mock(mockNetworkPath, () => ({
+			getNetworkStatus: jest.fn(() => {
+				throw Error('Network status not reachable');
+			}),
+		}));
+
+		jest.mock(mockRequestPath, () => ({
+			requestConnector: jest.fn(() => (mockedEscrowedAmounts)),
+		}));
+
+		jest.mock(mockMainchainPath, () => ({
+			getMainchainID: jest.fn(() => mockedMainchainID),
+		}));
+
+		const { getBlockchainApps } = require(mockBlockchainAppsPath);
+		await expect(getBlockchainApps(params)).rejects.toThrow();
+	});
+
+	it('should throw an error if the connector is not reachable', async () => {
+		const params = {
+			limit: 10,
+			offset: 0,
+		};
+
+		jest.mock('lisk-service-framework', () => ({
+			DB: {
+				MySQL: {
+					getTableInstance: jest.fn(() => ({
+						find: jest.fn(() => mockedBlockchainAppsDatabaseRes),
+						count: jest.fn(() => mockedBlockchainAppsValidResponse.meta.count),
+					})),
+				},
+			},
+		}));
+
+		jest.mock(mockNetworkPath, () => ({
+			getNetworkStatus: jest.fn(() => (
+				mockedNetworkStatus
+			)),
+		}));
+
+		jest.mock(mockRequestPath, () => ({
+			requestConnector: jest.fn(() => {
+				throw Error('Connector not reachable');
+			}),
+		}));
+
+		jest.mock(mockMainchainPath, () => ({
+			getMainchainID: jest.fn(() => mockedMainchainID),
+		}));
+
+		const { getBlockchainApps } = require(mockBlockchainAppsPath);
+		await expect(getBlockchainApps(params)).rejects.toThrow();
+	});
+
+	it('should throw an error if MainchainID is not found', async () => {
+		const params = {
+			limit: 10,
+			offset: 0,
+		};
+
+		jest.mock('lisk-service-framework', () => ({
+			DB: {
+				MySQL: {
+					getTableInstance: jest.fn(() => ({
+						find: jest.fn(() => mockedBlockchainAppsDatabaseRes),
+						count: jest.fn(() => mockedBlockchainAppsValidResponse.meta.count),
+					})),
+				},
+			},
+		}));
+
+		jest.mock(mockNetworkPath, () => ({
+			getNetworkStatus: jest.fn(() => (
+				mockedNetworkStatus
+			)),
+		}));
+
+		jest.mock(mockRequestPath, () => ({
+			requestConnector: jest.fn(() => (mockedEscrowedAmounts)),
+		}));
+
+		jest.mock(mockMainchainPath, () => ({
+			getMainchainID: jest.fn(() => {
+				throw Error('MainchainID not found');
+			}),
+		}));
+
+		const { getBlockchainApps } = require(mockBlockchainAppsPath);
+		await expect(getBlockchainApps(params)).rejects.toThrow();
+	});
+});
+
+describe('getTokenIDLSK', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.clearAllMocks();
+	});
+
+	it('should generate the token ID based on the mainchain ID', async () => {
+		jest.mock(mockMainchainPath, () => ({
+			getMainchainID: jest.fn(() => mockedMainchainID),
+		}));
+
+		const { getTokenIDLSK } = require(mockBlockchainAppsPath);
+		await expect(getTokenIDLSK()).resolves.not.toThrow();
+	});
+
+	it('should throw an error if MainchainID is not found', async () => {
+		jest.mock(mockMainchainPath, () => ({
+			getMainchainID: jest.fn(() => {
+				throw Error('MainchainID not found');
+			}),
+		}));
+
+		const { getTokenIDLSK } = require(mockBlockchainAppsPath);
+		await expect(getTokenIDLSK()).rejects.toThrow();
+	});
+});

--- a/services/gateway/apis/http-version3/swagger/definitions/blockchainApps.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/blockchainApps.json
@@ -42,7 +42,7 @@
 				"example": 1616008148,
 				"description": "timestamp"
 			},
-			"escrowedLsk": {
+			"escrowedLSK": {
 				"type": "string",
 				"example": "50000000000",
 				"description": "Number of LSK tokens escrowed to the sidechain."

--- a/services/gateway/apis/http-version3/swagger/definitions/blockchainApps.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/blockchainApps.json
@@ -42,6 +42,11 @@
 				"example": 1616008148,
 				"description": "timestamp"
 			},
+			"depositedLsk": {
+				"type": "string",
+				"example": "50000000000",
+				"description": "Number of LSK tokens escrowed to the sidechain."
+			},
 			"escrow": {
 				"type": "array",
 				"required": [

--- a/services/gateway/apis/http-version3/swagger/definitions/blockchainApps.json
+++ b/services/gateway/apis/http-version3/swagger/definitions/blockchainApps.json
@@ -42,7 +42,7 @@
 				"example": 1616008148,
 				"description": "timestamp"
 			},
-			"depositedLsk": {
+			"escrowedLsk": {
 				"type": "string",
 				"example": "50000000000",
 				"description": "Number of LSK tokens escrowed to the sidechain."

--- a/services/gateway/sources/version3/mappings/blockchainApp.js
+++ b/services/gateway/sources/version3/mappings/blockchainApp.js
@@ -20,7 +20,7 @@ module.exports = {
 	address: '=,string',
 	lastCertificateHeight: '=,number',
 	lastUpdated: '=,number',
-	depositedLsk: '=,string',
+	escrowedLsk: '=,string',
 	escrow: ['escrow', {
 		tokenID: '=,string',
 		amount: '=,string',

--- a/services/gateway/sources/version3/mappings/blockchainApp.js
+++ b/services/gateway/sources/version3/mappings/blockchainApp.js
@@ -20,6 +20,7 @@ module.exports = {
 	address: '=,string',
 	lastCertificateHeight: '=,number',
 	lastUpdated: '=,number',
+	depositedLsk: '=,string',
 	escrow: ['escrow', {
 		tokenID: '=,string',
 		amount: '=,string',

--- a/services/gateway/sources/version3/mappings/blockchainApp.js
+++ b/services/gateway/sources/version3/mappings/blockchainApp.js
@@ -20,7 +20,7 @@ module.exports = {
 	address: '=,string',
 	lastCertificateHeight: '=,number',
 	lastUpdated: '=,number',
-	escrowedLsk: '=,string',
+	escrowedLSK: '=,string',
 	escrow: ['escrow', {
 		tokenID: '=,string',
 		amount: '=,string',

--- a/tests/schemas/api_v3/blockchainApps.schema.js
+++ b/tests/schemas/api_v3/blockchainApps.schema.js
@@ -47,7 +47,7 @@ const dataSchema = {
 	status: Joi.string().valid(...validStatuses).required(),
 	address: Joi.string().pattern(regex.ADDRESS_LISK32).required(),
 	lastCertificateHeight: Joi.number().integer().min(0).required(),
-	escrowedLsk: Joi.string().pattern(regex.DIGITS).required(),
+	escrowedLSK: Joi.string().pattern(regex.DIGITS).required(),
 	lastUpdated: Joi.number()
 		.integer()
 		.positive()

--- a/tests/schemas/api_v3/blockchainApps.schema.js
+++ b/tests/schemas/api_v3/blockchainApps.schema.js
@@ -47,6 +47,7 @@ const dataSchema = {
 	status: Joi.string().valid(...validStatuses).required(),
 	address: Joi.string().pattern(regex.ADDRESS_LISK32).required(),
 	lastCertificateHeight: Joi.number().integer().min(0).required(),
+	depositedLsk: Joi.string().pattern(regex.DIGITS).required(),
 	lastUpdated: Joi.number()
 		.integer()
 		.positive()

--- a/tests/schemas/api_v3/blockchainApps.schema.js
+++ b/tests/schemas/api_v3/blockchainApps.schema.js
@@ -47,7 +47,7 @@ const dataSchema = {
 	status: Joi.string().valid(...validStatuses).required(),
 	address: Joi.string().pattern(regex.ADDRESS_LISK32).required(),
 	lastCertificateHeight: Joi.number().integer().min(0).required(),
-	depositedLsk: Joi.string().pattern(regex.DIGITS).required(),
+	escrowedLsk: Joi.string().pattern(regex.DIGITS).required(),
 	lastUpdated: Joi.number()
 		.integer()
 		.positive()


### PR DESCRIPTION
### What was the problem?
This PR resolves #1830 

### How was it solved?
- [x] Extend the /blockchain/apps endpoint response to support depositedLsk
- [x] Integration tests are up-to-date
- [x] Swagger is up-to-date
- [x] API documentation is up-to-date
- [x] Add unit tests


### How was it tested?
Local
