### PR TITLE
Fix mainnet genesis block indexing

### DIFF
--- a/docker/nats-server.conf
+++ b/docker/nats-server.conf
@@ -1,2 +1,2 @@
-max_payload: 4Mb
+max_payload: 8MB
 http_port: 8222

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -26,7 +26,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -75,7 +75,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '150M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -107,17 +107,17 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '150M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
 				SERVICE_BROKER: 'redis://127.0.0.1:6379/0',
-				LISK_APP_WS: 'ws://127.0.0.1:7887',
-				GEOIP_JSON: 'https://geoip.lisk.com/json',
-				// ENABLE_BLOCK_CACHING: true,
-				// EXPIRY_IN_HOURS: 12,
 				// USE_LISK_IPC_CLIENT: true,
 				// LISK_APP_DATA_PATH: '~/.lisk/lisk-core',
+				// LISK_APP_WS: 'ws://127.0.0.1:7887',
+				// GEOIP_JSON: 'https://geoip.lisk.com/json',
+				// ENABLE_BLOCK_CACHING: true,
+				// EXPIRY_IN_HOURS: 12,
 				// ENABLE_TESTING_MODE: false,
 				// SERVICE_BROKER_TIMEOUT: 10,
 				// SERVICE_LOG_LEVEL: 'info',
@@ -150,7 +150,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '500M',
+			max_memory_restart: '1000M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -159,9 +159,9 @@ module.exports = {
 				SERVICE_INDEXER_REDIS_VOLATILE: 'redis://127.0.0.1:6379/2',
 				SERVICE_MESSAGE_QUEUE_REDIS: 'redis://127.0.0.1:6379/3',
 				SERVICE_INDEXER_MYSQL: 'mysql://lisk:password@127.0.0.1:3306/lisk',
-				ENABLE_DATA_RETRIEVAL_MODE: true,
-				ENABLE_INDEXING_MODE: true,
-				ENABLE_PERSIST_EVENTS: false,
+				// ENABLE_DATA_RETRIEVAL_MODE: true,
+				// ENABLE_INDEXING_MODE: true,
+				// ENABLE_PERSIST_EVENTS: false,
 				// ENABLE_APPLY_SNAPSHOT: false,
 				// DURABILITY_VERIFY_FREQUENCY: 1,
 				// INDEX_SNAPSHOT_URL: '',
@@ -208,7 +208,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -237,14 +237,14 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
 				SERVICE_BROKER: 'redis://127.0.0.1:6379/0',
 				SERVICE_FEE_ESTIMATOR_CACHE: 'redis://127.0.0.1:6379/1',
-				ENABLE_FEE_ESTIMATOR_QUICK: true,
-				ENABLE_FEE_ESTIMATOR_FULL: false,
+				// ENABLE_FEE_ESTIMATOR_QUICK: true,
+				// ENABLE_FEE_ESTIMATOR_FULL: false,
 				// FEE_EST_COLD_START_BATCH_SIZE: 1,
 				// FEE_EST_DEFAULT_START_BLOCK_HEIGHT: 1,
 				// FEE_EST_EMA_BATCH_SIZE: 20,
@@ -269,14 +269,14 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
 				SERVICE_BROKER: 'redis://127.0.0.1:6379/0',
 				SERVICE_STATISTICS_REDIS: 'redis://127.0.0.1:6379/1',
 				SERVICE_STATISTICS_MYSQL: 'mysql://lisk:password@127.0.0.1:3306/lisk',
-				TRANSACTION_STATS_HISTORY_LENGTH_DAYS: 366,
+				// TRANSACTION_STATS_HISTORY_LENGTH_DAYS: 366,
 				// SERVICE_STATISTICS_MYSQL_READ_REPLICA: 'mysql://reader:password@127.0.0.1:3307/lisk',
 				// SERVICE_BROKER_TIMEOUT: 10,
 				// SERVICE_LOG_LEVEL: 'info',
@@ -301,15 +301,14 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
 				SERVICE_BROKER: 'redis://127.0.0.1:6379/0',
 				SERVICE_MARKET_REDIS: 'redis://127.0.0.1:6379/2',
