### PR TITLE
Add receivingChainID request param support to transactions endpoint

### DIFF
--- a/services/blockchain-indexer/methods/dataService/transactions.js
+++ b/services/blockchain-indexer/methods/dataService/transactions.js
@@ -33,6 +33,7 @@ module.exports = [
 			address: { optional: true, type: 'string' },
 			senderAddress: { optional: true, type: 'string' },
 			recipientAddress: { optional: true, type: 'string' },
+			receivingChainID: { optional: true, type: 'string' },
 			timestamp: { optional: true, type: 'string' },
 			nonce: { optional: true, type: 'string' },
 			blockID: { optional: true, type: 'string' },

--- a/services/blockchain-indexer/shared/dataService/business/pendingTransactions.js
+++ b/services/blockchain-indexer/shared/dataService/business/pendingTransactions.js
@@ -132,7 +132,9 @@ const getPendingTransactions = async params => {
 					transaction.sender.address === validatedParams.address ||
 					transaction.params.recipientAddress === validatedParams.address) &&
 				(!validatedParams.moduleCommand ||
-					transaction.moduleCommand === validatedParams.moduleCommand),
+					transaction.moduleCommand === validatedParams.moduleCommand) &&
+				(!validatedParams.receivingChainID ||
+					transaction.params.receivingChainID === validatedParams.receivingChainID),
 		);
 
 		pendingTransactions.data = filteredPendingTxs

