### PR TITLE
Querying events by senderAddress errors

### DIFF
--- a/services/blockchain-connector/tests/unit/delay.test.js
+++ b/services/blockchain-connector/tests/unit/delay.test.js
@@ -30,6 +30,6 @@ describe('Test delay method', () => {
 		await delay(delayMs);
 		const endTime = Date.now();
 		const millisDifference = endTime - startTime;
-		expect(millisDifference).toBeGreaterThanOrEqual(delayMs);
+		expect(millisDifference).toBeGreaterThanOrEqual(delayMs * 0.98);
 	});
 });

--- a/services/blockchain-connector/tests/unit/delay.test.js
+++ b/services/blockchain-connector/tests/unit/delay.test.js
@@ -30,6 +30,6 @@ describe('Test delay method', () => {
 		await delay(delayMs);
 		const endTime = Date.now();
 		const millisDifference = endTime - startTime;
-		expect(millisDifference).toBeGreaterThanOrEqual(delayMs * 0.98);
+		expect(millisDifference).toBeGreaterThanOrEqual(delayMs - 1);
 	});
 });

--- a/services/blockchain-connector/tests/unit/waitForIt.test.js
+++ b/services/blockchain-connector/tests/unit/waitForIt.test.js
@@ -36,7 +36,7 @@ describe('Test waitForIt method', () => {
 		await waitForIt(testFn);
 		const endTime = Date.now();
 		const millisDifference = endTime - startTime;
-		expect(millisDifference).toBeGreaterThanOrEqual(delayMs);
+		expect(millisDifference).toBeGreaterThanOrEqual(delayMs * 0.98);
 	});
 
 	it('should wait for the mocked function to return response', async () => {

--- a/services/blockchain-connector/tests/unit/waitForIt.test.js
+++ b/services/blockchain-connector/tests/unit/waitForIt.test.js
@@ -36,7 +36,7 @@ describe('Test waitForIt method', () => {
 		await waitForIt(testFn);
 		const endTime = Date.now();
 		const millisDifference = endTime - startTime;
-		expect(millisDifference).toBeGreaterThanOrEqual(delayMs * 0.98);
+		expect(millisDifference).toBeGreaterThanOrEqual(delayMs - 1);
 	});
 
 	it('should wait for the mocked function to return response', async () => {

--- a/services/blockchain-indexer/shared/dataService/business/events.js
+++ b/services/blockchain-indexer/shared/dataService/business/events.js
@@ -160,7 +160,18 @@ const getEvents = async (params) => {
 			throw new NotFoundException(`Invalid blockID: ${blockID}`);
 		}
 		if ('height' in params && Number(params.height) !== block.height) {
-			throw new NotFoundException(`Invalid combination of blockID: ${blockID} and height: ${params.height}`);
+			let heightLowerBound = Number(params.height);
+			let heightHigherBound = Number(params.height);
+
+			if (typeof params.height === 'string' && params.height.includes(':')) {
+				const [fromStr, toStr] = params.height.split(':');
+				heightLowerBound = Number(fromStr);
+				heightHigherBound = Number(toStr);
+			}
+
+			if (block.height < heightLowerBound || block.height > heightHigherBound) {
+				throw new NotFoundException(`Invalid combination of blockID: ${blockID} and height: ${params.height}`);
+			}
 		}
 		queryParams.height = block.height;
 	}

--- a/services/blockchain-indexer/shared/dataService/business/events.js
+++ b/services/blockchain-indexer/shared/dataService/business/events.js
@@ -14,6 +14,7 @@
  *
  */
 const BluebirdPromise = require('bluebird');
+const _ = require('lodash');
 
 const {
 	CacheLRU,
@@ -99,6 +100,8 @@ const cacheEventsByBlockID = async (blockID, events) => {
 const deleteEventsFromCache = async (height) => eventCache.delete(height);
 
 const getEvents = async (params) => {
+	let queryParams = _.cloneDeep(params);
+
 	const blocksTable = await getBlocksTable();
 	const eventsTable = await getEventsTable();
 	const eventTopicsTable = await getEventTopicsTable();
@@ -108,66 +111,70 @@ const getEvents = async (params) => {
 		meta: {},
 	};
 
-	const isTopicInQuery = !!params.topic;
-
 	if (params.height && typeof params.height === 'string' && params.height.includes(':')) {
-		params = normalizeRangeParam(params, 'height');
+		queryParams = normalizeRangeParam(queryParams, 'height');
 	}
 
 	if (params.timestamp && params.timestamp.includes(':')) {
-		params = normalizeRangeParam(params, 'timestamp');
+		queryParams = normalizeRangeParam(queryParams, 'timestamp');
 	}
 
 	if (params.topic) {
-		const { topic, ...remParams } = params;
-		params = remParams;
-		params.whereIn = {
+		const { topic, ...remQueryParams } = queryParams;
+		queryParams = remQueryParams;
+
+		queryParams.whereIn = {
 			property: 'topic',
 			values: topic.split(','),
 		};
 	}
 
 	if (params.transactionID) {
-		const { transactionID, topic, ...remParams } = params;
-		params = remParams;
-		if (!topic) {
-			params.topic = transactionID;
+		const { transactionID, ...remQueryParams } = queryParams;
+		queryParams = remQueryParams;
+
+		if (!params.topic) {
+			queryParams.topic = transactionID;
 		} else {
-			params.andWhere = { topic: transactionID };
+			queryParams.andWhere = { topic: transactionID };
 		}
 	}
 
 	if (params.senderAddress) {
-		const { senderAddress, topic, ...remParams } = params;
-		params = remParams;
-		if (!topic) {
-			params.topic = senderAddress;
+		const { senderAddress, ...remQueryParams } = queryParams;
+		queryParams = remQueryParams;
+
+		if (!params.topic) {
+			queryParams.topic = senderAddress;
 		} else {
-			params.andWhere = { topic: senderAddress };
+			queryParams.andWhere = { topic: senderAddress };
 		}
 	}
 
 	if (params.blockID) {
-		const { blockID, ...remParams } = params;
-		params = remParams;
+		const { blockID, ...remQueryParams } = queryParams;
+		queryParams = remQueryParams;
+
 		const [block] = await blocksTable.find({ id: blockID, limit: 1 }, ['height']);
 		if (!block || !block.height) {
 			throw new NotFoundException(`Invalid blockID: ${blockID}`);
 		}
-		if ('height' in params && params.height !== block.height) {
+		if ('height' in params && Number(params.height) !== block.height) {
 			throw new NotFoundException(`Invalid combination of blockID: ${blockID} and height: ${params.height}`);
 		}
-		params.height = block.height;
+		queryParams.height = block.height;
 	}
 
-	params.leftOuterJoin = {
+	const isTopicInQuery = !!params.topic || !!queryParams.topic;
+
+	queryParams.leftOuterJoin = {
 		targetTable: eventsTableSchema.tableName,
 		leftColumn: `${eventsTableSchema.tableName}.id`,
 		rightColumn: `${eventTopicsTableSchema.tableName}.eventID`,
 	};
 
 	const eventsInfo = await eventTopicsTable.find(
-		{ ...params, distinct: 'eventID' },
+		{ ...queryParams, distinct: 'eventID' },
 		['eventStr', 'height', 'index'],
 	);
 
@@ -194,17 +201,17 @@ const getEvents = async (params) => {
 	);
 
 	let total;
-	const { order, sort, ...remParams } = params;
+	const { order, sort, ...remQueryParams } = queryParams;
 
 	if (isTopicInQuery) {
 		total = await eventTopicsTable.count(
-			{ ...remParams, groupBy: 'eventID' },
+			{ ...remQueryParams, distinct: 'eventID' },
 			['eventID'],
 		);
 	} else {
-		// If params dosent contain event_topics specific column data
+		// If params doesn't contain event_topics specific column data
 		// then count all rows of event table for query optimization.
-		const { leftOuterJoin, ...remParamsWithoutJoin } = remParams;
+		const { leftOuterJoin, ...remParamsWithoutJoin } = remQueryParams;
 		total = await eventsTable.count(remParamsWithoutJoin, ['id']);
 	}
 

--- a/services/blockchain-indexer/tests/unit/shared/constants/events.js
+++ b/services/blockchain-indexer/tests/unit/shared/constants/events.js
@@ -321,7 +321,6 @@ const getEventsResult = {
 };
 
 const mockEventTopicsQueryParams = {
-	height: 123,
 	sort: 'timestamp:desc',
 	order: 'index:asc',
 	limit: 10,
@@ -338,12 +337,23 @@ const mockEventTopicsQueryParams = {
 			to: 1000000000,
 		},
 	],
+	whereIn: {
+		property: 'topic',
+		values: [
+			'03',
+		],
+	},
+	height: 123,
 	leftOuterJoin: {
 		targetTable: 'events',
 		leftColumn: 'events.id',
 		rightColumn: 'event_topics.eventID',
 	},
-	distinct: 'eventID' };
+	andWhere: {
+		topic: 'lskw68y3kyus7ota9mykr726aby44mw574m8dkngu',
+	},
+	distinct: 'eventID',
+};
 
 module.exports = {
 	mockEventTopics,

--- a/services/blockchain-indexer/tests/unit/shared/constants/events.js
+++ b/services/blockchain-indexer/tests/unit/shared/constants/events.js
@@ -320,8 +320,34 @@ const getEventsResult = {
 	},
 };
 
+const mockEventTopicsQueryParams = {
+	height: 123,
+	sort: 'timestamp:desc',
+	order: 'index:asc',
+	limit: 10,
+	offset: 0,
+	propBetweens: [
+		{
+			property: 'height',
+			from: 1,
+			to: 1000,
+		},
+		{
+			property: 'timestamp',
+			from: 1,
+			to: 1000000000,
+		},
+	],
+	leftOuterJoin: {
+		targetTable: 'events',
+		leftColumn: 'events.id',
+		rightColumn: 'event_topics.eventID',
+	},
+	distinct: 'eventID' };
+
 module.exports = {
 	mockEventTopics,
 	mockEventsForEventTopics,
 	getEventsResult,
+	mockEventTopicsQueryParams,
 };

--- a/services/blockchain-indexer/tests/unit/shared/dataservice/business/events.test.js
+++ b/services/blockchain-indexer/tests/unit/shared/dataservice/business/events.test.js
@@ -243,6 +243,8 @@ describe('getEvents', () => {
 
 		const params = {
 			blockID,
+			topic: '03',
+			senderAddress: 'lskw68y3kyus7ota9mykr726aby44mw574m8dkngu',
 			timestamp: '1:1000000000',
 			height: '1:1000',
 			sort: 'timestamp:desc',

--- a/services/blockchain-indexer/tests/unit/shared/dataservice/business/events.test.js
+++ b/services/blockchain-indexer/tests/unit/shared/dataservice/business/events.test.js
@@ -25,7 +25,7 @@ const mockEventsFilePath = path.resolve(`${__dirname}/../../../../../shared/data
 const mockBlocksTableSchema = require('../../../../../shared/database/schema/blocks');
 const mockEventsTableSchema = require('../../../../../shared/database/schema/events');
 const mockEventTopicsTableSchema = require('../../../../../shared/database/schema/eventTopics');
-const { mockEventTopics, mockEventsForEventTopics, getEventsResult } = require('../../constants/events');
+const { mockEventTopics, mockEventsForEventTopics, getEventsResult, mockEventTopicsQueryParams } = require('../../constants/events');
 
 describe('getEventsByBlockID', () => {
 	beforeEach(() => {
@@ -187,6 +187,8 @@ describe('getEvents', () => {
 	});
 
 	it('should retrieve events successfully', async () => {
+		const blockID = '793acee22acea7f4f474e2f8e9e24cb9220da2fc2405026214b5d72a152cb55d';
+
 		jest.mock('../../../../../config', () => {
 			const actual = jest.requireActual('../../../../../config');
 			return {
@@ -207,7 +209,16 @@ describe('getEvents', () => {
 						getTableInstance: jest.fn((schema) => {
 							if (schema.tableName === mockBlocksTableSchema.tableName) {
 								return {
-									find: jest.fn(() => []),
+									find: jest.fn((queryParams) => {
+										if (queryParams.id) {
+											expect(queryParams.id).toBe(blockID);
+										}
+
+										return [{
+											blockID,
+											height: 123,
+										}];
+									}),
 								};
 							} if (schema.tableName === mockEventsTableSchema.tableName) {
 								return {
@@ -216,7 +227,10 @@ describe('getEvents', () => {
 								};
 							} if (schema.tableName === mockEventTopicsTableSchema.tableName) {
 								return {
-									find: jest.fn(() => mockEventsForEventTopics),
+									find: jest.fn((queryParams) => {
+										expect(queryParams).toEqual(mockEventTopicsQueryParams);
+										return mockEventsForEventTopics;
+									}),
 									count: jest.fn(() => 10),
 								};
 							}
@@ -228,6 +242,9 @@ describe('getEvents', () => {
 		});
 
 		const params = {
+			blockID,
+			timestamp: '1:1000000000',
+			height: '1:1000',
 			sort: 'timestamp:desc',
 			order: 'index:asc',
 			limit: 10,

--- a/services/gateway/tests/unit/shared/waitForIt.test.js
+++ b/services/gateway/tests/unit/shared/waitForIt.test.js
@@ -38,7 +38,7 @@ describe('Test waitForIt method', () => {
 		await waitForIt(testFn);
 		const endTime = Date.now();
 		const millisDifference = endTime - startTime;
-		expect(millisDifference).toBeGreaterThanOrEqual(delayMs);
+		expect(millisDifference).toBeGreaterThanOrEqual(delayMs * 0.98);
 	});
 
 	it('should wait for the mocked function to return response', async () => {

--- a/services/gateway/tests/unit/shared/waitForIt.test.js
+++ b/services/gateway/tests/unit/shared/waitForIt.test.js
@@ -38,7 +38,7 @@ describe('Test waitForIt method', () => {
 		await waitForIt(testFn);
 		const endTime = Date.now();
 		const millisDifference = endTime - startTime;
-		expect(millisDifference).toBeGreaterThanOrEqual(delayMs * 0.98);
+		expect(millisDifference).toBeGreaterThanOrEqual(delayMs - 1);
 	});
 
 	it('should wait for the mocked function to return response', async () => {


### PR DESCRIPTION
### What was the problem?
This PR resolves #1864 #1863

### How was it solved?
- [x] Avoid inplace modification for passed api params and refactor check for presence of `topic`
- [x] Relax condition for `waitForIt` and `delay` functions test to avoid intermittent ci failure

### How was it tested?
- [x] Local
