### PR TITLE
Can't send transactions leaving the account with less than 0.05 LSK

### DIFF
--- a/services/blockchain-indexer/shared/dataService/business/transactionsEstimateFees.js
+++ b/services/blockchain-indexer/shared/dataService/business/transactionsEstimateFees.js
@@ -317,16 +317,10 @@ const validateTransactionParams = async transaction => {
 	if (transaction.params.tokenID) {
 		const senderAddress = getLisk32AddressFromPublicKey(transaction.senderPublicKey);
 		const {
-			data: { extraCommandFees },
-		} = await getTokenConstants();
-		const {
 			data: [balanceInfo],
 		} = await getTokenBalances({ address: senderAddress, tokenID: transaction.params.tokenID });
 
-		if (
-			BigInt(balanceInfo.availableBalance) <
-			BigInt(transaction.params.amount) + BigInt(extraCommandFees.userAccountInitializationFee)
-		) {
+		if (BigInt(balanceInfo.availableBalance) < BigInt(transaction.params.amount)) {
 			throw new ValidationException(
 				`${senderAddress} has insufficient balance for ${transaction.params.tokenID} to send the transaction.`,
 			);


### PR DESCRIPTION
### What was the problem?

This PR resolves #2022

### How was it solved?

- [x] Fix balance validation logic

### How was it tested?

Locally/ already patched on prod
