### PR TITLE
Automatic API client re-instantiation fails

### DIFF
--- a/services/blockchain-connector/shared/sdk/client.js
+++ b/services/blockchain-connector/shared/sdk/client.js
@@ -38,7 +38,8 @@ let clientCache;
 let instantiationBeginTime;
 let isInstantiating = false;
 
-const checkIsClientAlive = () => clientCache && clientCache._channel.isAlive;
+const checkIsClientAlive = () =>
+	clientCache && clientCache._channel && clientCache._channel.isAlive;
 
 // eslint-disable-next-line consistent-return
 const instantiateClient = async (isForceUpdate = false) => {
@@ -80,10 +81,7 @@ const instantiateClient = async (isForceUpdate = false) => {
 		if (err.code === 'ECONNREFUSED')
 			throw new Error('ECONNREFUSED: Unable to reach a network node.');
 
-		return {
-			data: { error: 'Action not supported' },
-			status: 'METHOD_NOT_ALLOWED',
-		};
+		return clientCache;
 	}
 };
 


### PR DESCRIPTION
### What was the problem?

This PR resolves #1920 

### How was it solved?

- [x] Fix error handling in `instantiateClient`

### How was it tested?

Locally
  - Added: `if (Math.ceil(Math.random() * 10) % 2 === 0) throw new Error('Test API client fix');` within `instantiateClient` immediately after the IPC/WS API client instantiation logic and run against Lisk Core