-				SERVICE_MARKET_FIAT_CURRENCIES: 'EUR,USD,CHF,GBP,RUB,PLN,JPY,AUD,GBP,INR',
-				SERVICE_MARKET_TARGET_PAIRS:
-					'LSK_BTC,LSK_EUR,LSK_USD,LSK_CHF,LSK_PLN,LSK_JPY,LSK_AUD,LSK_GBP,LSK_INR,BTC_EUR,BTC_USD,BTC_CHF',
+				// SERVICE_MARKET_FIAT_CURRENCIES: 'EUR,USD,CHF,GBP,RUB,PLN,JPY,AUD,GBP,INR',
+				// SERVICE_MARKET_TARGET_PAIRS: 'LSK_BTC,LSK_EUR,LSK_USD,LSK_CHF,LSK_PLN,LSK_JPY,LSK_AUD,LSK_GBP,LSK_INR,BTC_EUR,BTC_USD,BTC_CHF',
 				// EXCHANGERATESAPI_IO_API_KEY: ''
 				// SERVICE_BROKER_TIMEOUT: 10,
 				// SERVICE_LOG_LEVEL: 'info',
@@ -340,7 +339,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				SERVICE_BROKER: 'redis://127.0.0.1:6379/0',

--- a/ecosystem.jenkins.config.js
+++ b/ecosystem.jenkins.config.js
@@ -26,7 +26,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				PORT: 9901,
@@ -57,7 +57,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '150M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -76,7 +76,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '150M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -98,7 +98,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '500M',
+			max_memory_restart: '1000M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -122,7 +122,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -140,7 +140,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -160,7 +160,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				// --- Remember to set the properties below
@@ -180,7 +180,7 @@ module.exports = {
 			log_date_format: 'YYYY-MM-DD HH:mm:ss SSS',
 			watch: false,
 			kill_timeout: 10000,
-			max_memory_restart: '300M',
+			max_memory_restart: '500M',
 			autorestart: true,
 			env: {
 				SERVICE_BROKER: 'redis://127.0.0.1:6379/0',

--- a/services/blockchain-connector/shared/sdk/client.js
+++ b/services/blockchain-connector/shared/sdk/client.js
@@ -153,14 +153,19 @@ const invokeEndpoint = async (endpoint, params = {}, numRetries = NUM_REQUEST_RE
 	} while (retries--);
 };
 
-// Check to ensure that the API Client is always alive
-const triggerRegularClientLivelinessChecks = () =>
-	setInterval(async () => {
-		const isAlive = await checkIsClientAlive();
-		if (!isAlive) instantiateClient(true).catch(() => {});
-	}, CLIENT_ALIVE_ASSUMPTION_TIME);
+// Checks to ensure that the API Client is always alive
+const resetApiClientListener = async () => instantiateClient(true).catch(() => {});
+Signals.get('resetApiClient').add(resetApiClientListener);
 
-Signals.get('genesisBlockDownloaded').add(triggerRegularClientLivelinessChecks);
+if (!config.isUseLiskIPCClient) {
+	const triggerRegularClientLivelinessChecks = () =>
+		setInterval(async () => {
+			const isAlive = await checkIsClientAlive();
+			if (!isAlive) instantiateClient(true).catch(() => {});
+		}, CLIENT_ALIVE_ASSUMPTION_TIME);
+
+	Signals.get('genesisBlockDownloaded').add(triggerRegularClientLivelinessChecks);
+}
 
 module.exports = {
 	timeoutMessage,

--- a/services/blockchain-connector/shared/sdk/client.js
+++ b/services/blockchain-connector/shared/sdk/client.js
@@ -153,19 +153,14 @@ const invokeEndpoint = async (endpoint, params = {}, numRetries = NUM_REQUEST_RE
 	} while (retries--);
 };
 
-// Checks to ensure that the API Client is always alive
-const resetApiClientListener = async () => instantiateClient(true).catch(() => {});
-Signals.get('resetApiClient').add(resetApiClientListener);
+// Check to ensure that the API Client is always alive
+const triggerRegularClientLivelinessChecks = () =>
+	setInterval(async () => {
+		const isAlive = await checkIsClientAlive();
+		if (!isAlive) instantiateClient(true).catch(() => {});
+	}, CLIENT_ALIVE_ASSUMPTION_TIME);
 
-if (!config.isUseLiskIPCClient) {
-	const triggerRegularClientLivelinessChecks = () =>
-		setInterval(async () => {
-			const isAlive = await checkIsClientAlive();
-			if (!isAlive) instantiateClient(true).catch(() => {});
-		}, CLIENT_ALIVE_ASSUMPTION_TIME);
-
-	Signals.get('genesisBlockDownloaded').add(triggerRegularClientLivelinessChecks);
-}
+Signals.get('genesisBlockDownloaded').add(triggerRegularClientLivelinessChecks);
 
 module.exports = {
 	timeoutMessage,

--- a/services/blockchain-connector/shared/sdk/client.js
+++ b/services/blockchain-connector/shared/sdk/client.js
@@ -154,10 +154,10 @@ const invokeEndpoint = async (endpoint, params = {}, numRetries = NUM_REQUEST_RE
 };
 
 // Checks to ensure that the API Client is always alive
-const resetApiClientListener = async () => instantiateClient(true).catch(() => {});
-Signals.get('resetApiClient').add(resetApiClientListener);
-
-if (!config.isUseLiskIPCClient) {
+if (config.isUseLiskIPCClient) {
+	const resetApiClientListener = async () => instantiateClient(true).catch(() => {});
+	Signals.get('resetApiClient').add(resetApiClientListener);
+} else {
 	const triggerRegularClientLivelinessChecks = () =>
 		setInterval(async () => {
 			const isAlive = await checkIsClientAlive();

--- a/services/blockchain-connector/shared/sdk/client.js
+++ b/services/blockchain-connector/shared/sdk/client.js
@@ -158,10 +158,13 @@ const resetApiClientListener = async () => instantiateClient(true).catch(() => {
 Signals.get('resetApiClient').add(resetApiClientListener);
 
 if (!config.isUseLiskIPCClient) {
-	setInterval(async () => {
-		const isAlive = await checkIsClientAlive();
-		if (!isAlive) instantiateClient(true).catch(() => {});
-	}, CLIENT_ALIVE_ASSUMPTION_TIME);
+	const triggerRegularClientLivelinessChecks = () =>
+		setInterval(async () => {
+			const isAlive = await checkIsClientAlive();
+			if (!isAlive) instantiateClient(true).catch(() => {});
+		}, CLIENT_ALIVE_ASSUMPTION_TIME);
+
+	Signals.get('genesisBlockDownloaded').add(triggerRegularClientLivelinessChecks);
 }
 
 module.exports = {

--- a/services/blockchain-connector/shared/sdk/events.js
+++ b/services/blockchain-connector/shared/sdk/events.js
@@ -17,8 +17,6 @@ const util = require('util');
 
 const { Logger, Signals } = require('lisk-service-framework');
 
-const config = require('../../config');
-
 const { getApiClient } = require('./client');
 const { formatEvent } = require('./formatter');
 const { getRegisteredEvents, getEventsByHeight, getNodeInfo } = require('./endpoints');
@@ -40,17 +38,12 @@ const events = [
 	EVENT_TX_POOL_TRANSACTION_NEW,
 ];
 
-let eventsCounter;
-
 const logError = (method, err) => {
 	logger.warn(`Invocation for ${method} failed with error: ${err.message}.`);
 	logger.debug(err.stack);
 };
 
 const subscribeToAllRegisteredEvents = async () => {
-	// Reset eventsCounter first
-	eventsCounter = 0;
-
 	const apiClient = await getApiClient();
 	const registeredEvents = await getRegisteredEvents();
 	const allEvents = registeredEvents.concat(events);
@@ -58,8 +51,6 @@ const subscribeToAllRegisteredEvents = async () => {
 		apiClient.subscribe(event, async payload => {
 			// Force update necessary caches on new chain events
 			if (event.startsWith('chain_')) {
-				eventsCounter++; // Increase counter with every newBlock/deleteBlock
-
 				await getNodeInfo(true).catch(err => logError('getNodeInfo', err));
 				await updateTokenInfo().catch(err => logError('updateTokenInfo', err));
 			}
@@ -76,51 +67,6 @@ const getEventsByHeightFormatted = async height => {
 	const formattedEvents = chainEvents.map(event => formatEvent(event));
 	return formattedEvents;
 };
-
-// To ensure API Client is alive and receiving chain events
-let isNodeSynced = false;
-let isGenesisBlockDownloaded = false;
-
-const ensureAPIClientLiveness = () => {
-	if (isNodeSynced && isGenesisBlockDownloaded) {
-		setInterval(() => {
-			if (typeof eventsCounter === 'number' && eventsCounter > 0) {
-				eventsCounter = 0;
-			} else {
-				if (typeof eventsCounter !== 'number') {
-					logger.warn(
-						`eventsCounter ended up with non-numeric value: ${JSON.stringify(
-							eventsCounter,
-							null,
-							'\t',
-						)}.`,
-					);
-					eventsCounter = 0;
-				}
-
-				Signals.get('resetApiClient').dispatch();
-				logger.info("Dispatched 'resetApiClient' signal to re-instantiate the API client.");
-			}
-		}, config.clientConnVerifyInterval);
-	} else {
-		logger.info(
-			`Cannot start the events-based client liveness check yet. Either the node is not yet synced or the genesis block hasn't been downloaded yet.\nisNodeSynced: ${isNodeSynced}, isGenesisBlockDownloaded: ${isGenesisBlockDownloaded}`,
-		);
-	}
-};
-
-const nodeIsSyncedListener = () => {
-	isNodeSynced = true;
-	ensureAPIClientLiveness();
-};
-
-const genesisBlockDownloadedListener = () => {
-	isGenesisBlockDownloaded = true;
-	ensureAPIClientLiveness();
-};
-
-Signals.get('nodeIsSynced').add(nodeIsSyncedListener);
-Signals.get('genesisBlockDownloaded').add(genesisBlockDownloadedListener);
 
 module.exports = {
 	events,

--- a/services/blockchain-connector/shared/sdk/index.js
+++ b/services/blockchain-connector/shared/sdk/index.js
@@ -13,6 +13,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+const { Signals } = require('lisk-service-framework');
+
 const config = require('../../config');
 
 const {
@@ -112,7 +114,6 @@ const {
 const { cacheCleanup } = require('./cache');
 const { formatTransaction } = require('./formatter');
 const { encodeCCM } = require('./encoder');
-const { Signals } = require('lisk-service-framework');
 
 const init = async () => {
 	// Cache all the schemas

--- a/services/blockchain-connector/shared/sdk/index.js
+++ b/services/blockchain-connector/shared/sdk/index.js
@@ -112,6 +112,7 @@ const {
 const { cacheCleanup } = require('./cache');
 const { formatTransaction } = require('./formatter');
 const { encodeCCM } = require('./encoder');
+const { Signals } = require('lisk-service-framework');
 
 const init = async () => {
 	// Cache all the schemas
@@ -128,7 +129,9 @@ const init = async () => {
 	await getPosConstants();
 
 	// Download the genesis block, if applicable
-	await getGenesisBlock();
+	await getGenesisBlock().then(() => {
+		Signals.get('genesisBlockDownloaded').dispatch();
+	});
 
 	if (config.appExitDelay) {
 		setTimeout(() => process.exit(0), config.appExitDelay);

--- a/services/blockchain-indexer/jobs/dataService/validators.js
+++ b/services/blockchain-indexer/jobs/dataService/validators.js
@@ -32,7 +32,8 @@ module.exports = [
 					await reloadValidatorCache();
 					logger.info('Successfully initialized validators cache.');
 				} catch (err) {
-					logger.warn(`Initializing validators cache failed due to: ${err.stack}`);
+					logger.warn(`Initializing validators cache failed due to: ${err.message}`);
+					logger.debug(err.stack);
 				}
 			}
 		},
@@ -43,6 +44,7 @@ module.exports = [
 					await reloadValidatorCache();
 				} catch (err) {
 					logger.warn(`Reloading validators cache failed due to: ${err.message}`);
+					logger.debug(err.stack);
 				}
 			}
 		},

--- a/services/blockchain-indexer/shared/indexer/genesisBlock.js
+++ b/services/blockchain-indexer/shared/indexer/genesisBlock.js
@@ -41,7 +41,10 @@ const getStakesTable = () => getTableInstance(stakesTableSchema, MYSQL_ENDPOINT)
 const getCommissionsTable = () => getTableInstance(commissionsTableSchema, MYSQL_ENDPOINT);
 
 const allAccountsAddresses = [];
+let intervalTimeout;
 let isTokensBalanceIndexed = false;
+
+const getGenesisAssetIntervalTimeout = () => intervalTimeout;
 
 const indexTokenModuleAssets = async dbTrx => {
 	logger.info('Starting to index the genesis assets from the Token module.');
@@ -171,7 +174,7 @@ const indexPosModuleAssets = async dbTrx => {
 
 const indexGenesisBlockAssets = async dbTrx => {
 	logger.info('Starting to index the genesis assets.');
-	const intervalTimeout = setInterval(
+	intervalTimeout = setInterval(
 		() => logger.info('Genesis assets indexing still in progress...'),
 		5000,
 	);
@@ -204,6 +207,7 @@ const indexTokenBalancesListener = async () => {
 Signals.get('chainNewBlock').add(indexTokenBalancesListener);
 
 module.exports = {
+	getGenesisAssetIntervalTimeout,
 	indexGenesisBlockAssets,
 
 	// For testing


### PR DESCRIPTION
### What was the problem?

This PR resolves #1962 

### How was it solved?

- [x] Add safety checks to ensure that API client healthcheck is only triggered after both the nodes are synced and genesis block is downloaded
- [x] Use event-based liveness checks only for IPC clients
- [x] Update the NATS server max payload config
- [x] Update max_memory limits in pm2 config files

### How was it tested?

- [x] Locally against the mainnet
  - Follow "Steps to reproduce" from #1962 
- [x] Against the testnet, both locally and on the server
