### PR TITLE
Empty data in delete transactions event payload

### DIFF
--- a/services/blockchain-connector/shared/sdk/cache.js
+++ b/services/blockchain-connector/shared/sdk/cache.js
@@ -78,7 +78,7 @@ const cacheBlocksFromWaitlist = async () => {
 			);
 			logger.debug(err.stack);
 			blockCacheWaitlist.splice(0, 0, block);
-			await delay(3000); // Delay loop to facilitate reads from cache when writes are failing due to DB locks
+			await delay(10000); // Delay loop to facilitate reads from cache when writes are failing due to DB locks
 		}
 	}
 

--- a/services/blockchain-indexer/shared/dataService/business/transactions.js
+++ b/services/blockchain-indexer/shared/dataService/business/transactions.js
@@ -281,4 +281,5 @@ module.exports = {
 
 	// For unit test
 	validateParams,
+	normalizeTransactions,
 };

--- a/services/blockchain-indexer/shared/indexer/blockchainIndex.js
+++ b/services/blockchain-indexer/shared/indexer/blockchainIndex.js
@@ -508,11 +508,13 @@ const deleteIndexedBlocks = async job => {
 					);
 					forkedTransactions = transactionsToDelete.filter(t => ![null, undefined].includes(t));
 				}
-				await transactionsTable.deleteByPrimaryKey(forkedTransactionIDs, dbTrx);
-				Signals.get('deleteTransactions').dispatch({
-					data: forkedTransactions,
-					meta: { offset: 0, count: forkedTransactions.length, total: forkedTransactions.length },
-				});
+				if (forkedTransactionIDs.length) {
+					await transactionsTable.deleteByPrimaryKey(forkedTransactionIDs, dbTrx);
+					Signals.get('deleteTransactions').dispatch({
+						data: forkedTransactions,
+						meta: { offset: 0, count: forkedTransactions.length, total: forkedTransactions.length },
+					});
+				}
 
 				// Update generatedBlocks count for the block generator
 				const validatorsTable = await getValidatorsTable();

--- a/services/blockchain-indexer/shared/messageProcessor.js
+++ b/services/blockchain-indexer/shared/messageProcessor.js
@@ -113,8 +113,7 @@ const newRoundProcessor = async () => {
 	await reloadGeneratorsCache();
 	const limit = await getNumberOfGenerators();
 	const generators = await getGenerators({ limit, offset: 0 });
-	const response = { generators: generators.data.map(generator => generator.address) };
-	Signals.get('newRound').dispatch(response);
+	Signals.get('newRound').dispatch(generators);
 	logger.info(`Finished performing all updates on new round.`);
 };
 

--- a/services/blockchain-indexer/tests/unit/shared/dataservice/business/transactions.test.js
+++ b/services/blockchain-indexer/tests/unit/shared/dataservice/business/transactions.test.js
@@ -13,7 +13,15 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-const { validateParams } = require('../../../../../shared/dataService/business/transactions');
+const {
+	mockTxRequest,
+	mockTransferCrossChainTxRequest,
+} = require('../../constants/transactionEstimateFees');
+
+const {
+	validateParams,
+	normalizeTransactions,
+} = require('../../../../../shared/dataService/business/transactions');
 
 jest.mock('lisk-service-framework', () => {
 	const actual = jest.requireActual('lisk-service-framework');
@@ -62,5 +70,34 @@ describe('Test validateParams method', () => {
 
 	it('should throw error when called with null', async () => {
 		expect(() => validateParams(null)).rejects.toThrow();
+	});
+});
+
+describe('Test normalizeTransactions method', () => {
+	it('should return normalized transactions when called with valid transactions', async () => {
+		const transactions = [mockTxRequest.transaction, mockTransferCrossChainTxRequest.transaction];
+		const normalizedTransactions = await normalizeTransactions(transactions);
+
+		const expectedResult = [
+			{
+				...mockTxRequest.transaction,
+				moduleCommand: `${mockTxRequest.transaction.module}:${mockTxRequest.transaction.command}`,
+			},
+			{
+				...mockTransferCrossChainTxRequest.transaction,
+				moduleCommand: `${mockTransferCrossChainTxRequest.transaction.module}:${mockTransferCrossChainTxRequest.transaction.command}`,
+			},
+		];
+
+		expect(normalizedTransactions.length).toEqual(transactions.length);
+		expect(normalizedTransactions).toEqual(expectedResult);
+	});
+
+	it('should throw error when called with null', async () => {
+		expect(() => normalizeTransactions(null)).rejects.toThrow();
+	});
+
+	it('should throw error when called with undefined', async () => {
+		expect(() => normalizeTransactions(null)).rejects.toThrow();
 	});
 });


### PR DESCRIPTION
### What was the problem?

This PR resolves #1958 

### How was it solved?

- [x] Add null check before dispatching deleteTransactions signal
- [x] Fix `update.round` event payload 
- [x] Update delay to 10s for blocks caching upon error

### How was it tested?
Local