### PR TITLE
Top balances endpoint does not consider locked amounts

### DIFF
--- a/services/blockchain-indexer/shared/indexer/accountBalanceIndex.js
+++ b/services/blockchain-indexer/shared/indexer/accountBalanceIndex.js
@@ -38,11 +38,19 @@ const updateAccountBalances = async address => {
 	const accountBalancesTable = await getAccountBalancesTable();
 	const { data: balanceInfos } = await getTokenBalances({ address });
 
-	const updatedTokenBalances = balanceInfos.map(balanceInfo => ({
-		address,
-		tokenID: balanceInfo.tokenID,
-		balance: balanceInfo.availableBalance,
-	}));
+	const updatedTokenBalances = balanceInfos.map(balanceInfo => {
+		const { tokenID, availableBalance, lockedBalances } = balanceInfo;
+		const totalLockedBalance = lockedBalances.reduce(
+			(acc, entry) => BigInt(acc) + BigInt(entry.amount),
+			BigInt('0'),
+		);
+
+		return {
+			address,
+			tokenID,
+			balance: BigInt(availableBalance) + BigInt(totalLockedBalance),
+		};
+	});
 
 	// Update all token balances of the address
 	await accountBalancesTable.upsert(updatedTokenBalances);

--- a/services/blockchain-indexer/shared/indexer/genesisBlock.js
+++ b/services/blockchain-indexer/shared/indexer/genesisBlock.js
@@ -70,10 +70,18 @@ const indexTokenModuleAssets = async dbTrx => {
 
 	// eslint-disable-next-line no-restricted-syntax
 	for (const userInfo of userSubStoreInfos) {
-		const { address, availableBalance: balance, tokenID } = userInfo;
+		const { address, tokenID, availableBalance, lockedBalances } = userInfo;
+		const totalLockedBalance = lockedBalances.reduce(
+			(acc, entry) => BigInt(acc) + BigInt(entry.amount),
+			BigInt('0'),
+		);
 
 		// Add entry to index the genesis account balances
-		const accountBalanceEntry = { address, tokenID, balance };
+		const accountBalanceEntry = {
+			address,
+			tokenID,
+			balance: BigInt(availableBalance) + BigInt(totalLockedBalance),
+		};
 		genesisAccountBalances.push(accountBalanceEntry);
 
 		// eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
### What was the problem?

This PR resolves #2018

### How was it solved?

- [x] Fixed the indexing logic for total balance to be the sum of available balance and all the locked amounts

### How was it tested?

Locally
