### PR TITLE
503 response not present in swagger for fees endpoint

### DIFF
--- a/services/gateway/apis/http-version3/methods/fees.js
+++ b/services/gateway/apis/http-version3/methods/fees.js
@@ -39,6 +39,12 @@ module.exports = {
 					$ref: '#/definitions/FeeEstimateEnvelope',
 				},
 			},
+			503: {
+				description: 'Service Unavailable',
+				schema: {
+					$ref: '#/definitions/serviceUnavailable',
+				},
+			},
 		};
 		return feeEstimatePerByteSchema;
 	},

--- a/services/gateway/tests/constants/generateDocs.js
+++ b/services/gateway/tests/constants/generateDocs.js
@@ -505,6 +505,12 @@ const createApiDocsExpectedResponse = {
 						$ref: '#/definitions/FeeEstimateEnvelope',
 					},
 				},
+				503: {
+					description: 'Service Unavailable',
+					schema: {
+						$ref: '#/definitions/serviceUnavailable',
+					},
+				},
 			},
 		},
 	},


### PR DESCRIPTION
### What was the problem?
This PR resolves #1858 

### How was it solved?
- [x] Added 503 to fees endpoint

### How was it tested?
Local