--- a/services/blockchain-indexer/shared/dataService/business/pendingTransactions.js
+++ b/services/blockchain-indexer/shared/dataService/business/pendingTransactions.js
@@ -92,6 +92,7 @@ const validateParams = async params => {
 	if (params.senderAddress) validatedParams.senderAddress = params.senderAddress;
 	if (params.recipientAddress) validatedParams.recipientAddress = params.recipientAddress;
 	if (params.moduleCommand) validatedParams.moduleCommand = params.moduleCommand;
+	if (params.receivingChainID) validatedParams.receivingChainID = params.receivingChainID;
 	if (params.sort) validatedParams.sort = params.sort;
 
 	return validatedParams;

--- a/services/blockchain-indexer/shared/database/schema/transactions.js
+++ b/services/blockchain-indexer/shared/database/schema/transactions.js
@@ -46,6 +46,7 @@ module.exports = {
 		amount: { type: 'range' },
 		data: { type: 'key' },
 		senderAddress: { type: 'key' },
+		receivingChainID: { type: 'key' },
 		executionStatus: { type: 'key' },
 	},
 	purge: {},

--- a/services/blockchain-indexer/tests/unit/shared/constants/pendingTransactions.js
+++ b/services/blockchain-indexer/tests/unit/shared/constants/pendingTransactions.js
@@ -1,0 +1,58 @@
+const mockSenderAddress = 'lskvq67zzev53sa6ozt39ft3dsmwxxztb7h29275k';
+const mockRecipientAddress = 'lskyvvam5rxyvbvofxbdfcupxetzmqxu22phm4yuo';
+
+const mockSenderAccountDetails = {
+	name: 'genesis',
+	publicKey: '3972849f2ab66376a68671c10a00e8b8b67d880434cc65b04c6ed886dfa91c2c',
+};
+
+const mockPendingTransactions = [
+	{
+		module: 'token',
+		command: 'transfer',
+		fee: '100000000',
+		nonce: '1',
+		senderPublicKey: '3972849f2ab66376a68671c10a00e8b8b67d880434cc65b04c6ed886dfa91c2c',
+		signatures: [
+			'c7fd1abf9a552fa9c91b4121c87ae2c97cb0fc0aecc87d0ee8b1aa742238eef4a6815ddba31e21144c9652a7bd5c05577ae1100eac34fba43da6fc4879b8f206',
+		],
+		params: {
+			tokenID: '0000000000000000',
+			amount: '100000000000',
+			recipientAddress: 'lskyvvam5rxyvbvofxbdfcupxetzmqxu22phm4yuo',
+			data: '',
+		},
+		id: 'd96c777b67576ddf4cd933a97a60b4311881e68e3c8bef1393ac0020ec8a506c',
+		size: 167,
+		minFee: '166000',
+	},
+	{
+		module: 'token',
+		command: 'transferCrossChain',
+		fee: '100000000',
+		nonce: '1',
+		senderPublicKey: '3972849f2ab66376a68671c10a00e8b8b67d880434cc65b04c6ed886dfa91c2c',
+		signatures: [
+			'c7fd1abf9a552fa9c91b4121c87ae2c97cb0fc0aecc87d0ee8b1aa742238eef4a6815ddba31e21144c9652a7bd5c05577ae1100eac34fba43da6fc4879b8f206',
+		],
+		params: {
+			tokenID: '0000000000000000',
+			amount: '100000000000',
+			recipientAddress: 'lskyvvam5rxyvbvofxbdfcupxetzmqxu22phm4yuo',
+			receivingChainID: '02000000',
+			data: '',
+			messageFee: '10000000',
+			messageFeeTokenID: '0200000000000000',
+		},
+		id: 'd96c777b67576ddf4cd933a97a60b4311881e68e3c8bef1393ac0020ec8a506d',
+		size: 167,
+		minFee: '166000',
+	},
+];
+
+module.exports = {
+	mockPendingTransactions,
+	mockSenderAddress,
+	mockRecipientAddress,
+	mockSenderAccountDetails,
+};

--- a/services/blockchain-indexer/tests/unit/shared/dataservice/business/transactionEstimateFees.test.js
+++ b/services/blockchain-indexer/tests/unit/shared/dataservice/business/transactionEstimateFees.test.js
@@ -62,11 +62,13 @@ const {
 	mockRegisterValidatorTxResult,
 } = require('../../constants/transactionEstimateFees');
 
+const { tokenHasUserAccount } = require('../../../../../shared/dataService/business/token');
+
 const {
-	tokenHasUserAccount,
-	getTokenConstants,
-	getTokenBalances,
-} = require('../../../../../shared/dataService/business/token');
+	dryRunTransactions,
+} = require('../../../../../shared/dataService/business/transactionsDryRun');
+
+const { requestConnector } = require('../../../../../shared/utils/request');
 
 jest.mock('lisk-service-framework', () => {
 	const actual = jest.requireActual('lisk-service-framework');
@@ -138,40 +140,28 @@ jest.mock('../../../../../shared/dataService/business/schemas', () => {
 });
 
 jest.mock('../../../../../shared/dataService/business/token', () => ({
-	tokenHasUserAccount: jest.fn(),
-	getTokenConstants: jest.fn(),
-	getTokenBalances: jest.fn(),
-}));
-
-tokenHasUserAccount.mockImplementation(() => ({
-	data: { isExists: true },
-	meta: {},
-}));
-
-getTokenConstants.mockImplementation(() => ({
-	data: {
-		extraCommandFees: {
-			userAccountInitializationFee: '5000000',
-			escrowAccountInitializationFee: '5000000',
+	tokenHasUserAccount: jest.fn().mockImplementation(() => ({
+		data: { isExists: true },
+		meta: {},
+	})),
+	getTokenConstants: jest.fn().mockImplementation(() => ({
+		data: {
+			extraCommandFees: {
+				userAccountInitializationFee: '5000000',
+				escrowAccountInitializationFee: '5000000',
+			},
 		},
-	},
-	meta: {},
+		meta: {},
+	})),
+	getTokenBalances: jest.fn().mockImplementation(() => ({
+		data: [{ availableBalance: '500000000000' }],
+		meta: {},
+	})),
 }));
-
-getTokenBalances.mockImplementation(() => ({
-	data: [{ availableBalance: '500000000000' }],
-	meta: {},
-}));
-
-const {
-	dryRunTransactions,
-} = require('../../../../../shared/dataService/business/transactionsDryRun');
 
 jest.mock('../../../../../shared/dataService/business/transactionsDryRun', () => ({
 	dryRunTransactions: jest.fn(),
 }));
-
-const { requestConnector } = require('../../../../../shared/utils/request');
 
 jest.mock('../../../../../shared/utils/request', () => ({
 	requestConnector: jest.fn(),

--- a/services/gateway/apis/http-version3/methods/transactions.js
+++ b/services/gateway/apis/http-version3/methods/transactions.js
@@ -48,7 +48,7 @@ module.exports = {
 			max: 41,
 			pattern: regex.ADDRESS_LISK32,
 		},
-		receivingChainID: { optional: true, type: 'string', min: 1, pattern: regex.CHAIN_ID },
+		receivingChainID: { optional: true, type: 'string', pattern: regex.CHAIN_ID },
 		blockID: { optional: true, type: 'string', min: 64, max: 64, pattern: regex.HASH_SHA256 },
 		height: { optional: true, type: 'string', min: 1, pattern: regex.HEIGHT_RANGE },
 		timestamp: { optional: true, type: 'string', min: 1, pattern: regex.TIMESTAMP_RANGE },

--- a/services/gateway/apis/http-version3/methods/transactions.js
+++ b/services/gateway/apis/http-version3/methods/transactions.js
@@ -48,6 +48,7 @@ module.exports = {
 			max: 41,
 			pattern: regex.ADDRESS_LISK32,
 		},
+		receivingChainID: { optional: true, type: 'string', min: 1, pattern: regex.CHAIN_ID },
 		blockID: { optional: true, type: 'string', min: 64, max: 64, pattern: regex.HASH_SHA256 },
 		height: { optional: true, type: 'string', min: 1, pattern: regex.HEIGHT_RANGE },
 		timestamp: { optional: true, type: 'string', min: 1, pattern: regex.TIMESTAMP_RANGE },

--- a/services/gateway/apis/http-version3/swagger/parameters/transactions.json
+++ b/services/gateway/apis/http-version3/swagger/parameters/transactions.json
@@ -40,6 +40,14 @@
 		"minLength": 41,
 		"maxLength": 41
 	},
+	"receivingChainID": {
+		"name": "receivingChainID",
+		"in": "query",
+		"description": "Chain ID for the receiving chain in the case of cross-chain token transfers.",
+		"type": "string",
+		"minLength": 8,
+		"maxLength": 8
+	},
 	"senderAddress": {
 		"name": "senderAddress",
 		"in": "query",

--- a/services/gateway/sources/version3/transactions.js
+++ b/services/gateway/sources/version3/transactions.js
@@ -23,6 +23,7 @@ module.exports = {
 		moduleCommand: '=,string',
 		senderAddress: '=,string',
 		recipientAddress: '=,string',
+		receivingChainID: '=,string',
 		address: '=,string',
 		blockID: '=,string',
 		height: '=,string',

--- a/services/gateway/tests/constants/generateDocs.js
+++ b/services/gateway/tests/constants/generateDocs.js
@@ -690,6 +690,9 @@ const createApiDocsExpectedResponse = {
 					$ref: '#/parameters/recipientAddress',
 				},
 				{
+					$ref: '#/parameters/receivingChainID',
+				},
+				{
 					$ref: '#/parameters/blockID',
 				},
 				{

--- a/tests/integration/api_v3/constants/invalidInputs.js
+++ b/tests/integration/api_v3/constants/invalidInputs.js
@@ -43,6 +43,12 @@ const invalidNames = [
 	'______%',
 ];
 
+const invalidChainIDs = [
+	'0000000G', // contains invalid character 'G'
+	'0000000?', // contains invalid character '?'
+	'0 OR 1=1', // SQL injection
+];
+
 const invalidTokenIDs = [
 	'0123456789abcdefG', // contains invalid character 'G'
 	'0123456789abcdef?', // contains invalid character '?'
@@ -75,6 +81,7 @@ module.exports = {
 	invalidNames,
 	invalidNamesCSV,
 	invalidTokenIDs,
+	invalidChainIDs,
 	invalidTokenIDCSV,
 	invalidChainIDCSV,
 	invalidPartialSearches,

--- a/tests/integration/api_v3/http/transactions.test.js
+++ b/tests/integration/api_v3/http/transactions.test.js
@@ -24,6 +24,8 @@ import {
 } from '../constants/invalidInputs';
 import { waitMs } from '../../../helpers/utils';
 
+jest.setTimeout(1200000);
+
 const config = require('../../../config');
 const { api } = require('../../../helpers/api');
 
@@ -58,11 +60,11 @@ const fetchTxWithRetry = async txEndpoint => {
 			}
 		} catch (error) {
 			console.error(`Error fetching transactions. Retries left: ${retries}`);
-			retries--;
 
 			// Delay by 3 sec
 			await waitMs(3000);
 		}
+		retries--;
 	}
 
 	return {
@@ -74,7 +76,6 @@ describe('Transactions API', () => {
 	let refTransaction;
 
 	beforeAll(async () => {
-		jest.setTimeout(Number.MAX_SAFE_INTEGER);
 		const crossChainTxRes = await fetchTxWithRetry(
 			`${endpoint}?limit=1&moduleCommand=token:transferCrossChain`,
 		);

--- a/tests/integration/api_v3/http/transactions.test.js
+++ b/tests/integration/api_v3/http/transactions.test.js
@@ -18,6 +18,7 @@ import { TRANSACTION_EXECUTION_STATUSES } from '../../../schemas/api_v3/constant
 import {
 	invalidAddresses,
 	invalidBlockIDs,
+	invalidChainIDs,
 	invalidLimits,
 	invalidOffsets,
 } from '../constants/invalidInputs';
@@ -41,32 +42,56 @@ const baseAddress = config.SERVICE_ENDPOINT;
 const baseUrl = `${baseAddress}/api/v3`;
 const endpoint = `${baseUrl}/transactions`;
 
+const fetchTxWithRetry = async txEndpoint => {
+	let retries = 10;
+
+	while (retries > 0) {
+		try {
+			const response = await api.get(txEndpoint);
+			const [tx] = response.data;
+
+			if (tx) {
+				return {
+					success: true,
+					data: tx,
+				};
+			}
+		} catch (error) {
+			console.error(`Error fetching transactions. Retries left: ${retries}`);
+			retries--;
+
+			// Delay by 3 sec
+			await waitMs(3000);
+		}
+	}
+
+	return {
+		success: false,
+	};
+};
+
 describe('Transactions API', () => {
 	let refTransaction;
 
 	beforeAll(async () => {
-		let retries = 10;
-		let success = false;
+		jest.setTimeout(Number.MAX_SAFE_INTEGER);
+		const crossChainTxRes = await fetchTxWithRetry(
+			`${endpoint}?limit=1&moduleCommand=token:transferCrossChain`,
+		);
 
-		while (retries > 0 && !success) {
-			try {
-				const response = await api.get(`${endpoint}?limit=1&moduleCommand=token:transfer`);
-				[refTransaction] = response.data;
+		// Try to fetch transfer transaction on same chain, incase no transactions with transfer cross chain
+		if (!crossChainTxRes.success) {
+			const sameChainTxRes = await fetchTxWithRetry(
+				`${endpoint}?limit=1&moduleCommand=token:transfer`,
+			);
 
-				if (refTransaction) {
-					success = true;
-				}
-			} catch (error) {
-				console.error(`Error fetching transactions. Retries left: ${retries}`);
-				retries--;
-
-				// Delay by 3 sec
-				await waitMs(3000);
+			if (!sameChainTxRes.success) {
+				throw new Error('Failed to fetch transactions after 10 retries');
+			} else {
+				refTransaction = sameChainTxRes.data;
 			}
-		}
-
-		if (!success) {
-			throw new Error('Failed to fetch transactions after 10 retries');
+		} else {
+			refTransaction = crossChainTxRes.data;
 		}
 	});
 
@@ -341,6 +366,39 @@ describe('Transactions API', () => {
 		it('should throw error when called with invalid recipientAddress', async () => {
 			for (let i = 0; i < invalidAddresses.length; i++) {
 				const response = await api.get(`${endpoint}?recipientAddress=${invalidAddresses[i]}`, 400);
+				expect(response).toMap(badRequestSchema);
+			}
+		});
+	});
+
+	describe('Retrieve transaction list by receivingChainID', () => {
+		it('should return transactions when called with receivingChainID', async () => {
+			if (refTransaction.params.receivingChainID) {
+				const response = await api.get(
+					`${endpoint}?receivingChainID=${refTransaction.params.receivingChainID}`,
+				);
+				expect(response).toMap(goodRequestSchema);
+				expect(response.data).toBeInstanceOf(Array);
+				expect(response.data.length).toBeGreaterThanOrEqual(1);
+				expect(response.data.length).toBeLessThanOrEqual(10);
+				response.data.forEach((transaction, i) => {
+					expect(transaction).toMap(transactionSchema);
+					expect(transaction.params.receivingChainID).toEqual(
+						refTransaction.params.receivingChainID,
+					);
+					if (i > 0) {
+						const prevTx = response.data[i];
+						const prevTxTimestamp = prevTx.block.timestamp;
+						expect(prevTxTimestamp).toBeGreaterThanOrEqual(transaction.block.timestamp);
+					}
+				});
+				expect(response.meta).toMap(metaSchema);
+			}
+		});
+
+		it('should throw error when called with invalid receivingChainID', async () => {
+			for (let i = 0; i < invalidChainIDs.length; i++) {
+				const response = await api.get(`${endpoint}?receivingChainID=${invalidChainIDs[i]}`, 400);
 				expect(response).toMap(badRequestSchema);
 			}
 		});

--- a/tests/integration/api_v3/rpc/transactions.test.js
+++ b/tests/integration/api_v3/rpc/transactions.test.js
@@ -24,6 +24,8 @@ import {
 } from '../constants/invalidInputs';
 import { waitMs } from '../../../helpers/utils';
 
+jest.setTimeout(1200000);
+
 const config = require('../../../config');
 const { request } = require('../../../helpers/socketIoRpcRequest');
 
@@ -61,11 +63,11 @@ const fetchTxWithRetry = async params => {
 			}
 		} catch (error) {
 			console.error(`Error fetching transactions. Retries left: ${retries}`);
-			retries--;
 
 			// Delay by 3 sec
 			await waitMs(3000);
 		}
+		retries--;
 	}
 
 	return {
@@ -77,7 +79,6 @@ describe('Method get.transactions', () => {
 	let refTransaction;
 
 	beforeAll(async () => {
-		jest.setTimeout(Number.MAX_SAFE_INTEGER);
 		const crossChainTxRes = await fetchTxWithRetry({ moduleCommand: 'token:transferCrossChain' });
 
 		// Try to fetch transfer transaction on same chain, incase no transactions with transfer cross chain

--- a/tests/integration/api_v3/rpc/transactions.test.js
+++ b/tests/integration/api_v3/rpc/transactions.test.js
@@ -18,6 +18,7 @@ import { TRANSACTION_EXECUTION_STATUSES } from '../../../schemas/api_v3/constant
 import {
 	invalidAddresses,
 	invalidBlockIDs,
+	invalidChainIDs,
 	invalidLimits,
 	invalidOffsets,
 } from '../constants/invalidInputs';
@@ -44,32 +45,52 @@ const {
 const wsRpcUrl = `${config.SERVICE_ENDPOINT}/rpc-v3`;
 const getTransactions = async params => request(wsRpcUrl, 'get.transactions', params);
 
+const fetchTxWithRetry = async params => {
+	let retries = 10;
+
+	while (retries > 0) {
+		try {
+			const response = await getTransactions({ limit: 1, ...params });
+			const [tx] = response.result.data;
+
+			if (tx) {
+				return {
+					success: true,
+					data: tx,
+				};
+			}
+		} catch (error) {
+			console.error(`Error fetching transactions. Retries left: ${retries}`);
+			retries--;
+
+			// Delay by 3 sec
+			await waitMs(3000);
+		}
+	}
+
+	return {
+		success: false,
+	};
+};
+
 describe('Method get.transactions', () => {
 	let refTransaction;
 
 	beforeAll(async () => {
-		let retries = 10;
-		let success = false;
+		jest.setTimeout(Number.MAX_SAFE_INTEGER);
+		const crossChainTxRes = await fetchTxWithRetry({ moduleCommand: 'token:transferCrossChain' });
 
-		while (retries > 0 && !success) {
-			try {
-				const response = await getTransactions({ moduleCommand: 'token:transfer', limit: 1 });
-				[refTransaction] = response.result.data;
+		// Try to fetch transfer transaction on same chain, incase no transactions with transfer cross chain
+		if (!crossChainTxRes.success) {
+			const sameChainTxRes = await fetchTxWithRetry({ moduleCommand: 'token:transfer' });
 
-				if (refTransaction) {
-					success = true;
-				}
-			} catch (error) {
-				console.error(`Error fetching transactions. Retries left: ${retries}`);
-				retries--;
-
-				// Delay by 3 sec
-				await waitMs(3000);
+			if (!sameChainTxRes.success) {
+				throw new Error('Failed to fetch transactions after 10 retries');
+			} else {
+				refTransaction = sameChainTxRes.data;
 			}
-		}
-
-		if (!success) {
-			throw new Error('Failed to fetch transactions after 10 retries');
+		} else {
+			refTransaction = crossChainTxRes.data;
 		}
 	});
 
@@ -271,6 +292,41 @@ describe('Method get.transactions', () => {
 		it('should throw error when called with invalid recipientAddress', async () => {
 			for (let i = 0; i < invalidAddresses.length; i++) {
 				const response = await getTransactions({ recipientAddress: invalidAddresses[i] });
+				expect(response).toMap(invalidParamsSchema);
+			}
+		});
+	});
+
+	describe('is able to retrieve list of transactions using receivingChainID', () => {
+		it('should return transactions when called with known receivingChainID', async () => {
+			if (refTransaction.params.receivingChainID) {
+				const response = await getTransactions({
+					receivingChainID: refTransaction.params.receivingChainID,
+				});
+				expect(response).toMap(jsonRpcEnvelopeSchema);
+				const { result } = response;
+				expect(result.data).toBeInstanceOf(Array);
+				expect(result.data.length).toBeGreaterThanOrEqual(1);
+				expect(result.data.length).toBeLessThanOrEqual(10);
+				expect(response.result).toMap(resultEnvelopeSchema);
+				result.data.forEach((transaction, i) => {
+					expect(transaction).toMap(transactionSchema);
+					expect(transaction.params.receivingChainID).toEqual(
+						refTransaction.params.receivingChainID,
+					);
+					if (i > 0) {
+						const prevTx = result.data[i];
+						const prevTxTimestamp = prevTx.block.timestamp;
+						expect(prevTxTimestamp).toBeGreaterThanOrEqual(transaction.block.timestamp);
+					}
+				});
+				expect(result.meta).toMap(metaSchema);
+			}
+		});
+
+		it('should throw error when called with invalid receivingChainID', async () => {
+			for (let i = 0; i < invalidChainIDs.length; i++) {
+				const response = await getTransactions({ receivingChainID: invalidChainIDs[i] });
 				expect(response).toMap(invalidParamsSchema);
 			}
 		});


### PR DESCRIPTION
### What was the problem?

This PR resolves #1931 

### How was it solved?
- [x] Add support for receivingChainID to the GET /transactions endpoint
- [x] Update swagger
- [x] Add integration tests
- [x] Add unit tests
- [x] Fix unit tests for transaction fee estimates.

### How was it tested?
Local
